### PR TITLE
Added migrator for aarch64 and ppc64le

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -26,7 +26,6 @@ $MIGRATORS = [
    # Noarch(pr_limit=10),
    # Pinning(pr_limit=1, removals={'perl'}),
    # Compiler(pr_limit=7),
-   ArchRebuild(pr_limit=7)
 ]
 
 def run(attrs, migrator, feedstock=None, protocol='ssh',

--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -26,6 +26,7 @@ $MIGRATORS = [
    # Noarch(pr_limit=10),
    # Pinning(pr_limit=1, removals={'perl'}),
    # Compiler(pr_limit=7),
+   ArchRebuild(pr_limit=7)
 ]
 
 def run(attrs, migrator, feedstock=None, protocol='ssh',
@@ -206,6 +207,39 @@ def add_rebuild(migrators, gx):
                         cycles=cycles))
 
 
+def add_arch_migrate(migrators, gx):
+    """Adds rebuild migrators.
+
+    Parameters
+    ----------
+    migrators : list of Migrator
+        The list of migrators to run.
+
+    """
+    total_graph = copy.deepcopy(gx)
+
+    for node, attrs in gx.node.items():
+        meta_yaml = attrs.get("meta_yaml", {}) or {}
+        # no need to consider noarch packages for this rebuild
+        noarch = meta_yaml.get('build', {}).get('noarch')
+        if noarch:
+            pluck(total_graph, node)
+
+    # post plucking we can have several strange cases, lets remove all selfloops
+    total_graph.remove_edges_from(total_graph.selfloop_edges())
+
+    top_level = {node for node in total_graph if not set(total_graph.predecessors(node))}
+    cycles = list(nx.simple_cycles(total_graph))
+    print('cycles are here:', cycles)
+
+    migrators.append(
+        ArchRebuild(graph=total_graph,
+                pr_limit=5,
+                name='aarch64 and ppc64le addition',
+                        top_level=top_level,
+                        cycles=cycles))
+
+
 def initialize_migrators(do_rebuild=False):
     setup_logger(logger)
     temp = g`/tmp/*`
@@ -221,6 +255,7 @@ def initialize_migrators(do_rebuild=False):
     # TODO: reenable once graph order is correct
     if do_rebuild:
         add_rebuild($MIGRATORS, gx)
+    add_arch_migrate($MIGRATORS,gx)
 
     return gx, smithy_version, pinning_version, temp, $MIGRATORS
 

--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -70,7 +70,7 @@ def get_attrs(name, i):
     text, failed = fetch_file('conda-forge.yml')
     if failed:
         return sub_graph
