### PR TITLE
Add migrator for libevent=2.1.10

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -454,6 +454,7 @@ def initialize_migrators(do_rebuild=False):
     add_rebuild_successors($MIGRATORS, gx, 'zstd', '1.4.0')
     add_rebuild_successors($MIGRATORS, gx, 'hdf5', '1.10.5')
     add_rebuild_successors($MIGRATORS, gx, 'pixman', '0.38')
+    add_rebuild_successors($MIGRATORS, gx, 'libevent', '2.1.10')
 
     return gx, smithy_version, pinning_version, temp, $MIGRATORS
 


### PR DESCRIPTION
Depends on https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/238