### PR TITLE
increase number of version bump PRsto deal with backlog

### DIFF
--- a/conda_forge_tick/auto_tick.xsh
+++ b/conda_forge_tick/auto_tick.xsh
@@ -26,7 +26,7 @@ logger = logging.getLogger("conda_forge_tick.auto_tick")
 # https://travis-ci.org/regro/00-find-feedstocks/jobs/388387895#L1870
 from .migrators import *
 $MIGRATORS = [
-   Version(pr_limit=30, piggy_back_migrations=[PipMigrator(), LicenseMigrator()]),
+   Version(pr_limit=60, piggy_back_migrations=[PipMigrator(), LicenseMigrator()]),
    # Noarch(pr_limit=10),
    # Pinning(pr_limit=1, removals={'perl'}),
    # Compiler(pr_limit=7),


### PR DESCRIPTION
Currently we do 30 and it takes 20 mins so 60 should put us at 40mins, which should leave some breathing room for the other parts to be within the 1 hour time limit.