### PR TITLE
BUG prefer node names over outputs

### DIFF
--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -300,7 +300,7 @@ def make_graph(names: List[str], gx: Optional[nx.DiGraph] = None) -> nx.DiGraph:
             # replace output package names with feedstock names via LUT
             deps = set(
                 map(
-                    lambda x: outputs_lut.get(x, x),
+                    lambda x: x if x in gx else outputs_lut.get(x, x),
                     set().union(*attrs.get("requirements", {}).values()),
                 )
             )


### PR DESCRIPTION
This change fixes the pyp36 -> pypy-meta -> pypy36 circular dep.

IDK if it should be general though. 

closes #866 

cc @isuruf @CJ-Wright 