### PR TITLE
TST add test for alternate hashes with weird jinja2 names

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -442,7 +442,6 @@ def initialize_migrators(
     github_token: Optional[str] = None,
     dry_run: bool = False,
 ) -> Tuple[MigratorSessionContext, list, MutableSequence[Migrator]]:
-    setup_logger(logger)
     temp = glob.glob("/tmp/*")
     gx = load_graph()
     smithy_version = eval_xonsh("conda smithy --version")

--- a/conda_forge_tick/migrators/version.py
+++ b/conda_forge_tick/migrators/version.py
@@ -172,7 +172,10 @@ def _try_replace_hash(
     _replaced_hash = False
     if '{{' in src[hash_key] and '}}' in src[hash_key]:
         # it's jinja2 :(
-        cnames = CHECKSUM_NAMES + [hash_type]
+        cnames = set(
+            CHECKSUM_NAMES
+            + [hash_type]
+            + list(set(JINJA2_VAR_RE.findall(src[hash_key]))))
         for cname in cnames:
             if selector is not None:
                 key = cname + CONDA_SELECTOR + selector

--- a/tests/test_migrators.py
+++ b/tests/test_migrators.py
@@ -1773,7 +1773,7 @@ def run_test_migration(
     if should_filter:
         return
 
-    mr = m.migrate(tmpdir, pmy)
+    mr = m.migrate(tmpdir, pmy, hash_type=pmy.get("hash_type", "sha256"))
     assert mr_out == mr
     if not mr:
         return

--- a/tests/test_version_migrator.py
+++ b/tests/test_version_migrator.py
@@ -30,6 +30,7 @@ YAML_PATH = os.path.join(os.path.dirname(__file__), 'test_yaml')
     ('githuburl', '1.1.0'),
     ('ccacheerr', '3.7.7'),
     ('cranmirror', '0.3.3'),
+    ('sha1', '5.0.1'),
 ])
 def test_version(case, new_ver, tmpdir, caplog):
     caplog.set_level(
@@ -46,11 +47,15 @@ def test_version(case, new_ver, tmpdir, caplog):
     ) as fp:
         out_yaml = fp.read()
 
+    kwargs = {"new_version": new_ver}
+    if case == 'sha1':
+        kwargs['hash_type'] = 'sha1'
+
     run_test_migration(
         m=VERSION,
         inp=in_yaml,
         output=out_yaml,
-        kwargs={"new_version": new_ver},
+        kwargs=kwargs,
         prb="Dependencies have been updated if changed",
         mr_out={
             "migrator_name": "Version",

--- a/tests/test_yaml/version_sha1.yaml
+++ b/tests/test_yaml/version_sha1.yaml
@@ -1,0 +1,52 @@
+{% set name = 'assimp' %}
+{% set version = '4.1.0' %}
+{% set sha256 = 'ce3589f9455c743e993fd802bdaaed72838cd3f4' %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/assimp/assimp/archive/v{{ version }}.tar.gz
+  sha1: {{ sha256 }}
+
+build:
+  number: 2
+  skip: true  # [win and vc<14]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x.x') }}
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
+    - cmake
+    - make
+  host:
+    - boost-cpp
+    - zlib
+  run:
+    - boost-cpp
+    - zlib
+
+test:
+  commands:
+    - test -f $PREFIX/include/assimp/anim.h  # [unix]
+    - test -f $PREFIX/lib/libassimp${SHLIB_EXT}  # [unix]
+    - if exist %LIBRARY_PREFIX%\include\assimp\anim.h (exit 0) else (exit 1)  # [win]
+    - if exist %LIBRARY_PREFIX%\lib\assimp-vc140-mt.lib (exit 0) else (exit 1)  # [win]
+    - if exist %LIBRARY_PREFIX%\bin\assimp-vc140-mt.dll (exit 0) else (exit 1)  # [win]
+
+about:
+  home: https://assimp.org/
+  summary: |
+    A library to import and export various 3d-model-formats including
+    scene-post-processing to generate missing render data.
+  license: Modified BSD
+  license_family: BSD
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - wolfv
+    - lesteve

--- a/tests/test_yaml/version_sha1_correct.yaml
+++ b/tests/test_yaml/version_sha1_correct.yaml
@@ -1,0 +1,52 @@
+{% set name = "assimp" %}
+{% set version = "5.0.1" %}
+{% set sha256 = "f148ba31dc1e7e00e59cc09b25535af997dc1998" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/assimp/assimp/archive/v{{ version }}.tar.gz
+  sha1: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win and vc<14]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x.x') }}
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
+    - cmake
+    - make
+  host:
+    - boost-cpp
+    - zlib
+  run:
+    - boost-cpp
+    - zlib
+
+test:
+  commands:
+    - test -f $PREFIX/include/assimp/anim.h  # [unix]
+    - test -f $PREFIX/lib/libassimp${SHLIB_EXT}  # [unix]
+    - if exist %LIBRARY_PREFIX%\include\assimp\anim.h (exit 0) else (exit 1)  # [win]
+    - if exist %LIBRARY_PREFIX%\lib\assimp-vc140-mt.lib (exit 0) else (exit 1)  # [win]
+    - if exist %LIBRARY_PREFIX%\bin\assimp-vc140-mt.dll (exit 0) else (exit 1)  # [win]
+
+about:
+  home: https://assimp.org/
+  summary: |
+    A library to import and export various 3d-model-formats including
+    scene-post-processing to generate missing render data.
+  license: Modified BSD
+  license_family: BSD
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - wolfv
+    - lesteve


### PR DESCRIPTION
A recipe used a sha1 hash stored in a jinja2 variable called sha256. 🤦‍♂ 

We can now handle that.

Closes #839 