### PR TITLE
ENH migrate to gfortran 7 for osx

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -249,7 +249,7 @@ def add_rebuild_openssl(migrators, gx):
     total_graph.remove_edges_from(total_graph.selfloop_edges())
 
     top_level = {node for node in gx.successors("openssl") if
-                 (node in total_graph) and 
+                 (node in total_graph) and
                  len(list(total_graph.predecessors(node))) == 0}
     cycles = list(nx.simple_cycles(total_graph))
     # print('cycles are here:', cycles)
@@ -320,7 +320,7 @@ def add_rebuild_successors(migrators, gx, package_name, pin_version, pr_limit=5,
     pr_limit : int, optional
         The number of PRs per hour, defaults to 5
     obj_version : int, optional
-        The version of the migrator object (useful if there was an error) 
+        The version of the migrator object (useful if there was an error)
         defaults to 0
     """
 
@@ -446,7 +446,8 @@ def initialize_migrators(do_rebuild=False):
 
     add_arch_migrate($MIGRATORS, gx)
     add_rebuild_openssl($MIGRATORS, gx)
-    add_rebuild_successors($MIGRATORS, gx, 'fortran_compiler_stub', '7')
+    add_rebuild_successors($MIGRATORS, gx, 'fortran_compiler_stub', '7',
+                           rebuild_class=GFortranOSXRebuild)
     add_rebuild_successors($MIGRATORS, gx, 'gdal', '3.0.1')
     add_rebuild_successors($MIGRATORS, gx, 'qt', '5.12')
 

--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -450,6 +450,7 @@ def initialize_migrators(do_rebuild=False):
     add_rebuild_successors($MIGRATORS, gx, 'readline', '8.0')
     add_rebuild_successors($MIGRATORS, gx, 'cfitsio', '3.470')
     add_rebuild_successors($MIGRATORS, gx, 'pango', '1.42.4')
+    add_rebuild_successors($MIGRATORS, gx, 'fortran_compiler_stub', '7')
 
     return gx, smithy_version, pinning_version, temp, $MIGRATORS
 

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -1142,7 +1142,7 @@ class GFortranOSXRebuild(Rebuild):
     bump_number = 1
 
     def pr_body(self):
-        body = super().pr_body()
+        body = super(Rebuild, self).pr_body()
         additional_body = ("This PR has been triggered in an effort to update **{0}**.\n\n"
                            "Notes and instructions for merging this PR:\n"
                            "1. Please merge the PR only after the tests have passed. \n"

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -1106,7 +1106,7 @@ class RBaseRebuild(Rebuild):
 
             changed = False
             lines = text.split("\n")
-            
+
             if attrs['feedstock_name'].startswith("r-") and "- conda-forge/r" not in text \
                     and any(a in text for a in ["johanneskoester", "bgruening", "daler", "jdblischak", "cbrueffer", "dbast", "dpryan79"]):
                 for i, line in enumerate(lines):
@@ -1135,3 +1135,32 @@ class RBaseRebuild(Rebuild):
 
         return self.migrator_uid(attrs)
 
+
+class GFortranOSXRebuild(Rebuild):
+    migrator_version = 0
+    rerender = True
+    bump_number = 1
+
+    def pr_body(self):
+        body = super().pr_body()
+        additional_body = ("This PR has been triggered in an effort to update **{0}**.\n\n"
+                           "Notes and instructions for merging this PR:\n"
+                           "1. Please merge the PR only after the tests have passed. \n"
+                           "2. Feel free to push to the bot's branch to update this PR if needed. \n"
+                           "**Please note that if you close this PR we presume that "
+                           "the feedstock has been rebuilt, so if you are going to "
+                           "perform the rebuild yourself don't close this PR until "
+                           "the your rebuild has been merged.**\n\n"
+                           "This package has the following downstream children:\n"
+                           "{1}\n"
+                           "And potentially more."
+                           "".format("to gfortran 7 for OSX",
+                                     '\n'.join([a[1] for a in list(self.graph.out_edges($PROJECT))[: 5]])))
+        body = body.format(additional_body)
+        return body
+
+    def commit_message(self):
+        return "Rebuild for gfortran 7 for OSX"
+
+    def pr_title(self):
+        return "Rebuild for gfortran 7 for OSX"


### PR DESCRIPTION
This PR has code to migrate to gfortran 7 for osx. I've made an associated PR on the global pinning files [here](https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/252).

pinging 

@scopatz 
@CJ-Wright 
@isuruf 

for viz and guidance