### PR TITLE
migrate to qt 5.12

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -446,6 +446,7 @@ def initialize_migrators(do_rebuild=False):
 
     add_arch_migrate($MIGRATORS, gx)
     add_rebuild_openssl($MIGRATORS, gx)
+    add_rebuild_successors($MIGRATORS, gx, 'qt', '5.12')
     add_rebuild_successors($MIGRATORS, gx, 'r-base', '3.6.1', rebuild_class=RBaseRebuild)
 
     return gx, smithy_version, pinning_version, temp, $MIGRATORS


### PR DESCRIPTION
Thanks to the awesome work by @isuruf and @mingwandroid in https://github.com/conda-forge/qt-feedstock/pull/110, with the help of @msarahan and the sage math project, we can now move to a modern `qt`!