### PR TITLE
pause boost migration

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -450,7 +450,7 @@ def initialize_migrators(do_rebuild=False):
     add_rebuild_blas($MIGRATORS, gx)
     add_rebuild_successors($MIGRATORS, gx, 'pyqt', '5.9.2')
     add_rebuild_successors($MIGRATORS, gx, 'boost-cpp', '1.70.0')
-    add_rebuild_successors($MIGRATORS, gx, 'boost', '1.70.0')
+    # add_rebuild_successors($MIGRATORS, gx, 'boost', '1.70.0')
     add_rebuild_successors($MIGRATORS, gx, 'zstd', '1.4.0')
 
     return gx, smithy_version, pinning_version, temp, $MIGRATORS


### PR DESCRIPTION
As we discussed in our meeting yesterday let's pause the `boost` migration, let the `boos-cpp` finish, and then we can re-activate this one.