### PR TITLE
ENH matplotlib-base migration

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -442,7 +442,7 @@ def add_replacement_migrator(migrators, gx, old_pkg, new_pkg, rationale):
         for e in list(total_graph.in_edges(node)):
             if e[0] not in rq:
                 total_graph.remove_edge(*e)
-        if not any([old_pkg_c]):
+        if not old_pkg_c:
             pluck(total_graph, node)
 
     # post plucking we can have several strange cases, lets remove all selfloops

--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -412,7 +412,7 @@ def add_rebuild_blas(migrators, gx):
 
 
 def add_replacement_migrator(migrators, gx, old_pkg, new_pkg, rationale):
-    """Adds matplotlib migrator
+    """Adds a migrator to replace one package with another.
 
     Parameters
     ----------

--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -411,13 +411,21 @@ def add_rebuild_blas(migrators, gx):
                 cycles=cycles, obj_version=0))
 
 
-def add_matplotlib(migrators, gx):
+def add_replacement_migrator(migrators, gx, old_pkg, new_pkg, rationale):
     """Adds matplotlib migrator
 
     Parameters
     ----------
     migrators : list of Migrator
         The list of migrators to run.
+    gx : graph
+        The conda-forge dependency graph.
+    old_pkg : str
+        The package to be replaced.
+    new_pkg : str
+        The package to replace the `old_pkg`.
+    rationale : str
+        The reason the for the migration. Should be a full statement.
 
     """
     total_graph = copy.deepcopy(gx)
@@ -426,15 +434,15 @@ def add_matplotlib(migrators, gx):
         attrs = node_attrs['payload']
         meta_yaml = attrs.get("meta_yaml", {}) or {}
         bh = get_requirements(meta_yaml)
-        pkgs = set(["matplotlib"])
-        mpl_c = len(pkgs.intersection(bh)) > 0
+        pkgs = set([old_pkg])
+        old_pkg_c = len(pkgs.intersection(bh)) > 0
 
         rq = _host_run_test_dependencies(meta_yaml)
 
         for e in list(total_graph.in_edges(node)):
             if e[0] not in rq:
                 total_graph.remove_edge(*e)
-        if not any([mpl_c]):
+        if not any([old_pkg_c]):
             pluck(total_graph, node)
 
     # post plucking we can have several strange cases, lets remove all selfloops
@@ -445,7 +453,8 @@ def add_matplotlib(migrators, gx):
     cycles = list(nx.simple_cycles(total_graph))
 
     migrators.append(
-        Matplotlib(pr_limit=5))
+        Replacement(old_pkg=old_pkg, new_pkg=new_pkg, rationale=rationale,
+                    pr_limit=5))
 
 
 def add_arch_migrate(migrators, gx):
@@ -485,7 +494,7 @@ def add_arch_migrate(migrators, gx):
                         cycles=cycles))
 
 
