### PR TITLE
add r-base 3.6 migration and move all the build to azure

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -355,6 +355,56 @@ def add_rebuild_successors(migrators, gx, package_name, pin_version, pr_limit=5,
                 top_level=top_level,
                 cycles=cycles, obj_version=obj_version))
 
+def add_rebuild_rlang(migrators, gx, package_name, pin_version, pr_limit=10, obj_version=0):
+    """Adds rebuild migrator for the R language.
+
+    Parameters
+    ----------
+    migrators : list of Migrator
+        The list of migrators to run.
+    gx : networkx.DiGraph
+        The feedstock graph
+    package_name : str
+        The package who's pin was moved
+    pin_version : str
+        The new pin value
+    pr_limit : int, optional
+        The number of PRs per hour, defaults to 5
+    obj_version : int, optional
+        The version of the migrator object (useful if there was an error) 
+        defaults to 0
+    """
+
+    total_graph = copy.deepcopy(gx)
+
+    for node, attrs in gx.node.items():
+        meta_yaml = attrs.get("meta_yaml", {}) or {}
+        bh = get_requirements(meta_yaml)
+        criteria = package_name in bh
+
+        rq = _host_run_test_dependencies(meta_yaml)
+
+        for e in list(total_graph.in_edges(node)):
+            if e[0] not in rq:
+                total_graph.remove_edge(*e)
+        if not any([criteria]):
+            pluck(total_graph, node)
+
+    # post plucking we can have several strange cases, lets remove all selfloops
+    total_graph.remove_edges_from(total_graph.selfloop_edges())
+
+    top_level = {node for node in gx.successors(package_name) if
+                 (node in total_graph) and
+                 len(list(total_graph.predecessors(node))) == 0}
+    cycles = list(nx.simple_cycles(total_graph))
+
+    migrators.append(
+        RBaseRebuild(graph=total_graph,
+                pr_limit=pr_limit,
+                name=f'{package_name}-{pin_version}',
+                top_level=top_level,
+                cycles=cycles, obj_version=obj_version))
+
 
 def add_rebuild_blas(migrators, gx):
     """Adds rebuild blas 2.0 migrators.
@@ -449,7 +499,7 @@ def initialize_migrators(do_rebuild=False):
     add_rebuild_successors($MIGRATORS, gx, 'gsl', '2.5')
     add_rebuild_successors($MIGRATORS, gx, 'readline', '8.0')
     add_rebuild_successors($MIGRATORS, gx, 'geos', '3.7.2')
-    add_rebuild_successors($MIGRATORS, gx, 'r-base', '3.6.1')
+    add_rebuild_rlang($MIGRATORS, gx, 'r-base', '3.6.1')
 
     return gx, smithy_version, pinning_version, temp, $MIGRATORS
 

--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -304,7 +304,7 @@ def add_rebuild_libprotobuf(migrators, gx):
                 cycles=cycles, obj_version=3))
 
 
-def add_rebuild_successors(migrators, gx, package_name, pin_version, pr_limit=5, obj_version=0):
+def add_rebuild_successors(migrators, gx, package_name, pin_version, pr_limit=5, obj_version=0, rebuild_class=Rebuild):
     """Adds rebuild migrator.
 
     Parameters
