### PR TITLE
ENH more fixes for R

### DIFF
--- a/conda_forge_tick/cli.xsh
+++ b/conda_forge_tick/cli.xsh
@@ -4,6 +4,8 @@ import os
 
 from doctr.travis import run_command_hiding_token as doctr_run
 
+from .utils import load_graoh
+
 from .all_feedstocks import main as main_all_feedstocks
 from .make_graph import main as main_make_graph
 from .update_upstream_versions import main as main_update_upstream_versions
@@ -28,9 +30,15 @@ def deploy(args):
         except Exception as e:
             print(e)
 
+    try:
+        load_graoh()
+        graph_ok = True
+    except Exception:
+        graph_ok = False
+
     status = 1
     num_try = 0
-    while status != 0 and num_try < 10:
+    while status != 0 and num_try < 10 and graph_ok:
         try:
             @(['git', 'pull', '-s', 'recursive', '-X', 'theirs'])
         except Exception:
@@ -45,8 +53,8 @@ def deploy(args):
 
         num_try += 1
 
-    if status != 0:
-        _branch = "failed-circle-push-%s" % os.environ["CIRCLE_BUILD_NUM"]
+    if status != 0 or not graph_ok:
+        _branch = "failed-circle-run-%s" % os.environ["CIRCLE_BUILD_NUM"]
         @(["git", "checkout", "-b", _branch])
         @(["git", "commit", "--allow-empty", "-am", '"help me @regro/auto-tick!"'])
 

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -69,7 +69,7 @@ def _patch_dict(cfg, patches):
                 break
         # if it all worked, then pth is length zero and the last_key is in
         # the dict, so replace
-        if len(pth) == 0 and last_key in cfg_ref:
+        if len(pth) == 0:
             cfg_ref[last_key] = v
         else:
             logger.warning("conda-forge.yml patch %s: %s did not work!", k, v)

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -6,6 +6,7 @@ from typing import Optional, Set, Sequence, Any, MutableSet
 import time
 import re
 from collections import defaultdict
+import logging
 
 import networkx as nx
 import ruamel.yaml as yaml
@@ -20,6 +21,27 @@ if typing.TYPE_CHECKING:
         MigrationUidTypedDict,
         AttrsTypedDict,
     )
+
+logger = logging.getLogger("conda_forge_tick.migrators.migration_yaml")
+
+
+def _patch_dict(cfg, patches):
+    for k, v in patches.items():
+        cfg_ref = cfg
+        parts = k.split(".")
+        pth = parts[:-1][::-1]
+        last_key = parts[-1]
+        while len(pth) > 0:
+            _k = pth.pop()
+            if _k in cfg_ref:
+                cfg_ref = cfg_ref[_k]
+            else:
+                break
+        if len(pth) == 0:
+            if last_key in cfg_ref:
+                cfg_ref[last_key] = v
+        else:
+            logger.warning("conda-forge.yml patch %s: %s did not work!", k, v)
 
 
 def merge_migrator_cbc(migrator_yaml: str, conda_build_config_yaml: str):
@@ -75,6 +97,7 @@ class MigrationYaml(GraphMigrator):
         piggy_back_migrations: Optional[Sequence[MiniMigrator]] = None,
         automerge: bool = False,
         check_solvable=True,
+        conda_forge_yml_patches=None,
         **kwargs: Any,
     ):
         super().__init__(
@@ -90,6 +113,7 @@ class MigrationYaml(GraphMigrator):
         self.top_level = top_level or set()
         self.cycles = set(chain.from_iterable(cycles or []))
         self.automerge = automerge
+        self.conda_forge_yml_patches = conda_forge_yml_patches
 
         # auto set the pr_limit for initial things
         number_pred = len(
@@ -134,8 +158,19 @@ class MigrationYaml(GraphMigrator):
                     with open(f"{self.name}.yaml", "w") as f:
                         f.write(self.yaml_contents)
                     eval_xonsh("git add .")
+
+            if self.conda_forge_yml_patches is not None:
+                with indir(os.path.join(recipe_dir, "..")):
+                    with open("conda-forge.yml", "r") as fp:
+                        cfg = yaml.safe_load(fp.read())
+                    _patch_dict(cfg, self.conda_forge_yml_patches)
+                    with open("conda-forge.yml", "w") as fp:
+                        yaml.dump(cfg, fp, default_flow_style=False, indent=2)
+                    eval_xonsh("git add conda-forge.yml")
+
             with indir(recipe_dir):
                 self.set_build_number("meta.yaml")
+
             return super().migrate(recipe_dir, attrs)
 
     def pr_body(self, feedstock_ctx: "FeedstockContext") -> str:

--- a/tests/test_patch_dict.py
+++ b/tests/test_patch_dict.py
@@ -13,10 +13,9 @@ def test_patch_dict():
         {"a.c.d": 15, "e.f": {"k": 19}, "gh": 10, "x.y.z": 13, "new": 23}
     )
 
-    assert cfg["a"]["b"] == 1
-    assert cfg["a"]["c"]["d"] == 15
-    assert cfg["e"]["f"] == {"k": 19}
-    assert cfg["e"]["g"]["h"] == 18
-    assert cfg["gh"] == 10
-    assert "x.y.z" not in cfg
-    assert cfg["new"] == 23
+    assert cfg == {
+        "a": {"b": 1, "c": {"d": 15}},
+        "e": {"f": {"k": 19}, "g": {"h": 18}},
+        "gh": 10,
+        "new": 23,
+    }

--- a/tests/test_patch_dict.py
+++ b/tests/test_patch_dict.py
@@ -10,7 +10,7 @@ def test_patch_dict():
 
     _patch_dict(
         cfg,
-        {"a.c.d": 15, "e.f": {"k": 19}, "gh": 10}
+        {"a.c.d": 15, "e.f": {"k": 19}, "gh": 10, "x.y.z": 13, "new": 23}
     )
 
     assert cfg["a"]["b"] == 1
@@ -18,3 +18,5 @@ def test_patch_dict():
     assert cfg["e"]["f"] == {"k": 19}
     assert cfg["e"]["g"]["h"] == 18
     assert cfg["gh"] == 10
+    assert "x.y.z" not in cfg
+    assert cfg["new"] == 23

--- a/tests/test_patch_dict.py
+++ b/tests/test_patch_dict.py
@@ -1,0 +1,20 @@
+from conda_forge_tick.migrators.migration_yaml import _patch_dict
+
+
+def test_patch_dict():
+    cfg = {
+        "a": {"b": 1, "c": {"d": 10}},
+        "e": {"f": 5, "g": {"h": 18}},
+        "gh": [4, 5, 4, 4, 4, 4],
+    }
+
+    _patch_dict(
+        cfg,
+        {"a.c.d": 15, "e.f": {"k": 19}, "gh": 10}
+    )
+
+    assert cfg["a"]["b"] == 1
+    assert cfg["a"]["c"]["d"] == 15
+    assert cfg["e"]["f"] == {"k": 19}
+    assert cfg["e"]["g"]["h"] == 18
+    assert cfg["gh"] == 10


### PR DESCRIPTION
This PR has three things

1. We now check that the graph can be loaded before we deploy it. If it cannot, we deploy to a branch for debugging and stop the bot.

2. I added the ability to pause migrations.

3. I added the ability to patch the conda-forge.yml from the migrator via a syntax like

```yaml
conda_forge_yml_patches:
  provider.linux_ppc64le: azure
```

This will allow us to set this only for the R migration.