-    sub_graph["conda_forge.yml"] = {k: v for k, v in  yaml.safe_load(text).items() if
+    sub_graph["conda-forge.yml"] = {k: v for k, v in  yaml.safe_load(text).items() if
         k in {'provider', 'max_py_ver', 'max_r_ver', 'compiler_stack'}}
 
     # TODO: Write schema for dict

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -706,9 +706,6 @@ class NoarchR(Noarch):
         else:
             return 'Bump build number'
 
-    def pr_head(self):
-        return $USERNAME + ':' + self.remote_branch()
-
     def remote_branch(self):
         return 'r-noarch'
 
@@ -733,7 +730,7 @@ class Rebuild(Migrator):
             self.graph = graph
         self.name = name
         self.top_level = top_level
-        self.cycles = set(chain.from_iterable(cycles))
+        self.cycles = set(chain.from_iterable(cycles or []))
 
     def filter(self, attrs):
         if super().filter(attrs, 'Upstream:'):

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -600,51 +600,37 @@ class Noarch(Migrator):
         return 'noarch_migration'
 
 
-class Rebuild(Migrator):
-    """Migrator for bumping the build number."""
+class NoarchR(Noarch):
     migrator_version = 0
     rerender = True
     bump_number = 1
 
-    def __init__(self, graph=None, name=None, pr_limit=0, top_level=None,
-                 cycles=None):
-        super().__init__(pr_limit)
-        if graph == None:
-            self.graph = nx.DiGraph()
-        else:
-            self.graph = graph
-        self.name = name
-        self.top_level = top_level
-        self.cycles = set(chain.from_iterable(cycles))
-
     def filter(self, attrs):
-        if super().filter(attrs, 'Upstream:'):
+        conditional = (super().filter(attrs) or
+                       attrs.get('meta_yaml', {}).get('outputs') or
+                       attrs.get('meta_yaml', {}).get('build', {}).get('noarch')
+                      )
+        if conditional:
             return True
-        if attrs['feedstock_name'] not in self.graph:
+        r = False
+        for req in attrs.get('req', []):
+            if self.compiler_pat.match(req) or req in self.unallowed_reqs:
+                return True
+
+        if attrs['feedstock_name'].startswith("r-"):
+            r = True
+        if not r:
             return True
-        # If in top level or in a cycle don't check for upstreams just build
-        if ((self.top_level and attrs['feedstock_name'] in self.top_level)
-            or (self.cycles and attrs['feedstock_name'] in self.cycles)):
-            return False
-        # Check if all upstreams have been built
-        for node in self.graph.predecessors(attrs['feedstock_name']):
-            att = self.graph.node[node]
-            muid = self.migrator_uid(att)
-            if muid not in att.get('PRed', []):
-                return True
-            # This is due to some PRed_json loss due to bad graph deploy outage
-            m_pred_jsons = att.get('PRed_json').get(muid)
-            if m_pred_jsons and m_pred_jsons.get('state', '') == 'open':
-                return True
+
+        ## R recipes tend to have some things in their build / test that have selectors
+
+        # for line in attrs.get('raw_meta_yaml', '').splitlines():
+        #    if self.sel_pat.match(line):
+        #        return True
         return False
 
     def migrate(self, recipe_dir, attrs, **kwargs):
         check_for = ['toolchain', 'libgcc', 'compiler']
-
-        if (not attrs['feedstock_name'].startswith("r-")):
-            with indir(recipe_dir):
-                self.set_build_number('meta.yaml')
-            return self.migrator_uid(attrs)
 
         noarch = not any(c in attrs['raw_meta_yaml'] for c in check_for)
 
@@ -697,6 +683,83 @@ class Rebuild(Migrator):
             if new_text:
                 with open('meta.yaml', 'w') as f:
                     f.writelines(new_text)
+            self.set_build_number('meta.yaml')
+        return self.migrator_uid(attrs)
+
+    def pr_body(self):
+        body = super().pr_body()
+        body = body.format(
+                    'It is likely this feedstock needs to be rebuilt.\n'
+                    'Notes and instructions for merging this PR:\n'
+                    '1. Please merge the PR only after the tests have passed. \n'
+                    "2. Feel free to push to the bot's branch to update this PR if needed. \n"
+                    "{}\n"
+                    )
+        return body
+
+    def commit_message(self):
+        return "add noarch r"
+
+    def pr_title(self):
+        if self.name:
+            return 'Noarch R for ' + self.name
+        else:
+            return 'Bump build number'
+
+    def pr_head(self):
+        return $USERNAME + ':' + self.remote_branch()
+
+    def remote_branch(self):
+        return 'r-noarch'
+
+    def migrator_uid(self, attrs):
+        n = super().migrator_uid(attrs)
+        n = n.copy(name=self.name)
+        return n
+
+
+class Rebuild(Migrator):
+    """Migrator for bumping the build number."""
+    migrator_version = 0
+    rerender = True
+    bump_number = 1
+
+    def __init__(self, graph=None, name=None, pr_limit=0, top_level=None,
+                 cycles=None):
+        super().__init__(pr_limit)
+        if graph == None:
+            self.graph = nx.DiGraph()
+        else:
+            self.graph = graph
+        self.name = name
+        self.top_level = top_level
+        self.cycles = set(chain.from_iterable(cycles))
+
+    def filter(self, attrs):
+        if super().filter(attrs, 'Upstream:'):
+            return True
+        if attrs['feedstock_name'] not in self.graph:
+            return True
+        # If in top level or in a cycle don't check for upstreams just build
+        if ((self.top_level and attrs['feedstock_name'] in self.top_level)
+            or (self.cycles and attrs['feedstock_name'] in self.cycles)):
+            return False
+        # Check if all upstreams have been built
+        for node in self.graph.predecessors(attrs['feedstock_name']):
+            att = self.graph.node[node]
+            muid = self.migrator_uid(att)
+            if muid not in att.get('PRed', []):
+                return True
+            # This is due to some PRed_json loss due to bad graph deploy outage
+            m_pred_jsons = att.get('PRed_json').get(muid)
+            if m_pred_jsons and m_pred_jsons.get('state', '') == 'open':
+                return True
+        return False
+
+    def migrate(self, recipe_dir, attrs, **kwargs):
+        check_for = ['toolchain', 'libgcc', 'compiler']
+
+        with indir(recipe_dir):
             self.set_build_number('meta.yaml')
         return self.migrator_uid(attrs)
 
@@ -827,3 +890,82 @@ class Pinning(Migrator):
 
     def remote_branch(self):
         return 'pinning'
+
+
+class ArchRebuild(Rebuild):
+    """
+    A Migrator that add aarch64 and ppc64le builds to feedstocks
+    """
+    migrator_version = 1
+    rerender = True
+    # We purposefully don't want to bump build number for this migrator
+    bump_number = 0
+    # We are constraining the scope of this migrator
+    target_packages = {
+        'ncurses'
+        'conda-build',
+        'numpy',
+        'opencv',
+        'ipython',
+        'pandas',
+        'tornado',
+        'matplotlib',
+        'distributed',
+        'zeromq',
+        'notebook',
+        'scipy',
+        'libarchive',
+        'zstd',
+        'krb5',
+        'scikit-learn',
+        }
+    arches = {
+        "linux_aarch64": "azure",
+        "linux_ppc64le": "azure",
+    }
+
+    def __init__(self, graph=None, name=None, pr_limit=0, top_level=None,
+                 cycles=None):
+        super().__init__(graph=graph, name=name, pr_limit=pr_limit, top_level=top_level,
+                         cycles=cycles)
+        # filter the graph down to the target packages
+        if self.target_packages:
+            packages = self.target_packages.copy()
+            for target in self.target_packages:
+                if target in self.graph.nodes:
+                    packages.update(self.graph.predecessors(target))
+            self.graph.remove_nodes_from([n for n in self.graph if n not in packages])
+
+    def filter(self, attrs):
+        if super().filter(attrs):
+            return True
+        for arch in self.arches:
+            configured_arch = attrs["conda_forge.yml"].get("provider", {}).get(arch)
+            if configured_arch:
+                return True
+
+    def migrate(self, recipe_dir, attrs, **kwargs):
+        with indir(recipe_dir + '/..'):
+            with open('conda-forge.yml', 'r') as f:
+                y = safe_load(f)
+            if 'provider' not in y:
+                y['provider'] = {}
+            for k, v in self.arches.items():
+                if k not in y['provider']:
+                    y['provider'][k] = v
+
+            with open('conda-forge.yml', 'w') as f:
+                safe_dump(y, f)
+        return super().migrate(recipe_dir, attrs, **kwargs)
+
+    def pr_title(self):
+        return 'Arch Migrator'
+
+    def pr_body(self):
+        body = dedent("""This feedstock is being rebuilt as part of the aarch64/ppc64le migration
+
+        cc: @conda-forge/arm-arch
+
+        **Please don't close this PR without reaching out the the ARM migrators first**
+        """)
+        return body

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -932,7 +932,7 @@ class ArchRebuild(Rebuild):
         if super().filter(attrs):
             return True
         for arch in self.arches:
-            configured_arch = attrs["conda_forge.yml"].get("provider", {}).get(arch)
+            configured_arch = attrs.get("conda-forge.yml", {}).get("provider", {}).get(arch)
             if configured_arch:
                 return True
 

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -606,7 +606,7 @@ class NoarchR(Noarch):
     bump_number = 1
 
     def filter(self, attrs):
-        conditional = (super().filter(attrs) or
+        conditional = (Migrator.filter(self, attrs) or
                        attrs.get('meta_yaml', {}).get('outputs') or
                        attrs.get('meta_yaml', {}).get('build', {}).get('noarch')
                       )
@@ -708,11 +708,6 @@ class NoarchR(Noarch):
 
     def remote_branch(self):
         return 'r-noarch'
-
-    def migrator_uid(self, attrs):
-        n = super().migrator_uid(attrs)
-        n = n.copy(name=self.name)
-        return n
 
 
 class Rebuild(Migrator):

--- a/requirements/run
+++ b/requirements/run
@@ -13,3 +13,4 @@ feedparser
 conda
 conda-forge-pinning
 frozendict
+distributed

--- a/tests/test_migrators.py
+++ b/tests/test_migrators.py
@@ -4,7 +4,7 @@ import builtins
 import pytest
 import networkx as nx
 
-from conda_forge_tick.migrators import JS, Version, Compiler, Noarch, Pinning, Rebuild
+from conda_forge_tick.migrators import JS, Version, Compiler, Noarch, Pinning, Rebuild, ArchRebuild, NoarchR
 from conda_forge_tick.utils import parse_meta_yaml
 
 
@@ -1534,6 +1534,7 @@ js = JS()
 version = Version()
 compiler = Compiler()
 noarch = Noarch()
+noarchr = NoarchR()
 perl = Pinning(removals={"perl"})
 pinning = Pinning()
 rebuild = Rebuild(name='rebuild', cycles=[])
@@ -1730,12 +1731,12 @@ test_list = [
         False,
     ),
     (
-        rebuild,
+        noarchr,
         sample_r_base,
         updated_r_base,
         {"feedstock_name": "r-stabledist"},
-        "It is likely this feedstock needs to be rebuilt.",
-        {"migrator_name": "Rebuild", "migrator_version": rebuild.migrator_version, "name":"rebuild"},
+        "I think this feedstock could be built with noarch",
+        {"migrator_name": "NoarchR", "migrator_version": noarchr.migrator_version},
         False,
     ),
     (
@@ -1748,23 +1749,24 @@ test_list = [
         False,
     ),
     (
-        rebuild,
+        noarchr,
         sample_r_licenses_noarch,
         updated_r_licenses_noarch,
         {"feedstock_name": "r-stabledist"},
-        "It is likely this feedstock needs to be rebuilt.",
-        {"migrator_name": "Rebuild", "migrator_version": rebuild.migrator_version, "name":"rebuild"},
+        "I think this feedstock could be built with noarch",
+        {"migrator_name": "NoarchR", "migrator_version": noarchr.migrator_version},
         False,
     ),
-    (
-        rebuild,
-        sample_r_licenses_compiled,
-        updated_r_licenses_compiled,
-        {"feedstock_name": "r-stabledist"},
-        "It is likely this feedstock needs to be rebuilt.",
-        {"migrator_name": "Rebuild", "migrator_version": rebuild.migrator_version, "name":"rebuild"},
-        False,
-    ),
+    # Disabled for now because the R license stuff has been purpossefully moved into the noarchR migrator
+    # (
+    #     noarchr,
+    #     sample_r_licenses_compiled,
+    #     updated_r_licenses_compiled,
+    #     {"feedstock_name": "r-stabledist"},
+    #     "It is likely this feedstock needs to be rebuilt.",
+    #     {"migrator_name": "Rebuild", "migrator_version": rebuild.migrator_version, "name":"rebuild"},
+    #     False,
+    # ),
 ]
 
 G = nx.DiGraph()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,6 +39,6 @@ def test_get_requirements():
         ],
     }
     assert get_requirements({}) == set()
-    assert get_requirements(meta_yaml) == set(["1", "2", "3", "4", "5", "6"])
-    assert get_requirements(meta_yaml, outputs=False) == set(["1", "2", "3"])
-    assert get_requirements(meta_yaml, host=False) == set(["1", "2", "5", "6"])
+    assert get_requirements(meta_yaml) == {"1", "2", "3", "4", "5", "6"}
+    assert get_requirements(meta_yaml, outputs=False) == {"1", "2", "3"}
+    assert get_requirements(meta_yaml, host=False) == {"1", "2", "5", "6"}


### PR DESCRIPTION
This is a basic migrator for doing the Arch rebuild.

* We are purposefully ignoring noarch here and initially operating within a bounded set of packages.
* In order to determine if a package is migrated we take a look inside the conda-forge-config.yml and check for certain values.  If those are present a package is skipped.  
* The current set of constraints yields about 120 packages to run this migrator on.

Additionally, this also adds a refactor to allow using `distributed` instead of `multiprocessing` for performing the initial graph building.
