### PR TITLE
We seem to have some issues with newer xonsh

### DIFF
--- a/requirements/run
+++ b/requirements/run
@@ -6,7 +6,7 @@ setuptools
 requests
 doctr
 rever
-xonsh
+xonsh <0.8.0
 conda-smithy
 requests
 feedparser


### PR DESCRIPTION
```
2018-10-13 12:54:55,292 ERROR    conda_forge_tick.auto_tick || NON GITHUB ERROR
Traceback (most recent call last):
  File "/root/repo/cf-scripts/conda_forge_tick/auto_tick.xsh", line 313, in main
    hash_type=attrs.get('hash_type', 'sha256'))
  File "/root/repo/cf-scripts/conda_forge_tick/auto_tick.xsh", line 87, in run
    migrate_return = migrator.migrate(recipe_dir, attrs, **kwargs)
  File "/root/repo/cf-scripts/conda_forge_tick/migrators.xsh", line 309, in migrate
    new_patterns = self.get_hash_patterns('meta.yaml', urls, hash_type)
  File "/root/repo/cf-scripts/conda_forge_tick/migrators.xsh", line 247, in get_hash_patterns
    hash = hash_url(url, hash_type)
  File "/opt/conda/lib/python3.6/site-packages/rever/tools.xsh", line 206, in hash_url
    for b in stream_url_progress(url, verb='Hashing', quiet=quiet):
  File "/opt/conda/lib/python3.6/site-packages/rever/tools.xsh", line 187, in stream_url_progress
    progress(nbytes, totalbytes, width=width, quiet=quiet)
  File "/opt/conda/lib/python3.6/site-packages/rever/tools.xsh", line 151, in progress
    print_color(s, end='', file=file)
  File "/opt/conda/lib/python3.6/site-packages/xonsh/__amalgam__.py", line 5573, in print_color
    builtins.__xonsh__.shell.shell.print_color(string, **kwargs)
AttributeError: 'NoneType' object has no attribute 'shell'
```

