### PR TITLE
Sep deploy

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -250,13 +250,6 @@ def main(args=None):
                     logger.critical('COMMIT FAILED' + str(e))
                     if $(git ls-files -m):
                         raise
-                doctr_run(
-                    ['git',
-                     'push',
-                     'https://{token}@github.com/{deploy_repo}.git'.format(
-                         token=$PASSWORD, deploy_repo = 'regro/cf-graph'),
-                     'master'],
-                token=$PASSWORD.encode('utf-8'))
                 for f in g`/tmp/*`:
                     if f not in temp:
                         rm -rf @(f)

--- a/conda_forge_tick/cli.xsh
+++ b/conda_forge_tick/cli.xsh
@@ -8,11 +8,9 @@ from .make_graph import main as main1
 from .update_upstream_versions import main as main2
 from .auto_tick import main as main3
 
-int_script_dict = {0: main0, 1: main1, 2: main2, 3: main3,
-                   -1: deploy}
-
 
 def deploy(script):
+    """Deploy the graph to github"""
     try:
         git commit -am @("Finished stage {}".format(script))
     except Exception as e:
@@ -25,6 +23,8 @@ def deploy(script):
          'master'],
          token =$PASSWORD.encode('utf-8'))
 
+
+int_script_dict = {0: main0, 1: main1, 2: main2, 3: main3, -1: deploy}
 
 
 def main(*args, **kwargs):

--- a/conda_forge_tick/cli.xsh
+++ b/conda_forge_tick/cli.xsh
@@ -36,7 +36,5 @@ def main(*args, **kwargs):
         start = time.time()
         int_script_dict[script]()
         print('FINISHED STAGE {} IN {} SECONDS'.format(script, time.time() - start))
-        if script != -1:
-            deploy(script)
     else:
         raise RuntimeError("Unknown script number")

--- a/conda_forge_tick/cli.xsh
+++ b/conda_forge_tick/cli.xsh
@@ -8,7 +8,23 @@ from .make_graph import main as main1
 from .update_upstream_versions import main as main2
 from .auto_tick import main as main3
 
-int_script_dict = {0: main0, 1: main1, 2: main2, 3: main3}
+int_script_dict = {0: main0, 1: main1, 2: main2, 3: main3,
+                   -1: deploy}
+
+
+def deploy(script):
+    try:
+        git commit -am @("Finished stage {}".format(script))
+    except Exception as e:
+        print(e)
+    doctr_run(
+        ['git',
+         'push',
+         'https://{token}@github.com/{deploy_repo}.git'.format(
+             token=$PASSWORD, deploy_repo='regro/cf-graph'),
+         'master'],
+         token =$PASSWORD.encode('utf-8'))
+
 
 
 def main(*args, **kwargs):
@@ -20,16 +36,7 @@ def main(*args, **kwargs):
         start = time.time()
         int_script_dict[script]()
         print('FINISHED STAGE {} IN {} SECONDS'.format(script, time.time() - start))
-        try:
-            git commit -am @("Finished stage {}".format(script))
-        except Exception as e:
-            print(e)
-        doctr_run(
-            ['git',
-             'push',
-             'https://{token}@github.com/{deploy_repo}.git'.format(
-                 token=$PASSWORD, deploy_repo='regro/cf-graph'),
-             'master'],
-             token =$PASSWORD.encode('utf-8'))
+        if script != -1:
+            deploy(script)
     else:
         raise RuntimeError("Unknown script number")


### PR DESCRIPTION
This makes a separate deploy functionality which pushes up to github. The main benefit is that we can reduce our time pushing things to github for cf-graph. Note that this has a sister PR in [`circle_worker`](https://github.com/regro/circle_worker/pull/2) both need to go in at the same time.