### PR TITLE
Extract version starting at the first digit

### DIFF
--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -72,6 +72,8 @@ class VersionFromFeed:
                     ver = ver[len(prefix) :]
             if any(s in ver for s in self.dev_vers):
                 continue
+            # Extract vesion number starting at the first digit.
+            ver = re.search(r"(\d+[^\s]*)", ver).group(0)
             vers.append(ver)
         if vers:
             return max(vers, key=lambda x: VersionOrder(x.replace("-", ".")))


### PR DESCRIPTION
Issue:
- Version number from the `spacy-models` repository contains characters that are not a part of the version. Because of this, the updates do not get picked by the bot.

Changes:
- Perform a regex match to extract version number from the `ver` string such that everything starting at the first digit gets picked up in the pattern.

All of the expected version patterns expected by [`VersionOrder`](https://github.com/conda/conda/blob/da8b5a812bb17d83012f3a0bb63ef7158f1e846e/conda/models/version.py#L47) start with a numeric digit as well.

This fixes #707.