### PR TITLE
use host if host, use build if not host

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -475,7 +475,7 @@ def add_rebuild_migration_yaml(migrators, gx, package_names, yaml_contents,
     for node, node_attrs in gx.nodes.items():
         attrs = node_attrs['payload']
         meta_yaml = attrs.get("meta_yaml", {}) or {}
-        bh = get_requirements(meta_yaml)
+        bh = get_requirements(meta_yaml, host=True) or get_requirements(meta_yaml, build=True)
         criteria = any(package_name in bh for package_name in package_names) and ('noarch' not in meta_yaml.get('build', {}))
 
         rq = _host_run_test_dependencies(meta_yaml)


### PR DESCRIPTION
This way we don't end up rebuilding things for a build req.

@regro/auto-tick