### PR TITLE
end zeromq and lz4 migration

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -448,8 +448,6 @@ def initialize_migrators(do_rebuild=False):
     add_rebuild_openssl($MIGRATORS, gx)
     add_rebuild_libprotobuf($MIGRATORS, gx)
     add_rebuild_blas($MIGRATORS, gx)
-    add_rebuild_successors($MIGRATORS, gx, 'lz4-c', '1.8.3')
-    add_rebuild_successors($MIGRATORS, gx, 'zeromq', '4.3.1')
     add_rebuild_successors($MIGRATORS, gx, 'qt', '5.9.7')
     add_rebuild_successors($MIGRATORS, gx, 'glog', '0.4.0')
 


### PR DESCRIPTION
Follow up on the bot sub-group meeting today. We will keep `openssl` and `qt` open for a while. (Qt may be closed as soon as I fix the `qwtpolar` PR.)