### PR TITLE
Use regex to update path for any R license.

### DIFF
--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -680,18 +680,18 @@ class Rebuild(Migrator):
                     if s > 0:
                         spacing = s
                     lines[index] = lines[index] + " "*spacing + "noarch: generic\n"
+                regex_unix = re.compile('license_file: \'{{ environ\["PREFIX"\] }}/lib/R/share/licenses/(.+)\'\s+# \[unix\]')
+                regex_win = re.compile('license_file: \'{{ environ\["PREFIX"\] }}\\\R\\\share\\\licenses\\\(.+)\'\s+# \[win\]')
                 for i, line in enumerate(lines_stripped):
                     if noarch and line.lower().strip().startswith("skip: true"):
                         lines[i] = ""
-                    # Fix path to GPL licenses
-                    if line.strip() == 'license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2\'  # [unix]':
-                        lines[i] = '  license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2\'\n'
-                    if line.strip() == 'license_file: \'{{ environ["PREFIX"] }}\\R\\share\\licenses\\GPL-2\'  # [win]':
+                    # Fix path to licenses
+                    if regex_unix.match(line.strip()):
+                        lines[i] = regex_unix.sub('license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/\\1\'',
+                                                  lines[i])
+                    if regex_win.match(line.strip()):
                         lines[i] = ''
-                    if line.strip() == 'license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3\'  # [unix]':
-                        lines[i] = '  license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3\'\n'
-                    if line.strip() == 'license_file: \'{{ environ["PREFIX"] }}\\R\\share\\licenses\\GPL-3\'  # [win]':
-                        lines[i] = ''
+
                 new_text = ''.join(lines)
             if new_text:
                 with open('meta.yaml', 'w') as f:

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -680,8 +680,8 @@ class Rebuild(Migrator):
                     if s > 0:
                         spacing = s
                     lines[index] = lines[index] + " "*spacing + "noarch: generic\n"
-                regex_unix = re.compile('license_file: \'{{ environ\["PREFIX"\] }}/lib/R/share/licenses/(.+)\'\s+# \[unix\]')
-                regex_win = re.compile('license_file: \'{{ environ\["PREFIX"\] }}\\\R\\\share\\\licenses\\\(.+)\'\s+# \[win\]')
+                regex_unix = re.compile('license_file: \'{{ environ\["PREFIX"\] }}/lib/R/share/licenses/(\S+)\'\s+# \[unix\]')
+                regex_win = re.compile('license_file: \'{{ environ\["PREFIX"\] }}\\\R\\\share\\\licenses\\\(\S+)\'\s+# \[win\]')
                 for i, line in enumerate(lines_stripped):
                     if noarch and line.lower().strip().startswith("skip: true"):
                         lines[i] = ""

--- a/tests/test_migrators.py
+++ b/tests/test_migrators.py
@@ -959,6 +959,12 @@ about:
   license_family: LGPL
   license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2'  # [unix]
   license_file: '{{ environ["PREFIX"] }}\R\share\licenses\LGPL-2'  # [win]
+  license_family: LGPL
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2.1'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\LGPL-2.1'  # [win]
+  license_family: BSD
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/BSD_3_clause'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\BSD_3_clause'  # [win]
 """
 
 updated_r_licenses_noarch = """
@@ -1007,6 +1013,10 @@ about:
   license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
   license_family: LGPL
   license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2'
