### PR TITLE
migrato to gdal 3

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -446,6 +446,8 @@ def initialize_migrators(do_rebuild=False):
 
     add_arch_migrate($MIGRATORS, gx)
     add_rebuild_openssl($MIGRATORS, gx)
+    add_rebuild_successors($MIGRATORS, gx, 'libgdal', '3.0.1')
+    # add_rebuild_successors($MIGRATORS, gx, 'gdal', '3.0.1')
     add_rebuild_successors($MIGRATORS, gx, 'qt', '5.12')
 
     return gx, smithy_version, pinning_version, temp, $MIGRATORS


### PR DESCRIPTION
We must migrate `libgdal` first and then un-comment the `gdal` migration.

xref.: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/263