### PR TITLE
Add dummy argument to deploy() function

### DIFF
--- a/conda_forge_tick/cli.xsh
+++ b/conda_forge_tick/cli.xsh
@@ -10,8 +10,11 @@ from .auto_tick import main as main_auto_tick
 from .status_report import main as main_status_report
 
 
-def deploy():
+def deploy(args):
     """Deploy the graph to github"""
+    if args.dry_run:
+        print("(dry run) deploying")
+        return
     for cmd in [['git', 'add', 'pr_json/*'],
                 ['git', 'add', 'status/*'],
                 ['git', 'add', 'node_attrs/*'],


### PR DESCRIPTION
This PR fixes #712 by adding a dummy argument that accepts input, but does nothing with it.