### PR TITLE
ENH make sure to exclude things that would be built in mamba check

### DIFF
--- a/conda_forge_tick/mamba_solver.py
+++ b/conda_forge_tick/mamba_solver.py
@@ -252,7 +252,7 @@ def is_recipe_solvable(feedstock_dir):
 
 
 def _clean_reqs(reqs, names):
-    return [r for r in reqs if not any(r.startswith(nm) for nm in names)]
+    return [r for r in reqs if not any(r.split(" ")[0] == nm for nm in names)]
 
 
 def _is_recipe_solvable_on_platform(recipe_dir, cbc_path, platform, arch):

--- a/conda_forge_tick/migrators/disabled/legacy.py
+++ b/conda_forge_tick/migrators/disabled/legacy.py
@@ -5,6 +5,7 @@ import re
 from itertools import chain
 from textwrap import dedent
 from typing import Any, Optional, Set, List
+import tempfile
 
 import networkx as nx
 from conda_smithy.configure_feedstock import get_cfp_file_path
@@ -105,7 +106,8 @@ class Compiler(Migrator):
 
     def __init__(self, pr_limit: int = 0):
         super().__init__(pr_limit)
-        self.cfp = get_cfp_file_path()[0]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.cfp = get_cfp_file_path(tmpdir)[0]
 
     def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
         for req in attrs.get("req", []):


### PR DESCRIPTION
This PR fixes an error where we don't account for outputs that would be built when checking if a recipe's envs can be solved.