+  license_family: LGPL
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2.1'
+  license_family: BSD
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/BSD_3_clause'
 """
 
 # Test that filepaths to various licenses are updated for a compiled recipe
@@ -1060,6 +1070,12 @@ about:
   license_family: LGPL
   license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2'  # [unix]
   license_file: '{{ environ["PREFIX"] }}\R\share\licenses\LGPL-2'  # [win]
+  license_family: LGPL
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2.1'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\LGPL-2.1'  # [win]
+  license_family: BSD
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/BSD_3_clause'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\BSD_3_clause'  # [win]
 """
 
 updated_r_licenses_compiled = """
@@ -1109,6 +1125,10 @@ about:
   license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
   license_family: LGPL
   license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2'
+  license_family: LGPL
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2.1'
+  license_family: BSD
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/BSD_3_clause'
 """
 
 sample_noarch = """{% set name = "xpdan" %}

--- a/tests/test_migrators.py
+++ b/tests/test_migrators.py
@@ -866,15 +866,6 @@ test:
   commands:
     - $R -e "library('stabledist')"  # [not win]
     - "\"%R%\" -e \"library('stabledist')\""  # [win]
-
-about:
-  home: http://www.rmetrics.org, https://r-forge.r-project.org/scm/viewvc.php/pkg/stabledist/?root=rmetrics
-  license: GPL (>= 2)
-  summary: Density, Probability and Quantile functions, and random number generation for (skew)
-    stable distributions, using the parametrizations of Nolan.
-  license_family: GPL3
-  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
-  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
 """
 
 updated_r_base2 = """
@@ -916,46 +907,38 @@ test:
   commands:
     - $R -e "library('stabledist')"  # [not win]
     - "\"%R%\" -e \"library('stabledist')\""  # [win]
-
-about:
-  home: http://www.rmetrics.org, https://r-forge.r-project.org/scm/viewvc.php/pkg/stabledist/?root=rmetrics
-  license: GPL (>= 2)
-  summary: Density, Probability and Quantile functions, and random number generation for (skew)
-    stable distributions, using the parametrizations of Nolan.
-  license_family: GPL3
-  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
 """
 
-sample_r_base3 = """
-{% set version = '0.3' %}
+# Test that filepaths to various licenses are updated for a noarch recipe
+sample_r_licenses_noarch = """
+{% set version = '0.7-1' %}
 
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
 
 package:
-  name: r-xfun
+  name: r-stabledist
   version: {{ version|replace("-", "_") }}
 
 source:
-  fn: xfun_{{ version }}.tar.gz
+  fn: stabledist_{{ version }}.tar.gz
   url:
-    - {{ cran_mirror }}/src/contrib/xfun_{{ version }}.tar.gz
-    - {{ cran_mirror }}/src/contrib/Archive/xfun/xfun_{{ version }}.tar.gz
-  sha256: 897211d135a7fc5f955e4c810e0a0d8fa12b034b0a89dde47ab23e9b486b21e4
+    - https://cran.r-project.org/src/contrib/stabledist_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/stabledist/stabledist_{{ version }}.tar.gz
+
+
+  sha256: 06c5704d3a3c179fa389675c537c39a006867bc6e4f23dd7e406476ed2c88a69
 
 build:
-  merge_build_host: True  # [win]
   number: 1
 
   rpaths:
     - lib/R/lib/
     - lib/
+  skip: True  # [win32]
 
 requirements:
   build:
-    - {{posix}}zip               # [win]
-
-  host:
     - r-base
 
   run:
@@ -963,38 +946,42 @@ requirements:
 
 test:
   commands:
-    - $R -e "library('xfun')"           # [not win]
-    - "\"%R%\" -e \"library('xfun')\""  # [win]
+    - $R -e "library('stabledist')"  # [not win]
+    - "\"%R%\" -e \"library('stabledist')\""  # [win]
 
 about:
-  home: https://github.com/yihui/xfun
-  license: MIT
-  summary: Miscellaneous functions commonly used in other packages maintained by 'Yihui Xie'.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
   license_family: MIT
   license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'  # [unix]
   license_file: '{{ environ["PREFIX"] }}\R\share\licenses\MIT'  # [win]