@@ -349,57 +349,7 @@ def add_rebuild_successors(migrators, gx, package_name, pin_version, pr_limit=5,
     # print('cycles are here:', cycles)
 
     migrators.append(
-        Rebuild(graph=total_graph,
-                pr_limit=pr_limit,
-                name=f'{package_name}-{pin_version}',
-                top_level=top_level,
-                cycles=cycles, obj_version=obj_version))
-
-def add_rebuild_rlang(migrators, gx, package_name, pin_version, pr_limit=10, obj_version=0):
-    """Adds rebuild migrator for the R language.
-
-    Parameters
-    ----------
-    migrators : list of Migrator
-        The list of migrators to run.
-    gx : networkx.DiGraph
-        The feedstock graph
-    package_name : str
-        The package who's pin was moved
-    pin_version : str
-        The new pin value
-    pr_limit : int, optional
-        The number of PRs per hour, defaults to 5
-    obj_version : int, optional
-        The version of the migrator object (useful if there was an error) 
-        defaults to 0
-    """
-
-    total_graph = copy.deepcopy(gx)
-
-    for node, attrs in gx.node.items():
-        meta_yaml = attrs.get("meta_yaml", {}) or {}
-        bh = get_requirements(meta_yaml)
-        criteria = package_name in bh
-
-        rq = _host_run_test_dependencies(meta_yaml)
-
-        for e in list(total_graph.in_edges(node)):
-            if e[0] not in rq:
-                total_graph.remove_edge(*e)
-        if not any([criteria]):
-            pluck(total_graph, node)
-
-    # post plucking we can have several strange cases, lets remove all selfloops
-    total_graph.remove_edges_from(total_graph.selfloop_edges())
-
-    top_level = {node for node in gx.successors(package_name) if
-                 (node in total_graph) and
-                 len(list(total_graph.predecessors(node))) == 0}
-    cycles = list(nx.simple_cycles(total_graph))
-
-    migrators.append(
-        RBaseRebuild(graph=total_graph,
+        rebuild_class(graph=total_graph,
                 pr_limit=pr_limit,
                 name=f'{package_name}-{pin_version}',
                 top_level=top_level,
@@ -499,7 +449,7 @@ def initialize_migrators(do_rebuild=False):
     add_rebuild_successors($MIGRATORS, gx, 'gsl', '2.5')
     add_rebuild_successors($MIGRATORS, gx, 'readline', '8.0')
     add_rebuild_successors($MIGRATORS, gx, 'geos', '3.7.2')
-    add_rebuild_rlang($MIGRATORS, gx, 'r-base', '3.6.1')
+    add_rebuild_successors($MIGRATORS, gx, 'r-base', '3.6.1', rebuild_class=RBaseRebuild)
 
     return gx, smithy_version, pinning_version, temp, $MIGRATORS
 

--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -449,6 +449,7 @@ def initialize_migrators(do_rebuild=False):
     add_rebuild_successors($MIGRATORS, gx, 'gsl', '2.5')
     add_rebuild_successors($MIGRATORS, gx, 'readline', '8.0')
     add_rebuild_successors($MIGRATORS, gx, 'geos', '3.7.2')
+    add_rebuild_successors($MIGRATORS, gx, 'r-base', '3.6.1')
 
     return gx, smithy_version, pinning_version, temp, $MIGRATORS
 

--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -23,7 +23,7 @@ logger = logging.getLogger("conda_forge_tick.auto_tick")
 # https://travis-ci.org/regro/00-find-feedstocks/jobs/388387895#L1870
 from .migrators import *
 $MIGRATORS = [
-   Version(pr_limit=7),
+   Version(pr_limit=10),
    # Noarch(pr_limit=10),
    # Pinning(pr_limit=1, removals={'perl'}),
    # Compiler(pr_limit=7),
@@ -444,7 +444,7 @@ def initialize_migrators(do_rebuild=False):
     smithy_version = ![conda smithy --version].output.strip()
     pinning_version = json.loads(![conda list conda-forge-pinning --json].output.strip())[0]['version']
 
-    add_arch_migrate($MIGRATORS,gx)
+    add_arch_migrate($MIGRATORS, gx)
     add_rebuild_openssl($MIGRATORS, gx)
     add_rebuild_successors($MIGRATORS, gx, 'gsl', '2.5')
     add_rebuild_successors($MIGRATORS, gx, 'readline', '8.0')

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -337,6 +337,19 @@ class Version(Migrator):
                 n = eval_version(n)
                 replace_in_file(p, n, f)
             self.set_build_number('meta.yaml')
+
+        # Set the provider to Azure only
+        with indir(recipe_dir + '/..'):
+            with open('conda-forge.yml', 'r') as f:
+                y = safe_load(f)
+            if 'provider' not in y:
+                y['provider'] = {}
+            for arch in ['linux', 'osx', 'win']:
+                y['provider'][arch] = 'azure'
+
+            with open('conda-forge.yml', 'w') as f:
+                safe_dump(y, f)
+
         return self.migrator_uid(attrs)
 
     def pr_body(self):

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -337,19 +337,6 @@ class Version(Migrator):
                 n = eval_version(n)
                 replace_in_file(p, n, f)
             self.set_build_number('meta.yaml')
-
-        # Set the provider to Azure only
-        with indir(recipe_dir + '/..'):
-            with open('conda-forge.yml', 'r') as f:
-                y = safe_load(f)
-            if 'provider' not in y:
-                y['provider'] = {}
-            for arch in ['linux', 'osx', 'win']:
-                y['provider'][arch] = 'azure'
-
-            with open('conda-forge.yml', 'w') as f:
-                safe_dump(y, f)
-
         return self.migrator_uid(attrs)
 
     def pr_body(self):
@@ -1088,4 +1075,25 @@ class BlasRebuild(Rebuild):
 
     def pr_title(self):
         return 'Rebuild for new BLAS scheme'
+
+
+class RBaseRebuild(Rebuild):
+    """Migrator for rebuilding all R packages."""
+    migrator_version = 0
+    rerender = True
+    bump_number = 1
+
+    def migrate(self, recipe_dir, attrs, **kwargs):
+        # Set the provider to Azure only
+        with indir(recipe_dir + '/..'):
+            with open('conda-forge.yml', 'r') as f:
+                y = safe_load(f)
+            if 'provider' not in y:
+                y['provider'] = {}
+            for arch in ['linux', 'osx', 'win']:
+                y['provider'][arch] = 'azure'
+
+            with open('conda-forge.yml', 'w') as f:
+                safe_dump(y, f)
+        return self.migrator_uid(attrs)
 

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -1093,10 +1093,22 @@ class RBaseRebuild(Rebuild):
                 y = {}
             if 'provider' not in y:
                 y['provider'] = {}
-            for arch in ['linux', 'osx', 'win']:
-                y['provider'][arch] = 'azure'
-
+            y['provider']['win'] = 'azure'
             with open('conda-forge.yml', 'w') as f:
                 safe_dump(y, f)
+
+            with open('meta.yaml', 'r') as f:
+                text = f.read()
+            
+            if attrs['feedstock_name'].startswith("r-") and "- conda-forge/r" not in text \
+                    and any(a in text for a in ["johanneskoester", "bgruening", "daler", "jdblischak", "cbrueffer", "dbast", "dpryan79"]):
+                lines = text.split("\n")
+                for i, line in enumerate(lines):
+                    if line.strip() == "recipe-maintainers:" and i + 1 < len(lines):
+                        lines[i] = line + "\n" + lines[i+1][:lines[i+1].index("-")] + "- conda-forge/r"
+
+                with open('meta.yaml', 'w') as f:
+                    f.write('\n'.join(lines))
+
         return self.migrator_uid(attrs)
 

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -1086,8 +1086,11 @@ class RBaseRebuild(Rebuild):
     def migrate(self, recipe_dir, attrs, **kwargs):
         # Set the provider to Azure only
         with indir(recipe_dir + '/..'):
-            with open('conda-forge.yml', 'r') as f:
-                y = safe_load(f)
+            if os.path.exists('conda-forge.yml'):
+                with open('conda-forge.yml', 'r') as f:
+                    y = safe_load(f)
+            else:
+                y = {}
             if 'provider' not in y:
                 y['provider'] = {}
             for arch in ['linux', 'osx', 'win']:


### PR DESCRIPTION
This will migrate r-packages to 3.6 pinnings only and will only build on azure.

@isuruf I'm not sure this is correct :( This will probably not only run for r-packages now, isn't it?