### PR TITLE
Better match package output names when doing migrations (#852)

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -37,6 +37,7 @@ from typing import (
     Tuple,
     Dict,
     Set,
+    Mapping,
     MutableMapping,
     Union,
 )
@@ -338,6 +339,7 @@ def add_rebuild_migration_yaml(
     migrators: MutableSequence[Migrator],
     gx: nx.DiGraph,
     package_names: Sequence[str],
+    output_to_recipe: Mapping[str, str],
     migration_yaml: str,
     config: dict = {},
     migration_name: str = "",
@@ -393,6 +395,11 @@ def add_rebuild_migration_yaml(
 
     # post plucking we can have several strange cases, lets remove all selfloops
     total_graph.remove_edges_from(nx.selfloop_edges(total_graph))
+
+    package_names = {
+        p if p in gx.nodes else output_to_recipe[p]
+        for p in package_names
+    }
 
     top_level = {
         node
@@ -450,12 +457,12 @@ def migration_factory(
             (set(loaded_yaml) | {l.replace("_", "-") for l in loaded_yaml})
             & all_package_names
         ) - exclude_packages
-        package_names = {p if p in gx.nodes else output_to_recipe[p] for p in package_names} - exclude_packages
 
         add_rebuild_migration_yaml(
             migrators=migrators,
             gx=gx,
             package_names=list(package_names),
+            output_to_recipe=output_to_recipe,
             migration_yaml=yaml_contents,
             migration_name=os.path.splitext(yaml_file)[0],
             config=migrator_config,


### PR DESCRIPTION
I made a mistake when testing #853 which prevents it from properly working (it requires **both** the output and the top level recipe name to be requirement instead of either).

Assuming I've tested it properly this time, this PR fixes the issue.

Before:
```
aarch64 and ppc64le addition graph size: 644
grpc127 graph size: 1
python38 graph size: 2025
root620000 graph size: 1
boost172 graph size: 165
matplotlib-to-matplotlib-base graph size: 228
```
After:
```
aarch64 and ppc64le addition graph size: 644
grpc127 graph size: 1
python38 graph size: 2025
root620000 graph size: 7  # <- 6 more packages found
boost172 graph size: 165
matplotlib-to-matplotlib-base graph size: 228
```

Finishes fixing #852

cc @beckermr @duncanmmacleod 