### PR TITLE
Add attrs attribute to Migrator

### DIFF
--- a/03-auto_tick.xsh
+++ b/03-auto_tick.xsh
@@ -21,7 +21,7 @@ def run(attrs, migrator, feedstock=None, protocol='ssh',
         pull_request=True, rerender=True, fork=True, gh=None,
         **kwargs):
     # get the repo
-    migrator.set_attrs(attrs)
+    migrator.attrs = attrs
     feedstock_dir, repo = get_repo(attrs, branch=migrator.remote_branch(),
                                    feedstock=feedstock,
                                    protocol=protocol,

--- a/03-auto_tick.xsh
+++ b/03-auto_tick.xsh
@@ -21,6 +21,7 @@ def run(attrs, migrator, feedstock=None, protocol='ssh',
         pull_request=True, rerender=True, fork=True, gh=None,
         **kwargs):
     # get the repo
+    migrator.set_attrs(attrs)
     feedstock_dir, repo = get_repo(attrs, branch=migrator.remote_branch(),
                                    feedstock=feedstock,
                                    protocol=protocol,

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -208,7 +208,7 @@ class Version(Migrator):
         return True
 
     def set_attrs(self, attrs):
-        super().set_attrs()
+        super().set_attrs(attrs)
         self.version = attrs['new_version']
 
     def pr_body(self):

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -44,16 +44,6 @@ class Migrator:
         """
         return True
 
-    def set_attrs(self, attrs):
-        """Set the attributes of the node currently being migrated.
-
-        Parameters
-        ----------
-        attrs: dict
-            The attributes.
-        """
-        self.attrs = attrs
-
     def pr_body(self):
         """Create a PR message body
 
@@ -180,7 +170,7 @@ class Version(Migrator):
 
     def migrate(self, recipe_dir, attrs, hash_type='sha256'):
         # Render with new version but nothing else
-        self.set_attrs(attrs)
+        self.version = attrs['new_version']
         with indir(recipe_dir):
             with open('meta.yaml', 'r') as f:
                 text = f.read()
@@ -247,6 +237,7 @@ class Version(Migrator):
         return $USERNAME + ':' + self.remote_branch()
 
     def remote_branch(self):
+        self.version = self.attrs['new_version']
         return self.version
 
 class JS(Migrator):

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -44,6 +44,16 @@ class Migrator:
         """
         return True
 
+    def set_attrs(self, attrs):
+        """Set the attributes of the node currently being migrated.
+
+        Parameters
+        ----------
+        attrs: dict
+            The attributes.
+        """
+        self.attrs = attrs
+
     def pr_body(self):
         """Create a PR message body
 
@@ -170,7 +180,7 @@ class Version(Migrator):
 
     def migrate(self, recipe_dir, attrs, hash_type='sha256'):
         # Render with new version but nothing else
-        self.version = attrs['new_version']
+        self.set_attrs(attrs)
         with indir(recipe_dir):
             with open('meta.yaml', 'r') as f:
                 text = f.read()
@@ -196,6 +206,10 @@ class Version(Migrator):
                 n = eval_version(n)
                 replace_in_file(p, n, f)
         return True
+
+    def set_attrs(self, attrs):
+        super().set_attrs()
+        self.version = attrs['new_version']
 
     def pr_body(self):
         pred = [(name, $SUBGRAPH.node[name]['new_version'])

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -170,14 +170,14 @@ class Version(Migrator):
 
     def migrate(self, recipe_dir, attrs, hash_type='sha256'):
         # Render with new version but nothing else
-        self.version = attrs['new_version']
+        version = attrs['new_version']
         with indir(recipe_dir):
             with open('meta.yaml', 'r') as f:
                 text = f.read()
         url = re.search('  url:.*?\n(    -.*\n?)*', text).group()
         if 'cran.r-project.org/src/contrib' in url:
-            self.version = self.version.replace('_', '-')
-        with indir(recipe_dir), ${...}.swap(VERSION=self.version):
+            version = version.replace('_', '-')
+        with indir(recipe_dir), ${...}.swap(VERSION=version):
             for f, p, n in self.patterns:
                 p = eval_version(p)
                 n = eval_version(n)
@@ -224,17 +224,16 @@ class Version(Migrator):
         return body
 
     def commit_message(self):
-        return "updated v" + self.version
+        return "updated v" + self.attrs['new_version']
 
     def pr_title(self):
-        return $PROJECT + ' v' + self.version
+        return $PROJECT + ' v' + self.attrs['new_version']
 
     def pr_head(self):
         return $USERNAME + ':' + self.remote_branch()
 
     def remote_branch(self):
-        self.version = self.attrs['new_version']
-        return self.version
+        return self.attrs['new_version']
 
 class JS(Migrator):
     """Migrator for JavaScript syntax"""

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -197,10 +197,6 @@ class Version(Migrator):
                 replace_in_file(p, n, f)
         return True
 
-    def set_attrs(self, attrs):
-        super().set_attrs(attrs)
-        self.version = attrs['new_version']
-
     def pr_body(self):
         pred = [(name, $SUBGRAPH.node[name]['new_version'])
                 for name in list($SUBGRAPH.predecessors($NODE))]


### PR DESCRIPTION
The bot was running into a problem where it used `migrator.remote_branch()` before the `version` attribute was being set, causing an error. This should fix that.

Also I think it is useful to store the attributes of the node currently being migrated inside the migrator because other subclasses of Migrator might want to use other attributes of the node.