### PR TITLE
MNT end gfortran 7 for OSX migration

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -446,8 +446,6 @@ def initialize_migrators(do_rebuild=False):
 
     add_arch_migrate($MIGRATORS, gx)
     add_rebuild_openssl($MIGRATORS, gx)
-    add_rebuild_successors($MIGRATORS, gx, 'fortran_compiler_stub', '7',
-                           rebuild_class=GFortranOSXRebuild)
     add_rebuild_successors($MIGRATORS, gx, 'qt', '5.12')
 
     return gx, smithy_version, pinning_version, temp, $MIGRATORS


### PR DESCRIPTION
This PR ends the gfortran 7 for OSX migration. We have issued all of the PRs we possibly can. The remaining ~10-13 feedstocks that need migrating have complicated build issues or actual package test failures that need the attention of those maintainers.