+  license_family: LGPL
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\LGPL-2'  # [win]
 """
 
-updated_r_base3 = """
-{% set version = '0.3' %}
+updated_r_licenses_noarch = """
+{% set version = '0.7-1' %}
 
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
 
 package:
-  name: r-xfun
+  name: r-stabledist
   version: {{ version|replace("-", "_") }}
 
 source:
-  fn: xfun_{{ version }}.tar.gz
+  fn: stabledist_{{ version }}.tar.gz
   url:
-    - {{ cran_mirror }}/src/contrib/xfun_{{ version }}.tar.gz
-    - {{ cran_mirror }}/src/contrib/Archive/xfun/xfun_{{ version }}.tar.gz
-  sha256: 897211d135a7fc5f955e4c810e0a0d8fa12b034b0a89dde47ab23e9b486b21e4
+    - https://cran.r-project.org/src/contrib/stabledist_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/stabledist/stabledist_{{ version }}.tar.gz
+
+
+  sha256: 06c5704d3a3c179fa389675c537c39a006867bc6e4f23dd7e406476ed2c88a69
 
 build:
   noarch: generic
-  merge_build_host: True  # [win]
   number: 2
 
   rpaths:
@@ -1003,9 +990,6 @@ build:
 
 requirements:
   build:
-    - {{posix}}zip               # [win]
-
-  host:
     - r-base
 
   run:
@@ -1013,15 +997,118 @@ requirements:
 
 test:
   commands:
-    - $R -e "library('xfun')"           # [not win]
-    - "\"%R%\" -e \"library('xfun')\""  # [win]
+    - $R -e "library('stabledist')"  # [not win]
+    - "\"%R%\" -e \"library('stabledist')\""  # [win]
 
 about:
-  home: https://github.com/yihui/xfun
-  license: MIT
-  summary: Miscellaneous functions commonly used in other packages maintained by 'Yihui Xie'.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
   license_family: MIT
   license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+  license_family: LGPL
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2'
+"""
+
+# Test that filepaths to various licenses are updated for a compiled recipe
+sample_r_licenses_compiled = """
+{% set version = '0.7-1' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-stabledist
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: stabledist_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/stabledist_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/stabledist/stabledist_{{ version }}.tar.gz
+
+
+  sha256: 06c5704d3a3c179fa389675c537c39a006867bc6e4f23dd7e406476ed2c88a69
+
+build:
+  number: 1
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  skip: True  # [win32]
+
+requirements:
+  build:
+    - r-base
+    - {{ compiler('c') }}
+
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('stabledist')"  # [not win]
+    - "\"%R%\" -e \"library('stabledist')\""  # [win]
+
+about:
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+  license_family: MIT
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\MIT'  # [win]
+  license_family: LGPL
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\LGPL-2'  # [win]
+"""
+
+updated_r_licenses_compiled = """
+{% set version = '0.7-1' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-stabledist
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: stabledist_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/stabledist_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/stabledist/stabledist_{{ version }}.tar.gz
+
+
+  sha256: 06c5704d3a3c179fa389675c537c39a006867bc6e4f23dd7e406476ed2c88a69
+
+build:
+  number: 2
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  skip: True  # [win32]
+
+requirements:
+  build:
+    - r-base
+    - {{ compiler('c') }}
+
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('stabledist')"  # [not win]
+    - "\"%R%\" -e \"library('stabledist')\""  # [win]
+
+about:
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+  license_family: MIT
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+  license_family: LGPL
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2'
 """
 
 sample_noarch = """{% set name = "xpdan" %}
@@ -1630,9 +1717,18 @@ test_list = [
     ),
     (
         rebuild,
-        sample_r_base3,
-        updated_r_base3,
-        {"feedstock_name": "r-xfun"},
+        sample_r_licenses_noarch,
+        updated_r_licenses_noarch,
+        {"feedstock_name": "r-stabledist"},
+        "It is likely this feedstock needs to be rebuilt.",
+        {"migrator_name": "Rebuild", "migrator_version": rebuild.migrator_version, "name":"rebuild"},
+        False,
+    ),
+    (
+        rebuild,
+        sample_r_licenses_compiled,
+        updated_r_licenses_compiled,
+        {"feedstock_name": "r-stabledist"},
         "It is likely this feedstock needs to be rebuilt.",
         {"migrator_name": "Rebuild", "migrator_version": rebuild.migrator_version, "name":"rebuild"},
         False,

--- a/tests/test_migrators.py
+++ b/tests/test_migrators.py
@@ -926,6 +926,104 @@ about:
   license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
 """
 
