### PR TITLE
migrate to qt 5.9.7

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -450,6 +450,7 @@ def initialize_migrators(do_rebuild=False):
     add_rebuild_blas($MIGRATORS, gx)
     add_rebuild_successors($MIGRATORS, gx, 'lz4-c', '1.8.3')
     add_rebuild_successors($MIGRATORS, gx, 'zeromq', '4.3.1')
+    add_rebuild_successors($MIGRATORS, gx, 'qt', '5.9.7')
 
     return gx, smithy_version, pinning_version, temp, $MIGRATORS
 


### PR DESCRIPTION
Follow up on https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/221

Note to self: once this is over we may want to drop the pin on `pyqt` and let `conda-build 3` and `run_exports` that care of that one, and start a new migration to the `icu` with `run_exports`.