### PR TITLE
end pixman migration

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -453,7 +453,6 @@ def initialize_migrators(do_rebuild=False):
     # add_rebuild_successors($MIGRATORS, gx, 'boost', '1.70.0')
     add_rebuild_successors($MIGRATORS, gx, 'zstd', '1.4.0')
     add_rebuild_successors($MIGRATORS, gx, 'hdf5', '1.10.5')
-    add_rebuild_successors($MIGRATORS, gx, 'pixman', '0.38')
     add_rebuild_successors($MIGRATORS, gx, 'libevent', '2.1.10')
     add_rebuild_successors($MIGRATORS, gx, 'gsl', '2.5')
     add_rebuild_successors($MIGRATORS, gx, 'ntl', '11.3.2')

--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -453,7 +453,6 @@ def initialize_migrators(do_rebuild=False):
     # add_rebuild_successors($MIGRATORS, gx, 'boost', '1.70.0')
     add_rebuild_successors($MIGRATORS, gx, 'zstd', '1.4.0')
     add_rebuild_successors($MIGRATORS, gx, 'hdf5', '1.10.5')
-    add_rebuild_successors($MIGRATORS, gx, 'libevent', '2.1.10')
     add_rebuild_successors($MIGRATORS, gx, 'gsl', '2.5')
     add_rebuild_successors($MIGRATORS, gx, 'ntl', '11.3.2')
     add_rebuild_successors($MIGRATORS, gx, 'pari', '2.11')


### PR DESCRIPTION
There is only 1 open PR to tex-live and that feedstock is broken in a while. So this migration was a successful. Also ending the 100% completed libevent.