### PR TITLE
Add migrator for boost-cpp 1.70.0 pin

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -451,6 +451,8 @@ def initialize_migrators(do_rebuild=False):
     add_rebuild_successors($MIGRATORS, gx, 'proj4', '6.1.0')
     add_rebuild_successors($MIGRATORS, gx, 'pyqt', '5.9.2')
     add_rebuild_successors($MIGRATORS, gx, 'glog', '0.4.0')
+    add_rebuild_successors($MIGRATORS, gx, 'boost-cpp', '1.70.0')
+    add_rebuild_successors($MIGRATORS, gx, 'boost', '1.70.0')
 
     return gx, smithy_version, pinning_version, temp, $MIGRATORS
 


### PR DESCRIPTION
Updating pin here: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/231

Fixes https://github.com/regro/cf-scripts/issues/505