### PR TITLE
end proj4 6.0.0 migration

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -448,7 +448,6 @@ def initialize_migrators(do_rebuild=False):
     add_rebuild_openssl($MIGRATORS, gx)
     add_rebuild_libprotobuf($MIGRATORS, gx)
     add_rebuild_blas($MIGRATORS, gx)
-    add_rebuild_successors($MIGRATORS, gx, 'proj4', '6.0.0')
     add_rebuild_successors($MIGRATORS, gx, 'lz4-c', '1.8.3')
     add_rebuild_successors($MIGRATORS, gx, 'zeromq', '4.3.1')
 


### PR DESCRIPTION
Proj4 6.0.0 was a success IMO, only two left and they are already in PR\*. 

@scopatz and @mariusvniekerk I'm not sure if this is the right way to finish a migration, or even if we have to?

\* QGIS is quite complicated and may need patching to work with proj4 6 and postgis seems to have a conflict when installing gdal/proj4/postgresql that I'm investigating but it may take a while due to the high number of dependencies involved.

![proj4-migration](https://user-images.githubusercontent.com/950575/56428177-de8d6100-6294-11e9-9846-fbdf9b555b4a.png)