### PR TITLE
Add ROOT to ArchRebuild migrator

### DIFF
--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -941,6 +941,7 @@ class ArchRebuild(Rebuild):
         'functools32',
         'jsoncpp',
         'bcrypt',
+        'root',
         }
     ignored_packages = {'make', 'perl', 'toolchain', 'posix',
         'patchelf', # weird issue


### PR DESCRIPTION
I suspect this will pull in a lot of dependencies and I don't have any specific plans for it yet so I'm happy for this to be closed if you'd prefer.

It should be doable as there are already ARM and POWER builds outside of conda-forge and I be able to access to real hardware for testing afterwards.