### PR TITLE
migrate cfitsio and end geos

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -448,7 +448,7 @@ def initialize_migrators(do_rebuild=False):
     add_rebuild_openssl($MIGRATORS, gx)
     add_rebuild_successors($MIGRATORS, gx, 'gsl', '2.5')
     add_rebuild_successors($MIGRATORS, gx, 'readline', '8.0')
-    add_rebuild_successors($MIGRATORS, gx, 'geos', '3.7.2')
+    add_rebuild_successors($MIGRATORS, gx, 'cfitsio', '3.470')
 
     return gx, smithy_version, pinning_version, temp, $MIGRATORS
 


### PR DESCRIPTION
`geos` migration is done and we need a new one for `cfitsio` due to the recent ABI breakage.