### PR TITLE
end gsl, cfitsio, pango, and readline migrations

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -446,11 +446,7 @@ def initialize_migrators(do_rebuild=False):
 
     add_arch_migrate($MIGRATORS, gx)
     add_rebuild_openssl($MIGRATORS, gx)
-    add_rebuild_successors($MIGRATORS, gx, 'gsl', '2.5')
-    add_rebuild_successors($MIGRATORS, gx, 'readline', '8.0')
     add_rebuild_successors($MIGRATORS, gx, 'r-base', '3.6.1', rebuild_class=RBaseRebuild, pr_limit=25)
-    add_rebuild_successors($MIGRATORS, gx, 'cfitsio', '3.470')
-    add_rebuild_successors($MIGRATORS, gx, 'pango', '1.42.4')
     add_rebuild_successors($MIGRATORS, gx, 'icu', '64.2')
 
     return gx, smithy_version, pinning_version, temp, $MIGRATORS


### PR DESCRIPTION
`cfitsio` completed and the others issued all the PRs, no `0 awaiting parent`.