### PR TITLE
Enabled parsing of requirements in outputs

### DIFF
--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -20,7 +20,7 @@ import requests
 
 from xonsh.lib.collections import ChainDB, _convert_to_dict
 from .all_feedstocks import get_all_feedstocks
-from .utils import parse_meta_yaml, setup_logger
+from .utils import parse_meta_yaml, setup_logger, get_requirements
 from .git_utils import (
     refresh_pr,
     is_github_api_limit_reached,
@@ -70,21 +70,7 @@ def get_attrs(name, i):
     sub_graph["meta_yaml"] = _convert_to_dict(yaml_dict)
 
     # TODO: Write schema for dict
-    req = yaml_dict.get("requirements", set())
-    if req:
-        build = list(
-            req.get("build", []) if req.get("build", []) is not None else []
-        )
-        host = list(
-            req.get("host", []) if req.get("host", []) is not None else []
-        )
-        run = list(
-            req.get("run", []) if req.get("run", []) is not None else []
-        )
-        req = build + host + run
-        req = set(
-            pin_sep_pat.split(x)[0].lower() for x in req if x is not None
-        )
+    req = get_requirements(yaml_dict)
     sub_graph["req"] = req
 
     keys = [("package", "name"), ("package", "version")]

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -215,10 +215,13 @@ def _parse_requirements(req, build=True, host=True, run=True):
     """
     if not req:  # handle None as empty
         return set()
-    build = req.get("build", []) or [] if build else []
-    host = req.get("host", []) or [] if host else []
-    run = req.get("run", []) or [] if run else []
-    req = build + host + run
+    if isinstance(req, list):
+        reqlist = req
+    else:
+        build = req.get("build", []) or [] if build else []
+        host = req.get("host", []) or [] if host else []
+        run = req.get("run", []) or [] if run else []
+        reqlist = build + host + run
     return set(
-        pin_sep_pat.split(x)[0].lower() for x in req if x is not None
+        pin_sep_pat.split(x)[0].lower() for x in reqlist if x is not None
     )

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -215,8 +215,8 @@ def _parse_requirements(req, build=True, host=True, run=True):
     """
     if not req:  # handle None as empty
         return set()
-    if isinstance(req, list):
-        reqlist = req
+    if isinstance(req, list):  # simple list goes to both host and run
+        reqlist = req if (host or run) else []
     else:
         build = req.get("build", []) or [] if build else []
         host = req.get("host", []) or [] if host else []

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -5,8 +5,11 @@ from collections.abc import Set, MutableMapping
 import logging
 import itertools
 import json
+import re
 
 import jinja2
+
+pin_sep_pat = re.compile(" |>|<|=|\[")
 
 
 class UniversalSet(Set):
@@ -178,3 +181,44 @@ def pluck(G, node_id):
         )
         G.remove_node(node_id)
         G.add_edges_from(new_edges)
+
+
+def get_requirements(meta_yaml, outputs=True, build=True, host=True, run=True):
+    """Get the list of recipe requirements from a meta.yaml dict
+
+    Parameters
+    ----------
+    meta_yaml: `dict`
+        a parsed meta YAML dict
+    outputs : `bool`
+        if `True` (default) return top-level requirements _and_ all
+        requirements in `outputs`, otherwise just return top-level
+        requirememts.
+    build, host, run : `bool`
+        include (`True`) or not (`False`) requirements from these sections
+
+    Returns
+    -------
+    reqs : `set`
+        the set of recipe requirements
+    """
+    kw = dict(build=build, host=host, run=run)
+    reqs = _parse_requirements(meta_yaml.get("requirements", {}), **kw)
+    outputs = meta_yaml.get("outputs", []) or [] if outputs else []
+    for output in outputs:
+        reqs.update(_parse_requirements(output.get("requirements", {}) or {}, **kw))
+    return reqs
+
+
+def _parse_requirements(req, build=True, host=True, run=True):
+    """Flatten a YAML requirements section into a list of names
+    """
+    if not req:  # handle None as empty
+        return set()
+    build = req.get("build", []) or [] if build else []
+    host = req.get("host", []) or [] if host else []
+    run = req.get("run", []) or [] if run else []
+    req = build + host + run
+    return set(
+        pin_sep_pat.split(x)[0].lower() for x in req if x is not None
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import os
 import json
 import pickle
 
-from conda_forge_tick.utils import LazyJson
+from conda_forge_tick.utils import (LazyJson, get_requirements)
 
 
 def test_lazy_json(tmpdir):
@@ -24,3 +24,20 @@ def test_lazy_json(tmpdir):
     lj2 = pickle.loads(p)
     assert not getattr(lj2, "data", None)
     assert lj2["hi"] == "globe"
+
+
+def test_get_requirements():
+    meta_yaml = {
+        "requirements": {
+            "build": ["1", "2"],
+            "host": ["2", "3"],
+        },
+        "outputs": [
+            {"requirements": {"host": ["4"]},},
+            {"requirements": {"run": ["5"]},},
+        ],
+    }
+    assert get_requirements({}) == set()
+    assert get_requirements(meta_yaml) == set(["1", "2", "3", "4", "5"])
+    assert get_requirements(meta_yaml, outputs=False) == set(["1", "2", "3"])
+    assert get_requirements(meta_yaml, host=False) == set(["1", "2", "5"])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,9 +35,10 @@ def test_get_requirements():
         "outputs": [
             {"requirements": {"host": ["4"]},},
             {"requirements": {"run": ["5"]},},
+            {"requirements": ["6"],},
         ],
     }
     assert get_requirements({}) == set()
-    assert get_requirements(meta_yaml) == set(["1", "2", "3", "4", "5"])
+    assert get_requirements(meta_yaml) == set(["1", "2", "3", "4", "5", "6"])
     assert get_requirements(meta_yaml, outputs=False) == set(["1", "2", "3"])
-    assert get_requirements(meta_yaml, host=False) == set(["1", "2", "5"])
+    assert get_requirements(meta_yaml, host=False) == set(["1", "2", "5", "6"])


### PR DESCRIPTION
This PR modifies YAML `requirements` parsing to also parse those sections declared for `outputs`, mainly to fix the sort of problems seen in conda-forge/lal-feedstock#12 (the bot doesn't run when there are no top-level `requirements`).