### PR TITLE
use warehouse pypi.org instead of legacy pypi.python.org

### DIFF
--- a/02-graph_upstream.py
+++ b/02-graph_upstream.py
@@ -28,7 +28,7 @@ def source_location(meta_yaml):
 def pypi_version(meta_yaml, gh):
     """Copyright (c) 2017, Peter M. Landwehr"""
     pypi_name = meta_yaml['url'].split('/')[6]
-    r = requests.get('https://pypi.python.org/pypi/{}/json'.format(
+    r = requests.get('https://pypi.org/pypi/{}/json'.format(
         pypi_name))
     if not r.ok:
         with open('upstream_bad', 'a') as f:


### PR DESCRIPTION
fixes latest version when a prerelease is available

legacy PyPI uses the last release to populate 'info', whereas warehouse correctly uses the latest *stable* release

compare https://pypi.org/pypi/tornado/json (info.version = 4.5.3) with https://pypi.python.org/pypi/tornado/json (info.version = 5.0b1)

retrieving prerelease version produced an incorrect message about tornado being out of date in https://github.com/conda-forge/nbdime-feedstock/pull/11

The alternative is to parse, sort, and filter all of the versions in the legacy report yourself, I think.

PS autotick-bot is super cool!