### PR TITLE
add function for merging migrations into conda build config and add pinning to all migrations

### DIFF
--- a/conda_forge_tick/migrators/__init__.py
+++ b/conda_forge_tick/migrators/__init__.py
@@ -7,7 +7,7 @@ from .core import (
     Replacement,
 )
 from .conda_forge_yaml_cleanup import CondaForgeYAMLCleanup
-from .migration_yaml import MigrationYaml, MigrationYamlCreator
+from .migration_yaml import MigrationYaml, MigrationYamlCreator, merge_migrator_cbc
 from .arch import ArchRebuild
 from .pip_check import PipCheckMigrator
 from .matplotlib_base import MatplotlibBase

--- a/tests/test_migration_yaml_migration.py
+++ b/tests/test_migration_yaml_migration.py
@@ -245,7 +245,7 @@ def run_test_migration(
 
 
 with open(os.path.join(YAML_PATH, 'conda_build_config.yaml'), 'r') as fp:
-    cbc = fp.read()
+    CBC = fp.read()
 
 
 @pytest.mark.parametrize("migrator_name", ['pypy', 'krb', 'boost'])
@@ -254,4 +254,4 @@ def test_merge_migrator_cbc(migrator_name):
         migrator = fp.read()
     with open(os.path.join(YAML_PATH, f'{migrator_name}_out.yaml'), 'r') as fp:
         out = fp.read()
-    assert merge_migrator_cbc(migrator, cbc) == out
+    assert merge_migrator_cbc(migrator, CBC) == out

--- a/tests/test_migration_yaml_migration.py
+++ b/tests/test_migration_yaml_migration.py
@@ -11,7 +11,7 @@ import networkx as nx
 from conda_forge_tick.contexts import MigratorSessionContext, MigratorContext
 from conda_forge_tick.utils import parse_meta_yaml, frozen_to_json_friendly
 from conda_forge_tick.make_graph import populate_feedstock_attributes
-from conda_forge_tick.migrators import MigrationYamlCreator
+from conda_forge_tick.migrators import MigrationYamlCreator, merge_migrator_cbc
 from conda_forge_tick.xonsh_utils import eval_xonsh, indir
 
 G = nx.DiGraph()
@@ -20,6 +20,7 @@ env = builtins.__xonsh__.env  # type: ignore
 env["GRAPH"] = G
 env["CIRCLE_BUILD_URL"] = "hi world"
 
+YAML_PATH = os.path.join(os.path.dirname(__file__), 'test_yaml')
 
 IN_YAML = """\
 {% set version = datetime.datetime.utcnow().strftime("%Y.%m.%d.%H.%M.%S") %}
@@ -241,3 +242,16 @@ def run_test_migration(
     actual_output = pat.sub("", actual_output)
     output = pat.sub("", output)
     assert actual_output == output
+
+
+with open(os.path.join(YAML_PATH, 'conda_build_config.yaml'), 'r') as fp:
+    cbc = fp.read()
+
+
+@pytest.mark.parametrize("migrator_name", ['pypy', 'krb', 'boost'])
+def test_merge_migrator_cbc(migrator_name):
+    with open(os.path.join(YAML_PATH, f'{migrator_name}.yaml'), 'r') as fp:
+        migrator = fp.read()
+    with open(os.path.join(YAML_PATH, f'{migrator_name}_out.yaml'), 'r') as fp:
+        out = fp.read()
+    assert merge_migrator_cbc(migrator, cbc) == out

--- a/tests/test_yaml/boost.yaml
+++ b/tests/test_yaml/boost.yaml
@@ -1,0 +1,12 @@
+migrator_ts: 1582183745
+__migrator:
+  kind:
+    version
+  migration_number:
+    2
+  build_number:
+    1
+boost:
+  - 1.72
+boost_cpp:
+  - 1.72

--- a/tests/test_yaml/boost_out.yaml
+++ b/tests/test_yaml/boost_out.yaml
@@ -1,0 +1,609 @@
+# This differs from target_platform in that it determines what subdir the compiler
+#    will target, not what subdir the compiler package will be itself.
+#    For example, we need a win-64 vs2008_win-32 package, so that we compile win-32
+#    code on win-64 miniconda.
+cross_compiler_target_platform:  # [win]
+  - win-64                     # [win]
+c_compiler:
+  - gcc                        # [linux]
+  - clang                      # [osx]
+  - vs2015                     # [win]
+c_compiler_version:            # [unix]
+  - 9                          # [osx]
+  - 7                          # [linux64 or aarch64]
+  - 8                          # [ppc64le or armv7l]
+cxx_compiler:
+  - gxx                        # [linux]
+  - clangxx                    # [osx]
+  - vs2015                     # [win]
+cxx_compiler_version:          # [unix]
+  - 9                          # [osx]
+  - 7                          # [linux64 or aarch64]
+  - 8                          # [ppc64le or armv7l]
+fortran_compiler:              # [unix or win64]
+  - gfortran                   # [(linux64 or osx)]
+  - gfortran                   # [aarch64 or ppc64le or armv7l]
+  - flang                      # [win64]
+fortran_compiler_version:      # [unix or win64]
+  - 7                          # [linux64 or osx or aarch64]
+  - 8                          # [ppc64le or armv7l]
+  - 5                          # [win64]
+m2w64_c_compiler:              # [win]
+  - m2w64-toolchain            # [win]
+m2w64_cxx_compiler:            # [win]
+  - m2w64-toolchain            # [win]
+m2w64_fortran_compiler:        # [win]
+  - m2w64-toolchain            # [win]
+CMAKE_GENERATOR:               # [win]
+  - NMake Makefiles            # [win]
+
+cuda_compiler:                 # [linux64]
+  - nvcc                       # [linux64]
+cuda_compiler_version:         # [linux64]
+  - None                       # [linux64]
+  - 9.2                        # [linux64]
+  - 10.0                       # [linux64]
+  - 10.1                       # [linux64]
+  - 10.2                       # [linux64]
+
+_libgcc_mutex:
+  - 0.1 conda_forge
+#
+# Go Compiler Options
+#
+
+# The basic go-compiler with CGO disabled,
+# It generates fat binaries without libc dependencies
+# The activation scripts will set your CC,CXX and related flags
+# to invalid values.
+go_compiler:
+  - go-nocgo
+# The go compiler build with CGO enabled.
+# It can generate fat binaries that depend on conda's libc.
+# You should use this compiler if the underlying
+# program needs to link against other C libraries, in which
+# case make sure to add  'c,cpp,fortran_compiler' for unix
+# and the m2w64 equivalent for windows.
+cgo_compiler:
+  - go-cgo
+# The following are helpful variables to simplify go meta.yaml files.
+target_goos:
+  - linux                      # [linux]
+  - darwin                     # [osx]
+  - windows                    # [win]
+target_goarch:
+  - amd64                      # [x86_64]
+target_goexe:
+  -                            # [unix]
+  - .exe                       # [win]
+target_gobin:
+  - '${PREFIX}/bin/'           # [unix]
+  - '%PREFIX%\bin\'            # [win]
+
+# Rust Compiler Options
+rust_compiler:
+  - rust
+  - rust-gnu                   # [win]
+rust_compiler_version:
+  - 1.40.0
+
+
+macos_min_version:             # [osx]
+  - 10.9                       # [osx]
+macos_machine:                 # [osx]
+  - x86_64-apple-darwin13.4.0  # [osx]
+MACOSX_DEPLOYMENT_TARGET:      # [osx]
+  - 10.9                       # [osx]
+target_platform:               # [win]
+  - win-64                     # [win]
+VERBOSE_AT:
+  - V=1
+VERBOSE_CM:
+  - VERBOSE=1
+
+# dual build configuration
+channel_sources:
+  - conda-forge,defaults                        # [not (aarch64 or armv7l)]
+  - conda-forge                                 # [aarch64]
+  - conda-forge,c4armv7l,defaults               # [armv7l]
+
+channel_targets:
+  - conda-forge main
+
+docker_image:                                   # [linux]
+  - condaforge/linux-anvil-comp7                # [linux64]
+  - condaforge/linux-anvil-cuda:9.2             # [linux64]
+  - condaforge/linux-anvil-cuda:10.0            # [linux64]
+  - condaforge/linux-anvil-cuda:10.1            # [linux64]
+  - condaforge/linux-anvil-cuda:10.2            # [linux64]
+
+  - condaforge/linux-anvil-aarch64              # [aarch64]
+  - condaforge/linux-anvil-ppc64le              # [ppc64le]
+  - condaforge/linux-anvil-armv7l               # [armv7l]
+
+zip_keys:
+  -
+    - python
+  -                             # [linux64]
+    - cuda_compiler_version     # [linux64]
+    - docker_image              # [linux64]
+
+# aarch64 specifics because conda-build sets many things to centos 6
+# this can probably be removed when conda-build gets updated defaults
+# for aarch64
+cdt_arch: aarch64                       # [aarch64]
+cdt_name: cos7                          # [aarch64]
+BUILD: aarch64-conda_cos7-linux-gnu     # [aarch64]
+
+# armv7l specifics because conda-build sets many things to centos 6
+# this can probably be removed when conda-build gets updated defaults
+# for aarch64
+cdt_arch: armv7l                          # [armv7l]
+cdt_name: cos7                            # [armv7l]
+BUILD: armv7-conda_cos7-linux-gnueabihf   # [armv7l]
+
+# TODO: remove these when run_exports are added to the packages.
+pin_run_as_build:
+  arpack:
+    max_pin: x.x.x
+  boost:
+    max_pin: x.x.x
+  boost-cpp:
+    max_pin: x.x.x
+  bzip2:
+    max_pin: x
+  cairo:
+    max_pin: x.x
+  cudnn:
+    max_pin: x
+    min_pin: x.x
+  curl:
+    max_pin: x
+  dbus:
+    max_pin: x
+  expat:
+    max_pin: x.x
+  ffmpeg:
+    max_pin: x.x
+  fftw:
+    max_pin: x
+  flann:
+    max_pin: x.x.x
+  fontconfig:
+    max_pin: x
+  freetype:
+    max_pin: x
+  gdal:
+    max_pin: x.x
+  gdk_pixbuf:
+    max_pin: x.x.x
+  geotiff:
+    max_pin: x.x.x
+  glew:
+    max_pin: x.x
+  glpk:
+    max_pin: x.x
+  gmp:
+    max_pin: x
+  graphviz:
+    max_pin: x
+  grpc-cpp:
+    max_pin: x.x
+  harfbuzz:
+    max_pin: x
+  hdf4:
+    max_pin: x.x
+  icu:
+    max_pin: x
+  isl:
+    max_pin: x.x
+  jasper:
+    max_pin: x
+  jpeg:
+    max_pin: x
+  libjpeg_turbo:
+    max_pin: x
+  json-c:
+    max_pin: x.x
+  jsoncpp:
+    max_pin: x.x.x
+  kealib:
+    max_pin: x.x
+  krb5:
+    max_pin: x.x
+  libblitz:
+    max_pin: x.x
+  libcurl:
+    max_pin: x
+  libevent:
+    max_pin: x.x.x
+  libffi:
+    max_pin: x.x
+  libgdal:
+    max_pin: x.x
+  libiconv:
+    max_pin: x.x
+  libkml:
+    max_pin: x.x
+  libmatio:
+    max_pin: x.x
+  libpcap:
+    max_pin: x.x
+  libpng:
+    max_pin: x.x
+  librdkafka:
+    max_pin: x.x.x
+  librsvg:
+    max_pin: x
+  libssh2:
+    max_pin: x.x
+  libsvm:
+    max_pin: x.x
+  libunwind:
+    max_pin: x.x
+  libtiff:
+    max_pin: x
+  libwebp:
+    max_pin: x.x
+  libxml2:
+    max_pin: x.x
+  libuuid:
+    max_pin: x
+  lz4-c:
+    max_pin: x.x.x
+  lzo:
+    max_pin: x
+  metis:
+    max_pin: x.x
+  mkl:
+    max_pin: x
+  mpfr:
+    max_pin: x
+  ncurses:
+    max_pin: x.x
+  netcdf-cxx4:
+    max_pin: x.x
+  netcdf-fortran:
+    max_pin: x.x
+  nettle:
+    max_pin: x.x
+  nlopt:
+    max_pin: x.x.x
+  nss:
+    max_pin: x
+  nspr:
+    max_pin: x
+  occt:
+    max_pin: x.x
+  openblas:
+    max_pin: x.x.x
+  openturns:
+    max_pin: x.x
+  openjpeg:
+    max_pin: x.x
+  openssl:
+    max_pin: x.x.x
+  pango:
+    max_pin: x.x
+  perl:
+    max_pin: x.x.x
+  pixman:
+    max_pin: x.x
+  poppler:
+    max_pin: x.x
+  qt:
+    max_pin: x.x
+  readline:
+    max_pin: x
+  r-base:
+    max_pin: x.x
+    min_pin: x.x
+  sox:
+    max_pin: x.x.x
+  sqlite:
+    max_pin: x
+  tk:
+    max_pin: x.x
+  tiledb:
+    max_pin: x.x.x
+  vc:
+    max_pin: x
+  vlfeat:
+    max_pin: x.x.x
+  vtk:
+    max_pin: x.x.x
+  xerces-c:
+    max_pin: x.x.x
+  xz:
+    max_pin: x.x
+  zeromq:
+    max_pin: x.x  # [not win]
+    max_pin: x.x.x  # [win]
+  zlib:
+    max_pin: x.x
+  zstd:
+    max_pin: x.x.x
+
+# Pinning packages
+
+# blas
+libblas:
+  - 3.8 *netlib
+libcblas:
+  - 3.8 *netlib
+liblapack:
+  - 3.8.0 *netlib
+liblapacke:
+  - 3.8.0 *netlib
+blas_impl:
+  - openblas
+  - mkl          # [x86 or x86_64]
+  - blis         # [x86 or x86_64]
+
+abseil_cpp:
+  - 20200225.1
+arb:
+  - 2.17
+arpack:
+  - 3.6.3
+arrow_cpp:
+  - 0.16.0
+boost:
+  - 1.72
+boost_cpp:
+  - 1.72
+bzip2:
+  - 1
+cairo:
+  - 1.16
+cfitsio:
+  - 3.470
+cudnn:
+  - 7.6.5
+curl:
+  - 7.64
+dbus:
+  - 1
+expat:
+  - 2.2
+ffmpeg:
+  - 4.1
+fftw:
+  - 3
+flann:
+  - 1.9.1
+fontconfig:
+  - 2.13
+freetype:
+  - 2.9.1
+gf2x:
+  - 1.2
+gdk_pixbuf:
+  - 2.36.12
+gsl:
+  - 2.6
+gstreamer:
+  - 1.14.4
+gst_plugins_base:
+  - 1.14.4
+gdal:
+  - 3.0
+geos:
+  - 3.8.1
+geotiff:
+  - 1.5.1
+giflib:
+  - 5.2
+glew:
+  - 2.0.0
+glib:
+  - 2.58
+glog:
+  - 0.4.0
+glpk:
+  - 4.65
+gmp:
+  - 6
+graphviz:
+  - 2.40
+grpc_cpp:
+  - 1.27
+harfbuzz:
+  - 2
+hdf4:
+  - 4.2
+hdf5:
+  - 1.10.5
+icu:
+  - 64.2
+isl:
+  - 0.19
+jasper:
+  - 1.900.1
+jpeg:
+  - 9
+libjpeg_turbo:
+  - 2
+json_c:
+  - 0.13
+jsoncpp:
+  - 1.8.4
+kealib:
+  - 1.4.10
+krb5:
+  - 1.16
+libarchive:
+  - 3.3
+libblitz:
+  - 0.10
+libcurl:
+  - 7.64
+libdap4:
+  - 3.20.2
+libevent:
+  - 2.1.10
+libffi:
+  - 3.2
+libgdal:
+  - 3.0
+libiconv:
+  - 1.15
+libkml:
+  - 1.3
+libmatio:
+  - 1.5
+libnetcdf:
+  - 4.7.3
+libpcap:
+  - 1.8
+libpng:
+  - 1.6
+libprotobuf:
+  - 3.11
+librdkafka:
+  - 0.11.5
+librsvg:
+  - 2
+libsecret:
+  - 0.18
+libspatialindex:
+  - 1.9.3
+libssh2:
+  - 1.8
+libsvm:
+  - 3.21
+libtiff:
+  - 4.1.0
+libunwind:
+  - 1.2
+libwebp:
+  - 1.0
+libxml2:
+  - 2.9
+libuuid:
+  - 2.32.1
+lz4_c:
+  - 1.8.3
+lzo:
+  - 2
+metis:
+  - 5.1
+mkl:
+  - 2019
+mpich:
+  - 3.3
+mpfr:
+  - 4
+mumps_mpi:
+  - 5.2
+mumps_seq:
+  - 5.2
+nccl:
+  - 2.4.6.1
+ncurses:
+  - 6.1
+netcdf_cxx4:
+  - 4.3
+netcdf_fortran:
+  - 4.5
+nettle:
+  - 3.4
+nss:
+  - 3.39
+nspr:
+  - 4.20
+nlopt:
+  - 2.6.*
+ntl:
+  - 11.3.2
+# we build for the oldest version possible of numpy for forward compatibility
+numpy:
+  - 1.14       # [not (aarch64 or ppc64le)]
+  - 1.16       # [aarch64 or ppc64le]
+occt:
+  - 7.4
+openblas:
+  - 0.3.6
+openjpeg:
+  - 2.3
+openmpi:
+  - 4.0
+openssl:
+  - 1.1.1
+openturns:
+  - 1.14*
+pango:
+  - 1.42
+pari:
+  - 2.11
+perl:
+  - 5.26.2
+petsc:
+  - 3.12
+petsc4py:
+  - 3.12
+slepc:
+  - 3.12
+slepc4py:
+  - 3.12
+pixman:
+  - 0.38
+poppler:
+  - 0.67.0
+proj:
+  - 6.3.1
+python:
+  - 3.6.* *_cpython
+  - 3.7.* *_cpython
+python_impl:
+  - cpython
+qt:
+  - 5.12
+readline:
+  - 8.0
+root_base:
+  - 6.20.0
+ruby:
+  - 2.5
+  - 2.6
+r_base:
+  - 3.5.1
+  - 3.6
+scotch:
+  - 6.0.8
+ptscotch:
+  - 6.0.8
+singular:
+  - 4.1.2
+snappy:
+  - 1
+sox:
+  - 14.4.2
+sqlite:
+  - 3
+suitesparse:
+  - 5.6
+tk:
+  - 8.6                # [not ppc64le]
+tiledb:
+  - 1.7.0
+vc:                    # [win]
+  - 14                 # [win]
+vlfeat:
+  - 0.9.20
+vtk:
+  - 8.2.0
+x264:
+  - 1!152.*
+xerces_c:
+  - 3.2.2
+xrootd:
+  - 4.11.0
+xz:
+  - 5.2
+zeromq:
+  - 4.3.2
+zlib:
+  - 1.2
+zstd:
+  - 1.4.4

--- a/tests/test_yaml/conda_build_config.yaml
+++ b/tests/test_yaml/conda_build_config.yaml
@@ -1,0 +1,609 @@
+# This differs from target_platform in that it determines what subdir the compiler
+#    will target, not what subdir the compiler package will be itself.
+#    For example, we need a win-64 vs2008_win-32 package, so that we compile win-32
+#    code on win-64 miniconda.
+cross_compiler_target_platform:  # [win]
+  - win-64                     # [win]
+c_compiler:
+  - gcc                        # [linux]
+  - clang                      # [osx]
+  - vs2015                     # [win]
+c_compiler_version:            # [unix]
+  - 9                          # [osx]
+  - 7                          # [linux64 or aarch64]
+  - 8                          # [ppc64le or armv7l]
+cxx_compiler:
+  - gxx                        # [linux]
+  - clangxx                    # [osx]
+  - vs2015                     # [win]
+cxx_compiler_version:          # [unix]
+  - 9                          # [osx]
+  - 7                          # [linux64 or aarch64]
+  - 8                          # [ppc64le or armv7l]
+fortran_compiler:              # [unix or win64]
+  - gfortran                   # [(linux64 or osx)]
+  - gfortran                   # [aarch64 or ppc64le or armv7l]
+  - flang                      # [win64]
+fortran_compiler_version:      # [unix or win64]
+  - 7                          # [linux64 or osx or aarch64]
+  - 8                          # [ppc64le or armv7l]
+  - 5                          # [win64]
+m2w64_c_compiler:              # [win]
+  - m2w64-toolchain            # [win]
+m2w64_cxx_compiler:            # [win]
+  - m2w64-toolchain            # [win]
+m2w64_fortran_compiler:        # [win]
+  - m2w64-toolchain            # [win]
+CMAKE_GENERATOR:               # [win]
+  - NMake Makefiles            # [win]
+
+cuda_compiler:                 # [linux64]
+  - nvcc                       # [linux64]
+cuda_compiler_version:         # [linux64]
+  - None                       # [linux64]
+  - 9.2                        # [linux64]
+  - 10.0                       # [linux64]
+  - 10.1                       # [linux64]
+  - 10.2                       # [linux64]
+
+_libgcc_mutex:
+  - 0.1 conda_forge
+#
+# Go Compiler Options
+#
+
+# The basic go-compiler with CGO disabled,
+# It generates fat binaries without libc dependencies
+# The activation scripts will set your CC,CXX and related flags
+# to invalid values.
+go_compiler:
+  - go-nocgo
+# The go compiler build with CGO enabled.
+# It can generate fat binaries that depend on conda's libc.
+# You should use this compiler if the underlying
+# program needs to link against other C libraries, in which
+# case make sure to add  'c,cpp,fortran_compiler' for unix
+# and the m2w64 equivalent for windows.
+cgo_compiler:
+  - go-cgo
+# The following are helpful variables to simplify go meta.yaml files.
+target_goos:
+  - linux                      # [linux]
+  - darwin                     # [osx]
+  - windows                    # [win]
+target_goarch:
+  - amd64                      # [x86_64]
+target_goexe:
+  -                            # [unix]
+  - .exe                       # [win]
+target_gobin:
+  - '${PREFIX}/bin/'           # [unix]
+  - '%PREFIX%\bin\'            # [win]
+
+# Rust Compiler Options
+rust_compiler:
+  - rust
+  - rust-gnu                   # [win]
+rust_compiler_version:
+  - 1.40.0
+
+
+macos_min_version:             # [osx]
+  - 10.9                       # [osx]
+macos_machine:                 # [osx]
+  - x86_64-apple-darwin13.4.0  # [osx]
+MACOSX_DEPLOYMENT_TARGET:      # [osx]
+  - 10.9                       # [osx]
+target_platform:               # [win]
+  - win-64                     # [win]
+VERBOSE_AT:
+  - V=1
+VERBOSE_CM:
+  - VERBOSE=1
+
+# dual build configuration
+channel_sources:
+  - conda-forge,defaults                        # [not (aarch64 or armv7l)]
+  - conda-forge                                 # [aarch64]
+  - conda-forge,c4armv7l,defaults               # [armv7l]
+
+channel_targets:
+  - conda-forge main
+
+docker_image:                                   # [linux]
+  - condaforge/linux-anvil-comp7                # [linux64]
+  - condaforge/linux-anvil-cuda:9.2             # [linux64]
+  - condaforge/linux-anvil-cuda:10.0            # [linux64]
+  - condaforge/linux-anvil-cuda:10.1            # [linux64]
+  - condaforge/linux-anvil-cuda:10.2            # [linux64]
+
+  - condaforge/linux-anvil-aarch64              # [aarch64]
+  - condaforge/linux-anvil-ppc64le              # [ppc64le]
+  - condaforge/linux-anvil-armv7l               # [armv7l]
+
+zip_keys:
+  -
+    - python
+  -                             # [linux64]
+    - cuda_compiler_version     # [linux64]
+    - docker_image              # [linux64]
+
+# aarch64 specifics because conda-build sets many things to centos 6
+# this can probably be removed when conda-build gets updated defaults
+# for aarch64
+cdt_arch: aarch64                       # [aarch64]
+cdt_name: cos7                          # [aarch64]
+BUILD: aarch64-conda_cos7-linux-gnu     # [aarch64]
+
+# armv7l specifics because conda-build sets many things to centos 6
+# this can probably be removed when conda-build gets updated defaults
+# for aarch64
+cdt_arch: armv7l                          # [armv7l]
+cdt_name: cos7                            # [armv7l]
+BUILD: armv7-conda_cos7-linux-gnueabihf   # [armv7l]
+
+# TODO: remove these when run_exports are added to the packages.
+pin_run_as_build:
+  arpack:
+    max_pin: x.x.x
+  boost:
+    max_pin: x.x.x
+  boost-cpp:
+    max_pin: x.x.x
+  bzip2:
+    max_pin: x
+  cairo:
+    max_pin: x.x
+  cudnn:
+    max_pin: x
+    min_pin: x.x
+  curl:
+    max_pin: x
+  dbus:
+    max_pin: x
+  expat:
+    max_pin: x.x
+  ffmpeg:
+    max_pin: x.x
+  fftw:
+    max_pin: x
+  flann:
+    max_pin: x.x.x
+  fontconfig:
+    max_pin: x
+  freetype:
+    max_pin: x
+  gdal:
+    max_pin: x.x
+  gdk_pixbuf:
+    max_pin: x.x.x
+  geotiff:
+    max_pin: x.x.x
+  glew:
+    max_pin: x.x
+  glpk:
+    max_pin: x.x
+  gmp:
+    max_pin: x
+  graphviz:
+    max_pin: x
+  grpc-cpp:
+    max_pin: x.x
+  harfbuzz:
+    max_pin: x
+  hdf4:
+    max_pin: x.x
+  icu:
+    max_pin: x
+  isl:
+    max_pin: x.x
+  jasper:
+    max_pin: x
+  jpeg:
+    max_pin: x
+  libjpeg_turbo:
+    max_pin: x
+  json-c:
+    max_pin: x.x
+  jsoncpp:
+    max_pin: x.x.x
+  kealib:
+    max_pin: x.x
+  krb5:
+    max_pin: x.x
+  libblitz:
+    max_pin: x.x
+  libcurl:
+    max_pin: x
+  libevent:
+    max_pin: x.x.x
+  libffi:
+    max_pin: x.x
+  libgdal:
+    max_pin: x.x
+  libiconv:
+    max_pin: x.x
+  libkml:
+    max_pin: x.x
+  libmatio:
+    max_pin: x.x
+  libpcap:
+    max_pin: x.x
+  libpng:
+    max_pin: x.x
+  librdkafka:
+    max_pin: x.x.x
+  librsvg:
+    max_pin: x
+  libssh2:
+    max_pin: x.x
+  libsvm:
+    max_pin: x.x
+  libunwind:
+    max_pin: x.x
+  libtiff:
+    max_pin: x
+  libwebp:
+    max_pin: x.x
+  libxml2:
+    max_pin: x.x
+  libuuid:
+    max_pin: x
+  lz4-c:
+    max_pin: x.x.x
+  lzo:
+    max_pin: x
+  metis:
+    max_pin: x.x
+  mkl:
+    max_pin: x
+  mpfr:
+    max_pin: x
+  ncurses:
+    max_pin: x.x
+  netcdf-cxx4:
+    max_pin: x.x
+  netcdf-fortran:
+    max_pin: x.x
+  nettle:
+    max_pin: x.x
+  nlopt:
+    max_pin: x.x.x
+  nss:
+    max_pin: x
+  nspr:
+    max_pin: x
+  occt:
+    max_pin: x.x
+  openblas:
+    max_pin: x.x.x
+  openturns:
+    max_pin: x.x
+  openjpeg:
+    max_pin: x.x
+  openssl:
+    max_pin: x.x.x
+  pango:
+    max_pin: x.x
+  perl:
+    max_pin: x.x.x
+  pixman:
+    max_pin: x.x
+  poppler:
+    max_pin: x.x
+  qt:
+    max_pin: x.x
+  readline:
+    max_pin: x
+  r-base:
+    max_pin: x.x
+    min_pin: x.x
+  sox:
+    max_pin: x.x.x
+  sqlite:
+    max_pin: x
+  tk:
+    max_pin: x.x
+  tiledb:
+    max_pin: x.x.x
+  vc:
+    max_pin: x
+  vlfeat:
+    max_pin: x.x.x
+  vtk:
+    max_pin: x.x.x
+  xerces-c:
+    max_pin: x.x.x
+  xz:
+    max_pin: x.x
+  zeromq:
+    max_pin: x.x  # [not win]
+    max_pin: x.x.x  # [win]
+  zlib:
+    max_pin: x.x
+  zstd:
+    max_pin: x.x.x
+
+# Pinning packages
+
+# blas
+libblas:
+  - 3.8 *netlib
+libcblas:
+  - 3.8 *netlib
+liblapack:
+  - 3.8.0 *netlib
+liblapacke:
+  - 3.8.0 *netlib
+blas_impl:
+  - openblas
+  - mkl          # [x86 or x86_64]
+  - blis         # [x86 or x86_64]
+
+abseil_cpp:
+  - 20200225.1
+arb:
+  - 2.17
+arpack:
+  - 3.6.3
+arrow_cpp:
+  - 0.16.0
+boost:
+  - 1.70.0
+boost_cpp:
+  - 1.70.0
+bzip2:
+  - 1
+cairo:
+  - 1.16
+cfitsio:
+  - 3.470
+cudnn:
+  - 7.6.5
+curl:
+  - 7.64
+dbus:
+  - 1
+expat:
+  - 2.2
+ffmpeg:
+  - 4.1
+fftw:
+  - 3
+flann:
+  - 1.9.1
+fontconfig:
+  - 2.13
+freetype:
+  - 2.9.1
+gf2x:
+  - 1.2
+gdk_pixbuf:
+  - 2.36.12
+gsl:
+  - 2.6
+gstreamer:
+  - 1.14.4
+gst_plugins_base:
+  - 1.14.4
+gdal:
+  - 3.0
+geos:
+  - 3.8.1
+geotiff:
+  - 1.5.1
+giflib:
+  - 5.2
+glew:
+  - 2.0.0
+glib:
+  - 2.58
+glog:
+  - 0.4.0
+glpk:
+  - 4.65
+gmp:
+  - 6
+graphviz:
+  - 2.40
+grpc_cpp:
+  - 1.27
+harfbuzz:
+  - 2
+hdf4:
+  - 4.2
+hdf5:
+  - 1.10.5
+icu:
+  - 64.2
+isl:
+  - 0.19
+jasper:
+  - 1.900.1
+jpeg:
+  - 9
+libjpeg_turbo:
+  - 2
+json_c:
+  - 0.13
+jsoncpp:
+  - 1.8.4
+kealib:
+  - 1.4.10
+krb5:
+  - 1.16
+libarchive:
+  - 3.3
+libblitz:
+  - 0.10
+libcurl:
+  - 7.64
+libdap4:
+  - 3.20.2
+libevent:
+  - 2.1.10
+libffi:
+  - 3.2
+libgdal:
+  - 3.0
+libiconv:
+  - 1.15
+libkml:
+  - 1.3
+libmatio:
+  - 1.5
+libnetcdf:
+  - 4.7.3
+libpcap:
+  - 1.8
+libpng:
+  - 1.6
+libprotobuf:
+  - 3.11
+librdkafka:
+  - 0.11.5
+librsvg:
+  - 2
+libsecret:
+  - 0.18
+libspatialindex:
+  - 1.9.3
+libssh2:
+  - 1.8
+libsvm:
+  - 3.21
+libtiff:
+  - 4.1.0
+libunwind:
+  - 1.2
+libwebp:
+  - 1.0
+libxml2:
+  - 2.9
+libuuid:
+  - 2.32.1
+lz4_c:
+  - 1.8.3
+lzo:
+  - 2
+metis:
+  - 5.1
+mkl:
+  - 2019
+mpich:
+  - 3.3
+mpfr:
+  - 4
+mumps_mpi:
+  - 5.2
+mumps_seq:
+  - 5.2
+nccl:
+  - 2.4.6.1
+ncurses:
+  - 6.1
+netcdf_cxx4:
+  - 4.3
+netcdf_fortran:
+  - 4.5
+nettle:
+  - 3.4
+nss:
+  - 3.39
+nspr:
+  - 4.20
+nlopt:
+  - 2.6.*
+ntl:
+  - 11.3.2
+# we build for the oldest version possible of numpy for forward compatibility
+numpy:
+  - 1.14       # [not (aarch64 or ppc64le)]
+  - 1.16       # [aarch64 or ppc64le]
+occt:
+  - 7.4
+openblas:
+  - 0.3.6
+openjpeg:
+  - 2.3
+openmpi:
+  - 4.0
+openssl:
+  - 1.1.1
+openturns:
+  - 1.14*
+pango:
+  - 1.42
+pari:
+  - 2.11
+perl:
+  - 5.26.2
+petsc:
+  - 3.12
+petsc4py:
+  - 3.12
+slepc:
+  - 3.12
+slepc4py:
+  - 3.12
+pixman:
+  - 0.38
+poppler:
+  - 0.67.0
+proj:
+  - 6.3.1
+python:
+  - 3.6.* *_cpython
+  - 3.7.* *_cpython
+python_impl:
+  - cpython
+qt:
+  - 5.12
+readline:
+  - 8.0
+root_base:
+  - 6.20.0
+ruby:
+  - 2.5
+  - 2.6
+r_base:
+  - 3.5.1
+  - 3.6
+scotch:
+  - 6.0.8
+ptscotch:
+  - 6.0.8
+singular:
+  - 4.1.2
+snappy:
+  - 1
+sox:
+  - 14.4.2
+sqlite:
+  - 3
+suitesparse:
+  - 5.6
+tk:
+  - 8.6                # [not ppc64le]
+tiledb:
+  - 1.7.0
+vc:                    # [win]
+  - 14                 # [win]
+vlfeat:
+  - 0.9.20
+vtk:
+  - 8.2.0
+x264:
+  - 1!152.*
+xerces_c:
+  - 3.2.2
+xrootd:
+  - 4.11.0
+xz:
+  - 5.2
+zeromq:
+  - 4.3.2
+zlib:
+  - 1.2
+zstd:
+  - 1.4.4

--- a/tests/test_yaml/krb.yaml
+++ b/tests/test_yaml/krb.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+krb5:
+- 1.17.1
+migrator_ts: 1584168396.450607

--- a/tests/test_yaml/krb_out.yaml
+++ b/tests/test_yaml/krb_out.yaml
@@ -1,0 +1,609 @@
+# This differs from target_platform in that it determines what subdir the compiler
+#    will target, not what subdir the compiler package will be itself.
+#    For example, we need a win-64 vs2008_win-32 package, so that we compile win-32
+#    code on win-64 miniconda.
+cross_compiler_target_platform:  # [win]
+  - win-64                     # [win]
+c_compiler:
+  - gcc                        # [linux]
+  - clang                      # [osx]
+  - vs2015                     # [win]
+c_compiler_version:            # [unix]
+  - 9                          # [osx]
+  - 7                          # [linux64 or aarch64]
+  - 8                          # [ppc64le or armv7l]
+cxx_compiler:
+  - gxx                        # [linux]
+  - clangxx                    # [osx]
+  - vs2015                     # [win]
+cxx_compiler_version:          # [unix]
+  - 9                          # [osx]
+  - 7                          # [linux64 or aarch64]
+  - 8                          # [ppc64le or armv7l]
+fortran_compiler:              # [unix or win64]
+  - gfortran                   # [(linux64 or osx)]
+  - gfortran                   # [aarch64 or ppc64le or armv7l]
+  - flang                      # [win64]
+fortran_compiler_version:      # [unix or win64]
+  - 7                          # [linux64 or osx or aarch64]
+  - 8                          # [ppc64le or armv7l]
+  - 5                          # [win64]
+m2w64_c_compiler:              # [win]
+  - m2w64-toolchain            # [win]
+m2w64_cxx_compiler:            # [win]
+  - m2w64-toolchain            # [win]
+m2w64_fortran_compiler:        # [win]
+  - m2w64-toolchain            # [win]
+CMAKE_GENERATOR:               # [win]
+  - NMake Makefiles            # [win]
+
+cuda_compiler:                 # [linux64]
+  - nvcc                       # [linux64]
+cuda_compiler_version:         # [linux64]
+  - None                       # [linux64]
+  - 9.2                        # [linux64]
+  - 10.0                       # [linux64]
+  - 10.1                       # [linux64]
+  - 10.2                       # [linux64]
+
+_libgcc_mutex:
+  - 0.1 conda_forge
+#
+# Go Compiler Options
+#
+
+# The basic go-compiler with CGO disabled,
+# It generates fat binaries without libc dependencies
+# The activation scripts will set your CC,CXX and related flags
+# to invalid values.
+go_compiler:
+  - go-nocgo
+# The go compiler build with CGO enabled.
+# It can generate fat binaries that depend on conda's libc.
+# You should use this compiler if the underlying
+# program needs to link against other C libraries, in which
+# case make sure to add  'c,cpp,fortran_compiler' for unix
+# and the m2w64 equivalent for windows.
+cgo_compiler:
+  - go-cgo
+# The following are helpful variables to simplify go meta.yaml files.
+target_goos:
+  - linux                      # [linux]
+  - darwin                     # [osx]
+  - windows                    # [win]
+target_goarch:
+  - amd64                      # [x86_64]
+target_goexe:
+  -                            # [unix]
+  - .exe                       # [win]
+target_gobin:
+  - '${PREFIX}/bin/'           # [unix]
+  - '%PREFIX%\bin\'            # [win]
+
+# Rust Compiler Options
+rust_compiler:
+  - rust
+  - rust-gnu                   # [win]
+rust_compiler_version:
+  - 1.40.0
+
+
+macos_min_version:             # [osx]
+  - 10.9                       # [osx]
+macos_machine:                 # [osx]
+  - x86_64-apple-darwin13.4.0  # [osx]
+MACOSX_DEPLOYMENT_TARGET:      # [osx]
+  - 10.9                       # [osx]
+target_platform:               # [win]
+  - win-64                     # [win]
+VERBOSE_AT:
+  - V=1
+VERBOSE_CM:
+  - VERBOSE=1
+
+# dual build configuration
+channel_sources:
+  - conda-forge,defaults                        # [not (aarch64 or armv7l)]
+  - conda-forge                                 # [aarch64]
+  - conda-forge,c4armv7l,defaults               # [armv7l]
+
+channel_targets:
+  - conda-forge main
+
+docker_image:                                   # [linux]
+  - condaforge/linux-anvil-comp7                # [linux64]
+  - condaforge/linux-anvil-cuda:9.2             # [linux64]
+  - condaforge/linux-anvil-cuda:10.0            # [linux64]
+  - condaforge/linux-anvil-cuda:10.1            # [linux64]
+  - condaforge/linux-anvil-cuda:10.2            # [linux64]
+
+  - condaforge/linux-anvil-aarch64              # [aarch64]
+  - condaforge/linux-anvil-ppc64le              # [ppc64le]
+  - condaforge/linux-anvil-armv7l               # [armv7l]
+
+zip_keys:
+  -
+    - python
+  -                             # [linux64]
+    - cuda_compiler_version     # [linux64]
+    - docker_image              # [linux64]
+
+# aarch64 specifics because conda-build sets many things to centos 6
+# this can probably be removed when conda-build gets updated defaults
+# for aarch64
+cdt_arch: aarch64                       # [aarch64]
+cdt_name: cos7                          # [aarch64]
+BUILD: aarch64-conda_cos7-linux-gnu     # [aarch64]
+
+# armv7l specifics because conda-build sets many things to centos 6
+# this can probably be removed when conda-build gets updated defaults
+# for aarch64
+cdt_arch: armv7l                          # [armv7l]
+cdt_name: cos7                            # [armv7l]
+BUILD: armv7-conda_cos7-linux-gnueabihf   # [armv7l]
+
+# TODO: remove these when run_exports are added to the packages.
+pin_run_as_build:
+  arpack:
+    max_pin: x.x.x
+  boost:
+    max_pin: x.x.x
+  boost-cpp:
+    max_pin: x.x.x
+  bzip2:
+    max_pin: x
+  cairo:
+    max_pin: x.x
+  cudnn:
+    max_pin: x
+    min_pin: x.x
+  curl:
+    max_pin: x
+  dbus:
+    max_pin: x
+  expat:
+    max_pin: x.x
+  ffmpeg:
+    max_pin: x.x
+  fftw:
+    max_pin: x
+  flann:
+    max_pin: x.x.x
+  fontconfig:
+    max_pin: x
+  freetype:
+    max_pin: x
+  gdal:
+    max_pin: x.x
+  gdk_pixbuf:
+    max_pin: x.x.x
+  geotiff:
+    max_pin: x.x.x
+  glew:
+    max_pin: x.x
+  glpk:
+    max_pin: x.x
+  gmp:
+    max_pin: x
+  graphviz:
+    max_pin: x
+  grpc-cpp:
+    max_pin: x.x
+  harfbuzz:
+    max_pin: x
+  hdf4:
+    max_pin: x.x
+  icu:
+    max_pin: x
+  isl:
+    max_pin: x.x
+  jasper:
+    max_pin: x
+  jpeg:
+    max_pin: x
+  libjpeg_turbo:
+    max_pin: x
+  json-c:
+    max_pin: x.x
+  jsoncpp:
+    max_pin: x.x.x
+  kealib:
+    max_pin: x.x
+  krb5:
+    max_pin: x.x
+  libblitz:
+    max_pin: x.x
+  libcurl:
+    max_pin: x
+  libevent:
+    max_pin: x.x.x
+  libffi:
+    max_pin: x.x
+  libgdal:
+    max_pin: x.x
+  libiconv:
+    max_pin: x.x
+  libkml:
+    max_pin: x.x
+  libmatio:
+    max_pin: x.x
+  libpcap:
+    max_pin: x.x
+  libpng:
+    max_pin: x.x
+  librdkafka:
+    max_pin: x.x.x
+  librsvg:
+    max_pin: x
+  libssh2:
+    max_pin: x.x
+  libsvm:
+    max_pin: x.x
+  libunwind:
+    max_pin: x.x
+  libtiff:
+    max_pin: x
+  libwebp:
+    max_pin: x.x
+  libxml2:
+    max_pin: x.x
+  libuuid:
+    max_pin: x
+  lz4-c:
+    max_pin: x.x.x
+  lzo:
+    max_pin: x
+  metis:
+    max_pin: x.x
+  mkl:
+    max_pin: x
+  mpfr:
+    max_pin: x
+  ncurses:
+    max_pin: x.x
+  netcdf-cxx4:
+    max_pin: x.x
+  netcdf-fortran:
+    max_pin: x.x
+  nettle:
+    max_pin: x.x
+  nlopt:
+    max_pin: x.x.x
+  nss:
+    max_pin: x
+  nspr:
+    max_pin: x
+  occt:
+    max_pin: x.x
+  openblas:
+    max_pin: x.x.x
+  openturns:
+    max_pin: x.x
+  openjpeg:
+    max_pin: x.x
+  openssl:
+    max_pin: x.x.x
+  pango:
+    max_pin: x.x
+  perl:
+    max_pin: x.x.x
+  pixman:
+    max_pin: x.x
+  poppler:
+    max_pin: x.x
+  qt:
+    max_pin: x.x
+  readline:
+    max_pin: x
+  r-base:
+    max_pin: x.x
+    min_pin: x.x
+  sox:
+    max_pin: x.x.x
+  sqlite:
+    max_pin: x
+  tk:
+    max_pin: x.x
+  tiledb:
+    max_pin: x.x.x
+  vc:
+    max_pin: x
+  vlfeat:
+    max_pin: x.x.x
+  vtk:
+    max_pin: x.x.x
+  xerces-c:
+    max_pin: x.x.x
+  xz:
+    max_pin: x.x
+  zeromq:
+    max_pin: x.x  # [not win]
+    max_pin: x.x.x  # [win]
+  zlib:
+    max_pin: x.x
+  zstd:
+    max_pin: x.x.x
+
+# Pinning packages
+
+# blas
+libblas:
+  - 3.8 *netlib
+libcblas:
+  - 3.8 *netlib
+liblapack:
+  - 3.8.0 *netlib
+liblapacke:
+  - 3.8.0 *netlib
+blas_impl:
+  - openblas
+  - mkl          # [x86 or x86_64]
+  - blis         # [x86 or x86_64]
+
+abseil_cpp:
+  - 20200225.1
+arb:
+  - 2.17
+arpack:
+  - 3.6.3
+arrow_cpp:
+  - 0.16.0
+boost:
+  - 1.70.0
+boost_cpp:
+  - 1.70.0
+bzip2:
+  - 1
+cairo:
+  - 1.16
+cfitsio:
+  - 3.470
+cudnn:
+  - 7.6.5
+curl:
+  - 7.64
+dbus:
+  - 1
+expat:
+  - 2.2
+ffmpeg:
+  - 4.1
+fftw:
+  - 3
+flann:
+  - 1.9.1
+fontconfig:
+  - 2.13
+freetype:
+  - 2.9.1
+gf2x:
+  - 1.2
+gdk_pixbuf:
+  - 2.36.12
+gsl:
+  - 2.6
+gstreamer:
+  - 1.14.4
+gst_plugins_base:
+  - 1.14.4
+gdal:
+  - 3.0
+geos:
+  - 3.8.1
+geotiff:
+  - 1.5.1
+giflib:
+  - 5.2
+glew:
+  - 2.0.0
+glib:
+  - 2.58
+glog:
+  - 0.4.0
+glpk:
+  - 4.65
+gmp:
+  - 6
+graphviz:
+  - 2.40
+grpc_cpp:
+  - 1.27
+harfbuzz:
+  - 2
+hdf4:
+  - 4.2
+hdf5:
+  - 1.10.5
+icu:
+  - 64.2
+isl:
+  - 0.19
+jasper:
+  - 1.900.1
+jpeg:
+  - 9
+libjpeg_turbo:
+  - 2
+json_c:
+  - 0.13
+jsoncpp:
+  - 1.8.4
+kealib:
+  - 1.4.10
+krb5:
+  - 1.17.1
+libarchive:
+  - 3.3
+libblitz:
+  - 0.10
+libcurl:
+  - 7.64
+libdap4:
+  - 3.20.2
+libevent:
+  - 2.1.10
+libffi:
+  - 3.2
+libgdal:
+  - 3.0
+libiconv:
+  - 1.15
+libkml:
+  - 1.3
+libmatio:
+  - 1.5
+libnetcdf:
+  - 4.7.3
+libpcap:
+  - 1.8
+libpng:
+  - 1.6
+libprotobuf:
+  - 3.11
+librdkafka:
+  - 0.11.5
+librsvg:
+  - 2
+libsecret:
+  - 0.18
+libspatialindex:
+  - 1.9.3
+libssh2:
+  - 1.8
+libsvm:
+  - 3.21
+libtiff:
+  - 4.1.0
+libunwind:
+  - 1.2
+libwebp:
+  - 1.0
+libxml2:
+  - 2.9
+libuuid:
+  - 2.32.1
+lz4_c:
+  - 1.8.3
+lzo:
+  - 2
+metis:
+  - 5.1
+mkl:
+  - 2019
+mpich:
+  - 3.3
+mpfr:
+  - 4
+mumps_mpi:
+  - 5.2
+mumps_seq:
+  - 5.2
+nccl:
+  - 2.4.6.1
+ncurses:
+  - 6.1
+netcdf_cxx4:
+  - 4.3
+netcdf_fortran:
+  - 4.5
+nettle:
+  - 3.4
+nss:
+  - 3.39
+nspr:
+  - 4.20
+nlopt:
+  - 2.6.*
+ntl:
+  - 11.3.2
+# we build for the oldest version possible of numpy for forward compatibility
+numpy:
+  - 1.14       # [not (aarch64 or ppc64le)]
+  - 1.16       # [aarch64 or ppc64le]
+occt:
+  - 7.4
+openblas:
+  - 0.3.6
+openjpeg:
+  - 2.3
+openmpi:
+  - 4.0
+openssl:
+  - 1.1.1
+openturns:
+  - 1.14*
+pango:
+  - 1.42
+pari:
+  - 2.11
+perl:
+  - 5.26.2
+petsc:
+  - 3.12
+petsc4py:
+  - 3.12
+slepc:
+  - 3.12
+slepc4py:
+  - 3.12
+pixman:
+  - 0.38
+poppler:
+  - 0.67.0
+proj:
+  - 6.3.1
+python:
+  - 3.6.* *_cpython
+  - 3.7.* *_cpython
+python_impl:
+  - cpython
+qt:
+  - 5.12
+readline:
+  - 8.0
+root_base:
+  - 6.20.0
+ruby:
+  - 2.5
+  - 2.6
+r_base:
+  - 3.5.1
+  - 3.6
+scotch:
+  - 6.0.8
+ptscotch:
+  - 6.0.8
+singular:
+  - 4.1.2
+snappy:
+  - 1
+sox:
+  - 14.4.2
+sqlite:
+  - 3
+suitesparse:
+  - 5.6
+tk:
+  - 8.6                # [not ppc64le]
+tiledb:
+  - 1.7.0
+vc:                    # [win]
+  - 14                 # [win]
+vlfeat:
+  - 0.9.20
+vtk:
+  - 8.2.0
+x264:
+  - 1!152.*
+xerces_c:
+  - 3.2.2
+xrootd:
+  - 4.11.0
+xz:
+  - 5.2
+zeromq:
+  - 4.3.2
+zlib:
+  - 1.2
+zstd:
+  - 1.4.4

--- a/tests/test_yaml/pypy.yaml
+++ b/tests/test_yaml/pypy.yaml
@@ -1,0 +1,44 @@
+migrator_ts: 1580746218   # The timestamp of when the migration was made
+__migrator:
+  kind:
+    version
+  exclude:
+    - c_compiler
+    - vc
+    - cxx_compiler
+    - cuda_compiler_version
+    - docker_image
+  migration_number:  # Only use this if the bot messes up, putting this in will cause a complete rerun of the migration
+    1
+  bump_number: 1   # Hashes changed for cpython, so it's better to bump build numbers.
+
+python:
+  - 3.6.* *_cpython
+  - 3.7.* *_cpython
+  - 3.8.* *_cpython
+  - 3.6.* *_73_pypy   # [not win64]
+
+numpy:
+  - 1.14       # [not (aarch64 or ppc64le)]
+  - 1.14       # [not (aarch64 or ppc64le)]
+  - 1.14       # [not (aarch64 or ppc64le)]
+  - 1.16       # [aarch64 or ppc64le]
+  - 1.16       # [aarch64 or ppc64le]
+  - 1.16       # [aarch64 or ppc64le]
+  - 1.18       # [not win64]
+
+python_impl:
+  - cpython
+  - cpython
+  - cpython
+  - pypy       # [not win64]
+
+
+zip_keys:
+  -
+    - python
+    - numpy
+    - python_impl
+  -                             # [linux64]
+    - cuda_compiler_version     # [linux64]
+    - docker_image              # [linux64]

--- a/tests/test_yaml/pypy_out.yaml
+++ b/tests/test_yaml/pypy_out.yaml
@@ -1,0 +1,621 @@
+# This differs from target_platform in that it determines what subdir the compiler
+#    will target, not what subdir the compiler package will be itself.
+#    For example, we need a win-64 vs2008_win-32 package, so that we compile win-32
+#    code on win-64 miniconda.
+cross_compiler_target_platform:  # [win]
+  - win-64                     # [win]
+c_compiler:
+  - gcc                        # [linux]
+  - clang                      # [osx]
+  - vs2015                     # [win]
+c_compiler_version:            # [unix]
+  - 9                          # [osx]
+  - 7                          # [linux64 or aarch64]
+  - 8                          # [ppc64le or armv7l]
+cxx_compiler:
+  - gxx                        # [linux]
+  - clangxx                    # [osx]
+  - vs2015                     # [win]
+cxx_compiler_version:          # [unix]
+  - 9                          # [osx]
+  - 7                          # [linux64 or aarch64]
+  - 8                          # [ppc64le or armv7l]
+fortran_compiler:              # [unix or win64]
+  - gfortran                   # [(linux64 or osx)]
+  - gfortran                   # [aarch64 or ppc64le or armv7l]
+  - flang                      # [win64]
+fortran_compiler_version:      # [unix or win64]
+  - 7                          # [linux64 or osx or aarch64]
+  - 8                          # [ppc64le or armv7l]
+  - 5                          # [win64]
+m2w64_c_compiler:              # [win]
+  - m2w64-toolchain            # [win]
+m2w64_cxx_compiler:            # [win]
+  - m2w64-toolchain            # [win]
+m2w64_fortran_compiler:        # [win]
+  - m2w64-toolchain            # [win]
+CMAKE_GENERATOR:               # [win]
+  - NMake Makefiles            # [win]
+
+cuda_compiler:                 # [linux64]
+  - nvcc                       # [linux64]
+cuda_compiler_version:         # [linux64]
+  - None                       # [linux64]
+  - 9.2                        # [linux64]
+  - 10.0                       # [linux64]
+  - 10.1                       # [linux64]
+  - 10.2                       # [linux64]
+
+_libgcc_mutex:
+  - 0.1 conda_forge
+#
+# Go Compiler Options
+#
+
+# The basic go-compiler with CGO disabled,
+# It generates fat binaries without libc dependencies
+# The activation scripts will set your CC,CXX and related flags
+# to invalid values.
+go_compiler:
+  - go-nocgo
+# The go compiler build with CGO enabled.
+# It can generate fat binaries that depend on conda's libc.
+# You should use this compiler if the underlying
+# program needs to link against other C libraries, in which
+# case make sure to add  'c,cpp,fortran_compiler' for unix
+# and the m2w64 equivalent for windows.
+cgo_compiler:
+  - go-cgo
+# The following are helpful variables to simplify go meta.yaml files.
+target_goos:
+  - linux                      # [linux]
+  - darwin                     # [osx]
+  - windows                    # [win]
+target_goarch:
+  - amd64                      # [x86_64]
+target_goexe:
+  -                            # [unix]
+  - .exe                       # [win]
+target_gobin:
+  - '${PREFIX}/bin/'           # [unix]
+  - '%PREFIX%\bin\'            # [win]
+
+# Rust Compiler Options
+rust_compiler:
+  - rust
+  - rust-gnu                   # [win]
+rust_compiler_version:
+  - 1.40.0
+
+
+macos_min_version:             # [osx]
+  - 10.9                       # [osx]
+macos_machine:                 # [osx]
+  - x86_64-apple-darwin13.4.0  # [osx]
+MACOSX_DEPLOYMENT_TARGET:      # [osx]
+  - 10.9                       # [osx]
+target_platform:               # [win]
+  - win-64                     # [win]
+VERBOSE_AT:
+  - V=1
+VERBOSE_CM:
+  - VERBOSE=1
+
+# dual build configuration
+channel_sources:
+  - conda-forge,defaults                        # [not (aarch64 or armv7l)]
+  - conda-forge                                 # [aarch64]
+  - conda-forge,c4armv7l,defaults               # [armv7l]
+
+channel_targets:
+  - conda-forge main
+
+docker_image:                                   # [linux]
+  - condaforge/linux-anvil-comp7                # [linux64]
+  - condaforge/linux-anvil-cuda:9.2             # [linux64]
+  - condaforge/linux-anvil-cuda:10.0            # [linux64]
+  - condaforge/linux-anvil-cuda:10.1            # [linux64]
+  - condaforge/linux-anvil-cuda:10.2            # [linux64]
+
+  - condaforge/linux-anvil-aarch64              # [aarch64]
+  - condaforge/linux-anvil-ppc64le              # [ppc64le]
+  - condaforge/linux-anvil-armv7l               # [armv7l]
+
+zip_keys:
+  -
+    - python
+    - numpy
+    - python_impl
+  -                             # [linux64]
+    - cuda_compiler_version     # [linux64]
+    - docker_image              # [linux64]
+
+# aarch64 specifics because conda-build sets many things to centos 6
+# this can probably be removed when conda-build gets updated defaults
+# for aarch64
+cdt_arch: aarch64                       # [aarch64]
+cdt_name: cos7                          # [aarch64]
+BUILD: aarch64-conda_cos7-linux-gnu     # [aarch64]
+
+# armv7l specifics because conda-build sets many things to centos 6
+# this can probably be removed when conda-build gets updated defaults
+# for aarch64
+cdt_arch: armv7l                          # [armv7l]
+cdt_name: cos7                            # [armv7l]
+BUILD: armv7-conda_cos7-linux-gnueabihf   # [armv7l]
+
+# TODO: remove these when run_exports are added to the packages.
+pin_run_as_build:
+  arpack:
+    max_pin: x.x.x
+  boost:
+    max_pin: x.x.x
+  boost-cpp:
+    max_pin: x.x.x
+  bzip2:
+    max_pin: x
+  cairo:
+    max_pin: x.x
+  cudnn:
+    max_pin: x
+    min_pin: x.x
+  curl:
+    max_pin: x
+  dbus:
+    max_pin: x
+  expat:
+    max_pin: x.x
+  ffmpeg:
+    max_pin: x.x
+  fftw:
+    max_pin: x
+  flann:
+    max_pin: x.x.x
+  fontconfig:
+    max_pin: x
+  freetype:
+    max_pin: x
+  gdal:
+    max_pin: x.x
+  gdk_pixbuf:
+    max_pin: x.x.x
+  geotiff:
+    max_pin: x.x.x
+  glew:
+    max_pin: x.x
+  glpk:
+    max_pin: x.x
+  gmp:
+    max_pin: x
+  graphviz:
+    max_pin: x
+  grpc-cpp:
+    max_pin: x.x
+  harfbuzz:
+    max_pin: x
+  hdf4:
+    max_pin: x.x
+  icu:
+    max_pin: x
+  isl:
+    max_pin: x.x
+  jasper:
+    max_pin: x
+  jpeg:
+    max_pin: x
+  libjpeg_turbo:
+    max_pin: x
+  json-c:
+    max_pin: x.x
+  jsoncpp:
+    max_pin: x.x.x
+  kealib:
+    max_pin: x.x
+  krb5:
+    max_pin: x.x
+  libblitz:
+    max_pin: x.x
+  libcurl:
+    max_pin: x
+  libevent:
+    max_pin: x.x.x
+  libffi:
+    max_pin: x.x
+  libgdal:
+    max_pin: x.x
+  libiconv:
+    max_pin: x.x
+  libkml:
+    max_pin: x.x
+  libmatio:
+    max_pin: x.x
+  libpcap:
+    max_pin: x.x
+  libpng:
+    max_pin: x.x
+  librdkafka:
+    max_pin: x.x.x
+  librsvg:
+    max_pin: x
+  libssh2:
+    max_pin: x.x
+  libsvm:
+    max_pin: x.x
+  libunwind:
+    max_pin: x.x
+  libtiff:
+    max_pin: x
+  libwebp:
+    max_pin: x.x
+  libxml2:
+    max_pin: x.x
+  libuuid:
+    max_pin: x
+  lz4-c:
+    max_pin: x.x.x
+  lzo:
+    max_pin: x
+  metis:
+    max_pin: x.x
+  mkl:
+    max_pin: x
+  mpfr:
+    max_pin: x
+  ncurses:
+    max_pin: x.x
+  netcdf-cxx4:
+    max_pin: x.x
+  netcdf-fortran:
+    max_pin: x.x
+  nettle:
+    max_pin: x.x
+  nlopt:
+    max_pin: x.x.x
+  nss:
+    max_pin: x
+  nspr:
+    max_pin: x
+  occt:
+    max_pin: x.x
+  openblas:
+    max_pin: x.x.x
+  openturns:
+    max_pin: x.x
+  openjpeg:
+    max_pin: x.x
+  openssl:
+    max_pin: x.x.x
+  pango:
+    max_pin: x.x
+  perl:
+    max_pin: x.x.x
+  pixman:
+    max_pin: x.x
+  poppler:
+    max_pin: x.x
+  qt:
+    max_pin: x.x
+  readline:
+    max_pin: x
+  r-base:
+    max_pin: x.x
+    min_pin: x.x
+  sox:
+    max_pin: x.x.x
+  sqlite:
+    max_pin: x
+  tk:
+    max_pin: x.x
+  tiledb:
+    max_pin: x.x.x
+  vc:
+    max_pin: x
+  vlfeat:
+    max_pin: x.x.x
+  vtk:
+    max_pin: x.x.x
+  xerces-c:
+    max_pin: x.x.x
+  xz:
+    max_pin: x.x
+  zeromq:
+    max_pin: x.x  # [not win]
+    max_pin: x.x.x  # [win]
+  zlib:
+    max_pin: x.x
+  zstd:
+    max_pin: x.x.x
+
+# Pinning packages
+
+# blas
+libblas:
+  - 3.8 *netlib
+libcblas:
+  - 3.8 *netlib
+liblapack:
+  - 3.8.0 *netlib
+liblapacke:
+  - 3.8.0 *netlib
+blas_impl:
+  - openblas
+  - mkl          # [x86 or x86_64]
+  - blis         # [x86 or x86_64]
+
+abseil_cpp:
+  - 20200225.1
+arb:
+  - 2.17
+arpack:
+  - 3.6.3
+arrow_cpp:
+  - 0.16.0
+boost:
+  - 1.70.0
+boost_cpp:
+  - 1.70.0
+bzip2:
+  - 1
+cairo:
+  - 1.16
+cfitsio:
+  - 3.470
+cudnn:
+  - 7.6.5
+curl:
+  - 7.64
+dbus:
+  - 1
+expat:
+  - 2.2
+ffmpeg:
+  - 4.1
+fftw:
+  - 3
+flann:
+  - 1.9.1
+fontconfig:
+  - 2.13
+freetype:
+  - 2.9.1
+gf2x:
+  - 1.2
+gdk_pixbuf:
+  - 2.36.12
+gsl:
+  - 2.6
+gstreamer:
+  - 1.14.4
+gst_plugins_base:
+  - 1.14.4
+gdal:
+  - 3.0
+geos:
+  - 3.8.1
+geotiff:
+  - 1.5.1
+giflib:
+  - 5.2
+glew:
+  - 2.0.0
+glib:
+  - 2.58
+glog:
+  - 0.4.0
+glpk:
+  - 4.65
+gmp:
+  - 6
+graphviz:
+  - 2.40
+grpc_cpp:
+  - 1.27
+harfbuzz:
+  - 2
+hdf4:
+  - 4.2
+hdf5:
+  - 1.10.5
+icu:
+  - 64.2
+isl:
+  - 0.19
+jasper:
+  - 1.900.1
+jpeg:
+  - 9
+libjpeg_turbo:
+  - 2
+json_c:
+  - 0.13
+jsoncpp:
+  - 1.8.4
+kealib:
+  - 1.4.10
+krb5:
+  - 1.16
+libarchive:
+  - 3.3
+libblitz:
+  - 0.10
+libcurl:
+  - 7.64
+libdap4:
+  - 3.20.2
+libevent:
+  - 2.1.10
+libffi:
+  - 3.2
+libgdal:
+  - 3.0
+libiconv:
+  - 1.15
+libkml:
+  - 1.3
+libmatio:
+  - 1.5
+libnetcdf:
+  - 4.7.3
+libpcap:
+  - 1.8
+libpng:
+  - 1.6
+libprotobuf:
+  - 3.11
+librdkafka:
+  - 0.11.5
+librsvg:
+  - 2
+libsecret:
+  - 0.18
+libspatialindex:
+  - 1.9.3
+libssh2:
+  - 1.8
+libsvm:
+  - 3.21
+libtiff:
+  - 4.1.0
+libunwind:
+  - 1.2
+libwebp:
+  - 1.0
+libxml2:
+  - 2.9
+libuuid:
+  - 2.32.1
+lz4_c:
+  - 1.8.3
+lzo:
+  - 2
+metis:
+  - 5.1
+mkl:
+  - 2019
+mpich:
+  - 3.3
+mpfr:
+  - 4
+mumps_mpi:
+  - 5.2
+mumps_seq:
+  - 5.2
+nccl:
+  - 2.4.6.1
+ncurses:
+  - 6.1
+netcdf_cxx4:
+  - 4.3
+netcdf_fortran:
+  - 4.5
+nettle:
+  - 3.4
+nss:
+  - 3.39
+nspr:
+  - 4.20
+nlopt:
+  - 2.6.*
+ntl:
+  - 11.3.2
+# we build for the oldest version possible of numpy for forward compatibility
+numpy:
+  - 1.14       # [not (aarch64 or ppc64le)]
+  - 1.14       # [not (aarch64 or ppc64le)]
+  - 1.14       # [not (aarch64 or ppc64le)]
+  - 1.16       # [aarch64 or ppc64le]
+  - 1.16       # [aarch64 or ppc64le]
+  - 1.16       # [aarch64 or ppc64le]
+  - 1.18       # [not win64]
+occt:
+  - 7.4
+openblas:
+  - 0.3.6
+openjpeg:
+  - 2.3
+openmpi:
+  - 4.0
+openssl:
+  - 1.1.1
+openturns:
+  - 1.14*
+pango:
+  - 1.42
+pari:
+  - 2.11
+perl:
+  - 5.26.2
+petsc:
+  - 3.12
+petsc4py:
+  - 3.12
+slepc:
+  - 3.12
+slepc4py:
+  - 3.12
+pixman:
+  - 0.38
+poppler:
+  - 0.67.0
+proj:
+  - 6.3.1
+python:
+  - 3.6.* *_cpython
+  - 3.7.* *_cpython
+  - 3.8.* *_cpython
+  - 3.6.* *_73_pypy   # [not win64]
+python_impl:
+  - cpython
+  - cpython
+  - cpython
+  - pypy       # [not win64]
+qt:
+  - 5.12
+readline:
+  - 8.0
+root_base:
+  - 6.20.0
+ruby:
+  - 2.5
+  - 2.6
+r_base:
+  - 3.5.1
+  - 3.6
+scotch:
+  - 6.0.8
+ptscotch:
+  - 6.0.8
+singular:
+  - 4.1.2
+snappy:
+  - 1
+sox:
+  - 14.4.2
+sqlite:
+  - 3
+suitesparse:
+  - 5.6
+tk:
+  - 8.6                # [not ppc64le]
+tiledb:
+  - 1.7.0
+vc:                    # [win]
+  - 14                 # [win]
+vlfeat:
+  - 0.9.20
+vtk:
+  - 8.2.0
+x264:
+  - 1!152.*
+xerces_c:
+  - 3.2.2
+xrootd:
+  - 4.11.0
+xz:
+  - 5.2
+zeromq:
+  - 4.3.2
+zlib:
+  - 1.2
+zstd:
+  - 1.4.4


### PR DESCRIPTION
Closes #912

CC: @mariusvniekerk @beckermr

This introduces a function for merging the conda build config and a migration.
The function preserves selectors by not loading the yamls for either.
This causes the function to only implement a subset of the variant algebra.
However, this should cover most use cases that we currently have, including
the case where `zip_keys` is used and is completely represented in the migraiton.
The API is designed to be flexable so that future implementations can cover more
of the variant algebra.

Overall this makes the migration UX better as it requires fewer human made PRs, with a resonable expection that the bot issued PRs will be correct.
To the best of my knowledge this doesn't disrupt any of our existing UX.