### PR TITLE
Ensure correct migration for noarch-r packages

### DIFF
--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -682,6 +682,12 @@ class Rebuild(Migrator):
                         if line.lower().strip().startswith("skip: true"):
                             lines[i] = ""
 
+                        # remove win and not win selectors
+                        if "# [win]" in line:
+                            lines[i] = ""
+                        if "# [not win]" in line:
+                            lines[i] = line.replace("# [not win]", "").rstrip()
+
                 new_text = ''.join(lines)
             if new_text:
                 with open('meta.yaml', 'w') as f:

--- a/tests/test_migrators.py
+++ b/tests/test_migrators.py
@@ -768,6 +768,7 @@ source:
 build:
   number: 1
 
+  merge_build_host: True  # [win]
   rpaths:
     - lib/R/lib/
     - lib/
@@ -775,6 +776,7 @@ build:
 
 requirements:
   build:
+    - {{posix}}zip               # [win]
     - r-base
 
   run:
@@ -809,12 +811,14 @@ build:
   noarch: generic
   number: 2
 
+
   rpaths:
     - lib/R/lib/
     - lib/
 
 requirements:
   build:
+
     - r-base
 
   run:
@@ -822,8 +826,7 @@ requirements:
 
 test:
   commands:
-    - $R -e "library('stabledist')"  # [not win]
-    - "\"%R%\" -e \"library('stabledist')\""  # [win]
+    - $R -e "library('stabledist')"
 """
 
 

--- a/tests/test_migrators.py
+++ b/tests/test_migrators.py
@@ -811,14 +811,12 @@ build:
   noarch: generic
   number: 2
 
-
   rpaths:
     - lib/R/lib/
     - lib/
 
 requirements:
   build:
-
     - r-base
 
   run:


### PR DESCRIPTION
Several of the R packages have migrated failedly.  Eg: https://github.com/conda-forge/r-viridislite-feedstock/pull/3

This should fix that