+sample_r_base3 = """
+{% set version = '0.3' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-xfun
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: xfun_{{ version }}.tar.gz
+  url:
+    - {{ cran_mirror }}/src/contrib/xfun_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/xfun/xfun_{{ version }}.tar.gz
+  sha256: 897211d135a7fc5f955e4c810e0a0d8fa12b034b0a89dde47ab23e9b486b21e4
+
+build:
+  merge_build_host: True  # [win]
+  number: 1
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{posix}}zip               # [win]
+
+  host:
+    - r-base
+
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('xfun')"           # [not win]
+    - "\"%R%\" -e \"library('xfun')\""  # [win]
+
+about:
+  home: https://github.com/yihui/xfun
+  license: MIT
+  summary: Miscellaneous functions commonly used in other packages maintained by 'Yihui Xie'.
+  license_family: MIT
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\MIT'  # [win]
+"""
+
+updated_r_base3 = """
+{% set version = '0.3' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-xfun
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: xfun_{{ version }}.tar.gz
+  url:
+    - {{ cran_mirror }}/src/contrib/xfun_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/xfun/xfun_{{ version }}.tar.gz
+  sha256: 897211d135a7fc5f955e4c810e0a0d8fa12b034b0a89dde47ab23e9b486b21e4
+
+build:
+  noarch: generic
+  merge_build_host: True  # [win]
+  number: 2
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{posix}}zip               # [win]
+
+  host:
+    - r-base
+
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('xfun')"           # [not win]
+    - "\"%R%\" -e \"library('xfun')\""  # [win]
+
+about:
+  home: https://github.com/yihui/xfun
+  license: MIT
+  summary: Miscellaneous functions commonly used in other packages maintained by 'Yihui Xie'.
+  license_family: MIT
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+"""
+
 sample_noarch = """{% set name = "xpdan" %}
 {% set version = "0.3.3" %}
 {% set sha256 = "3f1a84f35471aa8e383da3cf4436492d0428da8ff5b02e11074ff65d400dd076" %}
@@ -1526,6 +1624,15 @@ test_list = [
         sample_r_base2,
         updated_r_base2,
         {"feedstock_name": "r-stabledist"},
+        "It is likely this feedstock needs to be rebuilt.",
+        {"migrator_name": "Rebuild", "migrator_version": rebuild.migrator_version, "name":"rebuild"},
+        False,
+    ),
+    (
+        rebuild,
+        sample_r_base3,
+        updated_r_base3,
+        {"feedstock_name": "r-xfun"},
         "It is likely this feedstock needs to be rebuilt.",
         {"migrator_name": "Rebuild", "migrator_version": rebuild.migrator_version, "name":"rebuild"},
         False,


### PR DESCRIPTION
I created a regex that will update the file path for any R license file that is shipped with r-base. It can also handle any number of spaces between the line and the selector in case this was done manually and used something other than 2 spaces.

```
# Fix path to licenses
import re
regex_unix = re.compile('license_file: \'{{ environ\["PREFIX"\] }}/lib/R/share/licenses/(.+)\'\\s+# \[unix\]')
regex_win = re.compile('license_file: \'{{ environ\["PREFIX"\] }}\\\R\\\share\\\licenses\\\(.+)\'\\s+# \[win\]')

lines = ['license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3\'  # [unix]',
         'license_file: \'{{ environ["PREFIX"] }}\R\share\licenses\GPL-3\'  # [win]',
         'license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2\'  # [unix]',
         'license_file: \'{{ environ["PREFIX"] }}\R\share\licenses\GPL-2\'  # [win]',
         'license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT\'  # [unix]',
         'license_file: \'{{ environ["PREFIX"] }}\R\share\licenses\MIT\'  # [win]',
         'license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/BSD_3_clause\'  # [unix]',
         'license_file: \'{{ environ["PREFIX"] }}\R\share\licenses\BSD_3_clause\'  # [win]']

for i, line in enumerate(lines):
    if regex_unix.match(line.strip()):
        lines[i] = regex_unix.sub('license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/\\1\'',
				  line)
    if regex_win.match(line.strip()):
        lines[i] = ''
lines
# ['license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3\'',
# '',
# 'license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2\'',
# '',
# 'license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT\'',
# '',
# 'license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/BSD_3_clause\'',
# '']
```

I added a new test and it passes on my local machine. However, I get a [strange error on Travis](https://travis-ci.org/jdblischak/cf-scripts/builds/456155898#L896):

```
        if pmy:
            pmy["version"] = pmy["package"]["version"]
            pmy["req"] = set()
            for k in ["build", "host", "run"]:
>               pmy["req"] |= set(pmy.get("requirements", {}).get(k, set()))
E               TypeError: 'NoneType' object is not iterable
tests/test_migrators.py:1663: TypeError
```

cc: @isuruf @CJ-Wright 

xref: https://github.com/regro/cf-scripts/pull/396/commits/2c41055cc80e78e7632700b5daefdb3e950c06a2#r234064627