### PR TITLE
[WIP] libjpeg-turbo migrator

### DIFF
--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -779,3 +779,9 @@ class LibjpegTurbo(Migrator):
     """Migrator for swapping jpeg 9 with libjpeg-turbo."""
     migrator_version = 0
     rerender = True
+
+    def commit_message(self):
+        return 'use libjpeg-turbo'
+
+    def pr_title(self):
+        return 'Use libjpeg-turbo'

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -777,8 +777,12 @@ class Pinning(Migrator):
 
 class LibjpegTurbo(Migrator):
     """Migrator for swapping jpeg 9 with libjpeg-turbo."""
+
     migrator_version = 0
     rerender = True
+
+    def filter(self, attrs):
+        return 'jpeg' not in attrs.get('req', [])
 
     def commit_message(self):
         return 'use libjpeg-turbo'

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -773,3 +773,9 @@ class Pinning(Migrator):
 
     def remote_branch(self):
         return 'pinning'
+
+
+class LibjpegTurbo(Migrator):
+    """Migrator for swapping jpeg 9 with libjpeg-turbo."""
+    migrator_version = 0
+    rerender = True


### PR DESCRIPTION
In case we decide to use libjpeg-turbo as conda-forge jpeg implementation of choice.

See: https://github.com/conda-forge/conda-forge.github.io/issues/673

TODO:

- [ ] Actually build the migrator (should be simply replacing "jpeg" with "libjpeg-turbo")
- [ ] Account for possible corner cases, like seemingly abandoned bob.image that has a build matrix for jpeg.
- [ ] Create jpeg package for version 8 that installs turbo; pin jpeg to 8 in conda-forge pinning
- [ ] Maybe do the same for a version targeting jpeg 6 ABI?