### PR TITLE
ENH stop matplotlib-base migration for a bit

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -592,12 +592,12 @@ def initialize_migrators(do_rebuild=False):
     pinning_version = json.loads(![conda list conda-forge-pinning --json].output.strip())[0]['version']
 
     add_arch_migrate($MIGRATORS, gx)
-    add_replacement_migrator(
-        $MIGRATORS, gx,
-        'matplotlib',
-        'matplotlib-base',
-        ('Unless you need `pyqt`, recipes should depend only on '
-         '`matplotlib-base`.'))
+    # add_replacement_migrator(
+    #     $MIGRATORS, gx,
+    #     'matplotlib',
+    #     'matplotlib-base',
+    #     ('Unless you need `pyqt`, recipes should depend only on '
+    #      '`matplotlib-base`.'))
     migration_factory($MIGRATORS, gx)
     for m in $MIGRATORS:
         print(f'{getattr(m, "name", m)} graph size: {len(getattr(m, "graph", []))}')


### PR DESCRIPTION
It appears that we are seeing a lot of failures on the matplotlib-base migration do to a non-working TK backend in the CI environment. I propose that we stop the migration and then restart it later after we have added `MPLBACKEND='Agg'` to the environment in CI.

@CJ-Wright for viz