### PR TITLE
Replace `this repo` with link to cf-graph in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ There are four scripts:
 1. `02-graph-upstream.py` finds versions for each recipe's upstream source. (potential 2 GH calls per feedstock (if on GH))
 1. `03-auto_tick.xsh` takes each node which is out of date and creates a PR to bring the recipe up to date with the source. This requires `xonsh` and will skip CI for packages who's dependencies are also out of date. (multiple GH api calls)
 
-These scripts will run on Travis from 4 different github repos as daily cron jobs and use `doctr` to write the output data (the list of all conda-forge packages and the dependency graph) to this repo. 
+These scripts will run on Travis from 4 different github repos as daily cron jobs and use `doctr` to write the output data (the list of all conda-forge packages and the dependency graph) to the [cf-graph repo](https://github.com/regro/cf-graph). 
 
 GH rate limit is a major concern for this as there are ~4000 feedstocks and only 5000 API calls per hour.


### PR DESCRIPTION
- After the package was split, the graph is kept on a separate repository.