### PR TITLE
Remove version pinning for github3.py

### DIFF
--- a/requirements/run
+++ b/requirements/run
@@ -1,4 +1,4 @@
-github3.py ==0.9.6
+github3.py
 networkx
 yaml
 jinja2


### PR DESCRIPTION
The bot failed on its most recent run, which I believe is due to pinning an old version of github3.py.