### PR TITLE
end boost pyqt zstd hdf5 libprotobuf migrations

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -446,12 +446,7 @@ def initialize_migrators(do_rebuild=False):
 
     add_arch_migrate($MIGRATORS,gx)
     add_rebuild_openssl($MIGRATORS, gx)
-    add_rebuild_successors($MIGRATORS, gx, 'pyqt', '5.9.2')
-    add_rebuild_successors($MIGRATORS, gx, 'boost', '1.70.0')
-    add_rebuild_successors($MIGRATORS, gx, 'zstd', '1.4.0')
-    add_rebuild_successors($MIGRATORS, gx, 'hdf5', '1.10.5')
     add_rebuild_successors($MIGRATORS, gx, 'gsl', '2.5')
-    add_rebuild_successors($MIGRATORS, gx, 'libprotobuf', '3.8')
     add_rebuild_successors($MIGRATORS, gx, 'readline', '8.0')
 
     return gx, smithy_version, pinning_version, temp, $MIGRATORS


### PR DESCRIPTION
`zstd` actually complete :tada: 
All others either issued all the possible PRs or have shogun/shogun-cpp awaiting parents.