### PR TITLE
blacklist a and b in version

### DIFF
--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -33,7 +33,7 @@ def next_version(ver):
 
 class VersionFromFeed:
     ver_prefix_remove = ['release-', 'releases%2F', 'v']
-    dev_vers = ['rc', 'beta', 'alpha', 'dev']
+    dev_vers = ['rc', 'beta', 'alpha', 'dev', 'a', 'b']
 
     def get_version(self, url):
         data = feedparser.parse(url)


### PR DESCRIPTION
This blacklists version numbers containing ``a`` or ``b``.
Attn:
@justcalamari I guess I got to it first :)
@ocefpaf
@jakirkham
@ericdill

I'm putting up this PR so we can merge it if we want to and to continue the discussion. I guess I'd rather default to the safer approach (not bumping to dev versions) until we have the infrastructure to handle dev releases more formally (pushing to dev branches,/labels not updating everything to the dev versions when installing things, etc.) However, I would like to get input/consensus if possible, and am more than happy to follow the majority's opinion.