-def add_rebuild_migration_yaml(migrators, gx, package_names, migration_yaml, 
+def add_rebuild_migration_yaml(migrators, gx, package_names, migration_yaml,
                                config={},
                                migration_name="", pr_limit=50):
     """Adds rebuild migrator.
@@ -513,11 +522,11 @@ def add_rebuild_migration_yaml(migrators, gx, package_names, migration_yaml,
     for node, node_attrs in gx.nodes.items():
         attrs = node_attrs['payload']
         meta_yaml = attrs.get("meta_yaml", {}) or {}
-        if ('strong' in meta_yaml.get('build', {}) or 
+        if ('strong' in meta_yaml.get('build', {}) or
             any(['strong' in output.get('build', {}) for output in meta_yaml.get('outputs', []) if output.get('build')])):
             bh = get_requirements(meta_yaml, run=False)
         else:
-            bh = (get_requirements(meta_yaml, run=False, build=False, host=True) or 
+            bh = (get_requirements(meta_yaml, run=False, build=False, host=True) or
                   get_requirements(meta_yaml, build=True, run=False, host=False))
         criteria = any(package_name in bh for package_name in package_names) and ('noarch' not in meta_yaml.get('build', {}))
 
@@ -536,12 +545,12 @@ def add_rebuild_migration_yaml(migrators, gx, package_names, migration_yaml,
                  (node in total_graph) and
                  len(list(total_graph.predecessors(node))) == 0}
     cycles = list(nx.simple_cycles(total_graph))
-    migrator = MigrationYaml(migration_yaml, 
+    migrator = MigrationYaml(migration_yaml,
                   graph=total_graph,
                   pr_limit=pr_limit,
                   name=migration_name,
                   top_level=top_level,
-                  cycles=cycles, 
+                  cycles=cycles,
                   piggy_back_migrations=[PipMigrator(), LicenseMigrator()], **config)
     print(f'bump number is {migrator.bump_number}')
     migrators.append(migrator)
@@ -583,7 +592,12 @@ def initialize_migrators(do_rebuild=False):
     pinning_version = json.loads(![conda list conda-forge-pinning --json].output.strip())[0]['version']
 
     add_arch_migrate($MIGRATORS, gx)
-    add_matplotlib($MIGRATORS, gx)
+    add_replacement_migrator(
+        $MIGRATORS, gx,
+        'matplotlib',
+        'matplotlib-base',
+        ('Unless you need `pyqt`, recipes should depend only on '
+         '`matplotlib-base`.'))
     migration_factory($MIGRATORS, gx)
     for m in $MIGRATORS:
         print(f'{getattr(m, "name", m)} graph size: {len(getattr(m, "graph", []))}')

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -1036,7 +1036,7 @@ class Matplotlib(Migrator):
     migrator_version = 0
     rerender = True
     mpl_pat = re.compile("\s*-\s*(matplotlib)(\s+|$)")
-    
+
     def __init__(self, pr_limit=0):
         super().__init__(pr_limit)
         self.mpl = set(["matplotlib"])
@@ -1051,7 +1051,7 @@ class Matplotlib(Migrator):
         lines = raw.splitlines()
         n = False
         for i, line in enumerate(lines):
-            m = self.mpl_p.match(line)
+            m = self.mpl_pat.match(line)
             if m is not None:
                 lines[i] = lines[i].replace(m.group(1), "matplotlib-base")
                 n = True

--- a/conda_forge_tick/migrators.xsh
+++ b/conda_forge_tick/migrators.xsh
@@ -1032,7 +1032,7 @@ class Pinning(Migrator):
 
 
 class Replacement(Migrator):
-    """Migrator for replacing on package with another.
+    """Migrator for replacing one package with another.
 
     Parameters
     ----------
@@ -1050,7 +1050,7 @@ class Replacement(Migrator):
         super().__init__(pr_limit)
         self.old_pkg = old_pkg
         self.new_pkg = new_pkg
-        self.pattern = re.compile("\s*-\s*(%s)(\s+|$)" % old_pkg
+        self.pattern = re.compile("\s*-\s*(%s)(\s+|$)" % old_pkg)
         self.packages = set([old_pkg])
         self.rationale = rationale
 

--- a/tests/test_migrators.py
+++ b/tests/test_migrators.py
@@ -2152,7 +2152,7 @@ source:
   sha256: c770e4b76f726e653d2b7c2c73f71941a88de6eb47ccf8fb8e984b55562d05a2
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: python -m pip install --no-deps --ignore-installed .
 

--- a/tests/test_migrators.py
+++ b/tests/test_migrators.py
@@ -16,6 +16,7 @@ from conda_forge_tick.migrators import (
     BlasRebuild,
     LicenseMigrator,
     MigrationYaml,
+    Matplotlib,
 )
 from conda_forge_tick.utils import parse_meta_yaml, frozen_to_json_friendly
 
@@ -2095,6 +2096,94 @@ extra:
     - kthyng
 """
 
+sample_matplotlib = """
+{% set version = "0.9" %}
+
+package:
+  name: viscm
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/v/viscm/viscm-{{ version }}.tar.gz
+  sha256: c770e4b76f726e653d2b7c2c73f71941a88de6eb47ccf8fb8e984b55562d05a2
+
+build:
+  number: 0
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - python
+    - pip
+    - numpy
+  run:
+    - python
+    - numpy
+    - matplotlib
+    - colorspacious
+
+test:
+  imports:
+    - viscm
+
+about:
+  home: https://github.com/bids/viscm
+  license: MIT
+  license_file: LICENSE
+  license_family: MIT
+  # license_file: '' we need to an issue upstream to get a license in the source dist.
+  summary: A colormap tool
+
+extra:
+  recipe-maintainers:
+    - kthyng
+"""
+
+sample_matplotlib_correct = """
+{% set version = "0.9" %}
+
+package:
+  name: viscm
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/v/viscm/viscm-{{ version }}.tar.gz
+  sha256: c770e4b76f726e653d2b7c2c73f71941a88de6eb47ccf8fb8e984b55562d05a2
+
+build:
+  number: 0
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - python
+    - pip
+    - numpy
+  run:
+    - python
+    - numpy
+    - matplotlib-base
+    - colorspacious
+
+test:
+  imports:
+    - viscm
+
+about:
+  home: https://github.com/bids/viscm
+  license: MIT
+  license_file: LICENSE
+  license_family: MIT
+  # license_file: '' we need to an issue upstream to get a license in the source dist.
+  summary: A colormap tool
+
+extra:
+  recipe-maintainers:
+    - kthyng
+"""
+
 js = JS()
 version = Version()
 lm = LicenseMigrator()
@@ -2110,6 +2199,8 @@ rebuild.filter = lambda x: False
 
 blas_rebuild = BlasRebuild(cycles=[])
 blas_rebuild.filter = lambda x: False
+
+matplotlib = Matplotlib()
 
 test_list = [
     (
@@ -2368,6 +2459,18 @@ test_list = [
             "migrator_name": "BlasRebuild",
             "migrator_version": blas_rebuild.migrator_version,
             "name": "blas2",
+        },
+        False,
+    ),
+    (
+        matplotlib,
+        sample_matplotlib,
+        sample_matplotlib_correct,
+        {},
+        "I noticed that this recipe depends on `matplotlib` instead of ",
+        {
+            "migrator_name": "Matplotlib",
+            "migrator_version": matplotlib.migrator_version,
         },
         False,
     ),

--- a/tests/test_migrators.py
+++ b/tests/test_migrators.py
@@ -16,7 +16,7 @@ from conda_forge_tick.migrators import (
     BlasRebuild,
     LicenseMigrator,
     MigrationYaml,
-    Matplotlib,
+    Replacement,
 )
 from conda_forge_tick.utils import parse_meta_yaml, frozen_to_json_friendly
 
@@ -2200,7 +2200,11 @@ rebuild.filter = lambda x: False
 blas_rebuild = BlasRebuild(cycles=[])
 blas_rebuild.filter = lambda x: False
 
-matplotlib = Matplotlib()
+matplotlib = Replacement(
+    old_pkg='matplotlib', new_pkg='matplotlib-base',
+    rationale=('Unless you need `pyqt`, recipes should depend only on '
+               '`matplotlib-base`.'),
+    pr_limit=5)
 
 test_list = [
     (
@@ -2469,7 +2473,7 @@ test_list = [
         {},
         "I noticed that this recipe depends on `matplotlib` instead of ",
         {
-            "migrator_name": "Matplotlib",
+            "migrator_name": "Replacement",
             "migrator_version": matplotlib.migrator_version,
         },
         False,


### PR DESCRIPTION
This PR adds the migration for `matplotlib` to `matplotlib-base`. Closes #705 