### PR TITLE
fix doc on merge criteria

### DIFF
--- a/docs/github_actions_infrastructure.rst
+++ b/docs/github_actions_infrastructure.rst
@@ -39,7 +39,7 @@ Automerging PRs
 PRs from the regro-cf-autotick-bot are automatically merged when all of the
 following conditions are met
 
-1. all PR statuses must be passing, except maybe the linter
+1. all PR statuses must be passing, there must be at least one passing status, except maybe the linter
    (which is not fully reliable due to various bugs that need fixing)
 2. the PR must be from the regro-cf-autotick-bot user
 3. the feedstock must have ``bot: automerge: True`` set in the ``conda-forge.yml``

--- a/docs/github_actions_infrastructure.rst
+++ b/docs/github_actions_infrastructure.rst
@@ -39,7 +39,7 @@ Automerging PRs
 PRs from the regro-cf-autotick-bot are automatically merged when all of the
 following conditions are met
 
-1. the PR must have at least one passing status besides the linter
+1. all PR statuses must be passing, except maybe the linter
    (which is not fully reliable due to various bugs that need fixing)
 2. the PR must be from the regro-cf-autotick-bot user
 3. the feedstock must have ``bot: automerge: True`` set in the ``conda-forge.yml``


### PR DESCRIPTION
I was pretty surprised by this line in the docs, implying that if e.g. the Mac build fails but Linux passes then it'll still get merged – but that's [not what the code does](https://github.com/regro/cf-autotick-bot-action/blob/master/conda_forge_tick_action/automerge.py#L73).