### PR TITLE
end openssl migration

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -445,7 +445,6 @@ def initialize_migrators(do_rebuild=False):
     pinning_version = json.loads(![conda list conda-forge-pinning --json].output.strip())[0]['version']
 
     add_arch_migrate($MIGRATORS, gx)
-    add_rebuild_openssl($MIGRATORS, gx)
     add_rebuild_successors($MIGRATORS, gx, 'fortran_compiler_stub', '7',
                            rebuild_class=GFortranOSXRebuild)
     add_rebuild_successors($MIGRATORS, gx, 'qt', '5.12')


### PR DESCRIPTION
We have more code related to the `openssl` migration here but I guess we should keep it. Maybe we can make it cleaner in a future re-factor.