### PR TITLE
Add occt to the arch migrator

### DIFF
--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -66,6 +66,7 @@ class ArchRebuild(GraphMigrator):
         "lime",
         "shap",
         "tesseract",
+        "occt",
         # mpi variants
         "openmpi",
         "mpich",


### PR DESCRIPTION
I got a request for the python version of this by email. so this is at least a start.