### PR TITLE
DOC make sure aarch migrator PR body uses the parent text too

### DIFF
--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -97,14 +97,15 @@ class ArchRebuild(GraphMigrator):
         return "Arch Migrator"
 
     def pr_body(self, feedstock_ctx: FeedstockContext) -> str:
-        body = dedent(
+        body = super().pr_body(feedstock_ctx)
+        body.format(dedent(
             """\
         This feedstock is being rebuilt as part of the aarch64/ppc64le migration.
 
         **Feel free to merge the PR if CI is all green, but please don't close it
         without reaching out the the ARM migrators first at @conda-forge/arm-arch.**
         """
-        )
+        ))
         return body
 
     def remote_branch(self, feedstock_ctx: FeedstockContext) -> str:


### PR DESCRIPTION
Closes #729 

@regro/auto-tick for CR