### PR TITLE
request review from feedstock maintainers if checks have updated and none are pending

### DIFF
--- a/conda_forge_tick/git_utils.xsh
+++ b/conda_forge_tick/git_utils.xsh
@@ -12,6 +12,7 @@ import github3
 import github3.pulls
 
 import networkx as nx
+import requests
 from doctr.travis import run_command_hiding_token as doctr_run
 from pkg_resources import parse_version
 from rever.tools import (eval_version, hash_url, replace_in_file)
@@ -157,6 +158,24 @@ def refresh_pr(pr_json: LazyJson, gh=None):
         # if state passed from opened to closed delete the branch
         if pr_obj_d['state'] == 'closed' and pr_obj_d.get('merged_at', False):
             delete_branch(pr_json)
+        return pr_obj.as_dict()
+
+
+def ping_maintainers(pr_json: LazyJson, gh=None):
+    if gh is None:
+        gh = github3.login($USERNAME, $PASSWORD)
+    if not pr_json['state'] == 'closed':
+        r = requests.get(pr_json['statuses_url'],
+                         auth=($USERNAME, password=$PASSWORD))
+        statuses_json = r.json()
+        current_status = {i['context']: (i['state'], i['id']) for i in
+             sorted(statuses_json, key=lambda x: x['updated_at'])}
+        cached_status = LazyJson(pr_json['id'] + 'status.json')
+        # If the status has been updated, and none are pending
+        if current_status != cached_status and all(i['state'] != 'pending' for i in current_status):
+            pr_obj = github3.pulls.PullRequest(pr_json, gh)
+            if pr_obj.create_review_requests(team_reviewers=['conda-forge/' + pr_json['head']['repo']['name']]):
+                cached_status.update(**current_status)
         return pr_obj.as_dict()
 
 


### PR DESCRIPTION
at least for the bot's PRs. As a maintainer it can be difficult to rememe to come back to a PR when the CI is done. This helps by notifying maintainers. This might also accelerate the compiler migration as PRs may be closed faster than waiting for maintainers to remember they exist.

Closes #325

Attn: @regro/auto-tick