### PR TITLE
Add initial glog migrator

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -451,6 +451,7 @@ def initialize_migrators(do_rebuild=False):
     add_rebuild_successors($MIGRATORS, gx, 'lz4-c', '1.8.3')
     add_rebuild_successors($MIGRATORS, gx, 'zeromq', '4.3.1')
     add_rebuild_successors($MIGRATORS, gx, 'qt', '5.9.7')
+    add_rebuild_successors($MIGRATORS, gx, 'glog', '0.4.0')
 
     return gx, smithy_version, pinning_version, temp, $MIGRATORS
 


### PR DESCRIPTION
Note that this is an initial migrator, `glog` is not yet pinned. Does the code also work for this or does it need extra work for that?

Please don't merge until https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/226 has been merged and rolled out to the auto-tick bot.