### PR TITLE
ENH add in `.*` for mamba solvability test

### DIFF
--- a/conda_forge_tick/mamba_solver.py
+++ b/conda_forge_tick/mamba_solver.py
@@ -28,9 +28,9 @@ from mamba import mamba_api as api
 logger = logging.getLogger("conda_forge_tick.mamba_solver")
 
 
-# these characters are in requirements that do not need to be munged from
+# these characters are start requirements that do not need to be munged from
 # 1.1 to 1.1.*
-REQ_LOG = ["!", "=", ">", "<", "~", "*"]
+REQ_START = ["!=", "==", ">", "<", ">=", "<="]
 
 
 def _munge_req_star(req):
@@ -54,12 +54,16 @@ def _munge_req_star(req):
             psplit = p.split("|")
             nps = len(psplit)
             for ip, pp in enumerate(psplit):
+                # clear white space
+                pp = pp.strip()
 
                 # finally add the star if we need it
-                if any(_r in REQ_LOG for _r in pp):
+                if any(pp.startswith(__v) for __v in REQ_START) or "*" in pp:
                     reqs.append(pp)
                 else:
-                    reqs.append(pp + ".*")
+                    if pp.startswith("="):
+                        pp = pp[1:]
+                    reqs.append(pp + "*")
 
                 # add | back on the way out
                 if ip != nps-1:

--- a/tests/test_mamba_solvable.py
+++ b/tests/test_mamba_solvable.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from conda_forge_tick.mamba_solver import is_recipe_solvable, _munge_req_star
+from conda_forge_tick.mamba_solver import is_recipe_solvable, _norm_spec
 
 
 FEEDSTOCK_DIR = os.path.join(os.path.dirname(__file__), 'test_feedstock')
@@ -110,17 +110,15 @@ extra:
 
 
 @pytest.mark.parametrize("inreq,outreq", [
-    ("blah  #", "blah  #"),
-    ("blah 1.1.*  #", "blah 1.1*  #"),
-    ("blah * *_osx  #", "blah * *_osx  #"),
-    ("blah 1.2 *_osx #", "blah 1.2* *_osx  #"),
-    ("blah 1.1", "blah 1.1*"),
-    ("blah =1.1", "blah 1.1*"),
+    ("blah 1.1*", "blah 1.1.*"),
     ("blah * *_osx", "blah * *_osx"),
-    ("blah 1.2 *_osx", "blah 1.2* *_osx"),
+    ("blah 1.1", "blah 1.1.*"),
+    ("blah =1.1", "blah 1.1.*"),
+    ("blah * *_osx", "blah * *_osx"),
+    ("blah 1.2 *_osx", "blah 1.2.* *_osx"),
     ("blah >=1.1", "blah >=1.1"),
-    ("blah >=1.1|5|>=5,<10|19.0", "blah >=1.1|5*|>=5,<10|19.0*"),
-    ("blah >=1.1|5| >=5 , <10 |19.0", "blah >=1.1|5*|>=5,<10|19.0*"),
+    ("blah >=1.1|5|>=5,<10|19.0", "blah >=1.1|5.*|>=5,<10|19.0.*"),
+    ("blah >=1.1|5| >=5 , <10 |19.0", "blah >=1.1|5.*|>=5,<10|19.0.*"),
 ])
-def test_munge_req_star(inreq, outreq):
-    assert _munge_req_star(inreq) == outreq
+def test_norm_spec(inreq, outreq):
+    assert _norm_spec(inreq) == outreq

--- a/tests/test_mamba_solvable.py
+++ b/tests/test_mamba_solvable.py
@@ -1,6 +1,8 @@
 import os
 
-from conda_forge_tick.mamba_solver import is_recipe_solvable
+import pytest
+
+from conda_forge_tick.mamba_solver import is_recipe_solvable, _munge_req_star
 
 
 FEEDSTOCK_DIR = os.path.join(os.path.dirname(__file__), 'test_feedstock')
@@ -105,3 +107,18 @@ extra:
             os.remove(recipe_file)
         except Exception:
             pass
+
+
+@pytest.mark.parametrize("inreq,outreq", [
+    ("blah  #", "blah  #"),
+    ("blah 1.1.*  #", "blah 1.1.*  #"),
+    ("blah * *_osx  #", "blah * *_osx  #"),
+    ("blah 1.2 *_osx #", "blah 1.2.* *_osx  #"),
+    ("blah 1.1", "blah 1.1.*"),
+    ("blah * *_osx", "blah * *_osx"),
+    ("blah 1.2 *_osx", "blah 1.2.* *_osx"),
+    ("blah >=1.1", "blah >=1.1"),
+    ("blah >=1.1|5|>=5,<10|19.0", "blah >=1.1|5.*|>=5,<10|19.0.*"),
+])
+def test_munge_req_star(inreq, outreq):
+    assert _munge_req_star(inreq) == outreq

--- a/tests/test_mamba_solvable.py
+++ b/tests/test_mamba_solvable.py
@@ -111,14 +111,16 @@ extra:
 
 @pytest.mark.parametrize("inreq,outreq", [
     ("blah  #", "blah  #"),
-    ("blah 1.1.*  #", "blah 1.1.*  #"),
+    ("blah 1.1.*  #", "blah 1.1*  #"),
     ("blah * *_osx  #", "blah * *_osx  #"),
-    ("blah 1.2 *_osx #", "blah 1.2.* *_osx  #"),
-    ("blah 1.1", "blah 1.1.*"),
+    ("blah 1.2 *_osx #", "blah 1.2* *_osx  #"),
+    ("blah 1.1", "blah 1.1*"),
+    ("blah =1.1", "blah 1.1*"),
     ("blah * *_osx", "blah * *_osx"),
-    ("blah 1.2 *_osx", "blah 1.2.* *_osx"),
+    ("blah 1.2 *_osx", "blah 1.2* *_osx"),
     ("blah >=1.1", "blah >=1.1"),
-    ("blah >=1.1|5|>=5,<10|19.0", "blah >=1.1|5.*|>=5,<10|19.0.*"),
+    ("blah >=1.1|5|>=5,<10|19.0", "blah >=1.1|5*|>=5,<10|19.0*"),
+    ("blah >=1.1|5| >=5 , <10 |19.0", "blah >=1.1|5*|>=5,<10|19.0*"),
 ])
 def test_munge_req_star(inreq, outreq):
     assert _munge_req_star(inreq) == outreq


### PR DESCRIPTION
This PR adds in a `.*` for pins in the requirement strings before feeding them to mamba.

cc @CJ-Wright @wolfv 

closes #987 