### PR TITLE
Add URL to status graph nodes

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -556,6 +556,7 @@ def migrator_status(
                 fillcolor=fc,
                 style="filled",
                 fontcolor=fntc,
+                URL=pr_json.get("PR", {}).get("html_url", "")
             )
 
         # additional metadata for reporting

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -556,7 +556,7 @@ def migrator_status(
                 fillcolor=fc,
                 style="filled",
                 fontcolor=fntc,
-                URL=pr_json.get("PR", {}).get("html_url", "")
+                URL=(pr_json or {}).get("PR", {}).get("html_url", "")
             )
 
         # additional metadata for reporting


### PR DESCRIPTION
Love the new graph!

This adds the PR URL (if available) to each node that has one, which becomes clickable when the SVG is not shown as an `img` tag. While this sets a bunch of empty strings, they just get removed. I suppose a fallback value could be just to the feedstock URL itself (wasn't sure where that would come from in hte data). This does make the generated SVG a fair amount chunkier, but a good amount richer.

I couldn't tell how to test the generated SVG locally, but have used this feature a fair amount in the past.