### PR TITLE
lazy json all the way to the nodes

### DIFF
--- a/scripts/migrate_to_lzjson.py
+++ b/scripts/migrate_to_lzjson.py
@@ -1,10 +1,8 @@
-from conda_forge_tick.utils import LazyJson
+from conda_forge_tick.utils import LazyJson, load_graph, dump_graph
 
-
-import networkx as nx
-gx = nx.read_gpickle('graph.pkl')
+gx = load_graph()
 for k in gx.nodes.keys():
     lzj = LazyJson(f'node_attrs/{k}.json')
     lzj.update(**gx.nodes[k])
     gx.nodes[k] = lzj
-nx.write_gpickle(gx, 'graph.pkl')
+dump_graph(gx)


### PR DESCRIPTION
This needs to be checked over, since I'd like to stop the
bot when we go to run this migration of the graph itself.

Overall this should reduce git thrashing a lot, 
since we will only touch the files we need to
and it will make the graph.json smaller.

Additionally this will make the state of individual
nodes much easier to read since they can be read as
json themselves.