### PR TITLE
remove qt migrations and add proj4 6.1.0

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -448,7 +448,7 @@ def initialize_migrators(do_rebuild=False):
     add_rebuild_openssl($MIGRATORS, gx)
     add_rebuild_libprotobuf($MIGRATORS, gx)
     add_rebuild_blas($MIGRATORS, gx)
-    add_rebuild_successors($MIGRATORS, gx, 'qt', '5.9.7')
+    add_rebuild_successors($MIGRATORS, gx, 'proj4', '6.1.0')
     add_rebuild_successors($MIGRATORS, gx, 'glog', '0.4.0')
 
     return gx, smithy_version, pinning_version, temp, $MIGRATORS


### PR DESCRIPTION
As discussed in the previous bot-meeting the `qt` migration is "done," the remaining packages are either abandoned or not central to the `conda-forge` and will be updated when the maintainers there re-render.

This PR also adds a new migration to `proj4 6.1.0`. (Ping @snowman2.)