### PR TITLE
WIP: Fix file path to GPL license for R packages.

### DIFF
--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -676,11 +676,11 @@ class Rebuild(Migrator):
                         # Fix path to GPL licenses
                         if line.strip() == 'license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2\'  # [unix]':
                             lines[i] = '  license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2\'\n'
-                        if line.strip() == 'license_file: \'{{ environ["PREFIX"] }}\\\\R\\\\share\\\\licenses\\\\GPL-2\'  # [win]':
+                        if line.strip() == 'license_file: \'{{ environ["PREFIX"] }}\\R\\share\\licenses\\GPL-2\'  # [win]':
                             lines[i] = ''
                         if line.strip() == 'license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3\'  # [unix]':
                             lines[i] = '  license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3\'\n'
-                        if line.strip() == 'license_file: \'{{ environ["PREFIX"] }}\\\\R\\\\share\\\\licenses\\\\GPL-3\'  # [win]':
+                        if line.strip() == 'license_file: \'{{ environ["PREFIX"] }}\\R\\share\\licenses\\GPL-3\'  # [win]':
                             lines[i] = ''
 
                 new_text = ''.join(lines)

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -674,13 +674,13 @@ class Rebuild(Migrator):
                         if line.lower().strip().startswith("skip: true"):
                             lines[i] = ""
                         # Fix path to GPL licenses
-                        if line.strip() == '  license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2\'  # [unix]':
-                            lines[i] = '  license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2\''
-                        if line.strip() == '  license_file: \'{{ environ["PREFIX"] }}\\\\R\\\\share\\\\licenses\\\\GPL-2\'  # [win]':
+                        if line.strip() == 'license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2\'  # [unix]':
+                            lines[i] = '  license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2\'\n'
+                        if line.strip() == 'license_file: \'{{ environ["PREFIX"] }}\\\\R\\\\share\\\\licenses\\\\GPL-2\'  # [win]':
                             lines[i] = ''
-                        if line.strip() == '  license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3\'  # [unix]':
-                            lines[i] = '  license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3\''
-                        if line.strip() == '  license_file: \'{{ environ["PREFIX"] }}\\\\R\\\\share\\\\licenses\\\\GPL-3\'  # [win]':
+                        if line.strip() == 'license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3\'  # [unix]':
+                            lines[i] = '  license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3\'\n'
+                        if line.strip() == 'license_file: \'{{ environ["PREFIX"] }}\\\\R\\\\share\\\\licenses\\\\GPL-3\'  # [win]':
                             lines[i] = ''
 
                 new_text = ''.join(lines)

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -673,6 +673,15 @@ class Rebuild(Migrator):
                     for i, line in enumerate(lines_stripped):
                         if line.lower().strip().startswith("skip: true"):
                             lines[i] = ""
+                        # Fix path to GPL licenses
+                        if line.strip() == '  license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2\'  # [unix]':
+                            lines[i] = '  license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2\''
+                        if line.strip() == '  license_file: \'{{ environ["PREFIX"] }}\\\\R\\\\share\\\\licenses\\\\GPL-2\'  # [win]':
+                            lines[i] = ''
+                        if line.strip() == '  license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3\'  # [unix]':
+                            lines[i] = '  license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3\''
+                        if line.strip() == '  license_file: \'{{ environ["PREFIX"] }}\\\\R\\\\share\\\\licenses\\\\GPL-3\'  # [win]':
+                            lines[i] = ''
 
                 new_text = ''.join(lines)
             if new_text:

--- a/tests/test_migrators.py
+++ b/tests/test_migrators.py
@@ -866,6 +866,15 @@ test:
   commands:
     - $R -e "library('stabledist')"  # [not win]
     - "\"%R%\" -e \"library('stabledist')\""  # [win]
+
+about:
+  home: http://www.rmetrics.org, https://r-forge.r-project.org/scm/viewvc.php/pkg/stabledist/?root=rmetrics
+  license: GPL (>= 2)
+  summary: Density, Probability and Quantile functions, and random number generation for (skew)
+    stable distributions, using the parametrizations of Nolan.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
 """
 
 updated_r_base2 = """
@@ -907,6 +916,14 @@ test:
   commands:
     - $R -e "library('stabledist')"  # [not win]
     - "\"%R%\" -e \"library('stabledist')\""  # [win]
+
+about:
+  home: http://www.rmetrics.org, https://r-forge.r-project.org/scm/viewvc.php/pkg/stabledist/?root=rmetrics
+  license: GPL (>= 2)
+  summary: Density, Probability and Quantile functions, and random number generation for (skew)
+    stable distributions, using the parametrizations of Nolan.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
 """
 
 sample_noarch = """{% set name = "xpdan" %}


### PR DESCRIPTION
After PR https://github.com/conda-forge/r-base-feedstock/pull/61 was merged, the installation path for r-base is no longer different for Windows. As packages are rebuilt for the compiler migration, it would be nice if the license paths could also be updated so that the license files are properly packaged for Windows binaries.

This is just a start mainly to stimulate discussion. Long-term we'll want to update all GPL'd R packages, so it might be better to have this in a separate class definition. Suggestions and advice on how to implement this would be appreciated.

cc: @isuruf @bgruening 

xref: https://github.com/bgruening/conda_r_skeleton_helper/pull/24, https://github.com/conda-forge/r-base-feedstock/pull/61, #394, #395 