### PR TITLE
New main update version and sources module.

### DIFF
--- a/conda_forge_tick/cli.xsh
+++ b/conda_forge_tick/cli.xsh
@@ -13,6 +13,7 @@ from .auto_tick import main as main_auto_tick
 from .status_report import main as main_status_report
 from .audit import main as main_audit
 from .update_prs import main as main_update_prs
+from .new_update_upstream_versions import main as main_populate_versions
 
 
 def deploy(args):
@@ -87,6 +88,7 @@ int_script_dict = {
   4: main_status_report,
   5: main_audit,
   6: main_update_prs,
+  7: main_populate_versions
   -1: deploy
 }
 

--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -338,6 +338,29 @@ def update_nodes_with_bot_rerun(gx):
                     )
 
 
+
+def update_nodes_with_new_versions(gx):
+    """Updates every node with it's new version (when available)"""
+    try:
+        with open('new_version.json') as file:
+            ver_attrs = json.load(file)
+    except FileNotFoundError as e:
+        logger.debug(f'Process interrupted with exeption: {e}')
+        return
+    
+    # Update graph according to ver_attrs
+    for node, vertrs in ver_attrs.items():
+        with gx.nodes[f'{node}']['payload'] as attrs:
+            if vertrs["bad"]:
+                attrs["bad"] = vertrs.get("bad")
+            elif vertrs["archived"]:
+                attrs["archived"] = vertrs.get("archived")
+            # Update with new information
+            attrs["new_version"] = vertrs.get("new_version")
+            attrs["new_version_attempts"] = vertrs.get("new_version_attempts")
+            attrs["new_version_errors"] = vertrs.get("new_version_errors")
+            
+
 def main(args: "CLIArgs") -> None:
     setup_logger(logger)
 
@@ -353,6 +376,7 @@ def main(args: "CLIArgs") -> None:
     )
 
     update_nodes_with_bot_rerun(gx)
+    update_nodes_with_new_versions(gx)
 
     dump_graph(gx)
 

--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -338,29 +338,6 @@ def update_nodes_with_bot_rerun(gx):
                     )
 
 
-
-def update_nodes_with_new_versions(gx):
-    """Updates every node with it's new version (when available)"""
-    try:
-        with open('new_version.json') as file:
-            ver_attrs = json.load(file)
-    except FileNotFoundError as e:
-        logger.debug(f'Process interrupted with exeption: {e}')
-        return
-    
-    # Update graph according to ver_attrs
-    for node, vertrs in ver_attrs.items():
-        with gx.nodes[f'{node}']['payload'] as attrs:
-            if vertrs["bad"]:
-                attrs["bad"] = vertrs.get("bad")
-            elif vertrs["archived"]:
-                attrs["archived"] = vertrs.get("archived")
-            # Update with new information
-            attrs["new_version"] = vertrs.get("new_version")
-            attrs["new_version_attempts"] = vertrs.get("new_version_attempts")
-            attrs["new_version_errors"] = vertrs.get("new_version_errors")
-            
-
 def main(args: "CLIArgs") -> None:
     setup_logger(logger)
 
@@ -376,7 +353,6 @@ def main(args: "CLIArgs") -> None:
     )
 
     update_nodes_with_bot_rerun(gx)
-    update_nodes_with_new_versions(gx)
 
     dump_graph(gx)
 

--- a/conda_forge_tick/new_update_versions.py
+++ b/conda_forge_tick/new_update_versions.py
@@ -118,7 +118,7 @@ def new_update_upstream_versions(
                 "bad": attrs.get("bad"),
                 "new_version": attrs.get("new_version")
             }
-            logger.info("writing out file")
+            logger.debug("writing out file")
             with open(f"versions/{node}.json", "w") as outfile:
                 json.dump(to_update, outfile)
             Node_count += 1

--- a/conda_forge_tick/new_update_versions.py
+++ b/conda_forge_tick/new_update_versions.py
@@ -118,6 +118,9 @@ def new_update_upstream_versions(
                 "bad": attrs.get("bad"),
                 "new_version": attrs.get("new_version")
             }
+            logger.info("writing out file")
+            with open(f"versions/{node}.json", "w") as outfile:
+                json.dump(to_update, outfile)
             Node_count += 1
     return up_to
 
@@ -132,12 +135,10 @@ def main(args: Any = None) -> None:
     # Graph enabled for inspection
     gx = load_graph()
 
+    # Check if 'versions' folder exists or create a new one;
+    os.makedirs('versions', exist_ok=True)
     # call update
     to_update = new_update_upstream_versions(gx)
-
-    logger.info("writing out file")
-    with open("new_version.json", "w") as outfile:
-        json.dump(to_update, outfile)
 
 
 if __name__ == "__main__":

--- a/conda_forge_tick/new_update_versions.py
+++ b/conda_forge_tick/new_update_versions.py
@@ -90,10 +90,7 @@ def new_update_upstream_versions(
 
             # rude exception
             if node == "ca-policy-lcg":
-                up_to["ca-policy-lcg"] = {
-                    "bad": attrs.get("bad"),
-                    "new_version": False
-                }
+                up_to["ca-policy-lcg"] = {"bad": attrs.get("bad"), "new_version": False}
                 Node_count += 1
                 continue
 
@@ -116,7 +113,7 @@ def new_update_upstream_versions(
                 )
             up_to[f"{node}"] = {
                 "bad": attrs.get("bad"),
-                "new_version": attrs.get("new_version")
+                "new_version": attrs.get("new_version"),
             }
             logger.debug("writing out file")
             with open(f"versions/{node}.json", "w") as outfile:
@@ -136,7 +133,7 @@ def main(args: Any = None) -> None:
     gx = load_graph()
 
     # Check if 'versions' folder exists or create a new one;
-    os.makedirs('versions', exist_ok=True)
+    os.makedirs("versions", exist_ok=True)
     # call update
     to_update = new_update_upstream_versions(gx)
 

--- a/conda_forge_tick/new_update_versions.py
+++ b/conda_forge_tick/new_update_versions.py
@@ -1,0 +1,130 @@
+import networkx as nx
+import logging
+import random
+import json
+import os
+
+from conda_forge_tick.utils import setup_logger, load_graph
+from update_sources import (
+    AbstractSource,
+    PyPI,
+    CRAN,
+    NPM,
+    ROSDistro,
+    RawURL,
+    Github,
+)
+from typing import (
+    Any,
+    Optional,
+    Iterable,
+    Set,
+    Iterator,
+    List,
+)
+
+# conda_forge_tick :: cft
+logger = logging.getLogger("cft._update_versions")
+
+
+def get_latest_version(
+    name: str, payload_meta_yaml: Any, sources: Iterable[AbstractSource]
+):
+    with payload_meta_yaml as meta_yaml:
+        for source in sources:
+            logger.debug("source: %s", source.__class__.__name__)
+            url = source.get_url(meta_yaml)
+            logger.debug("url: %s", url)
+            if url is None:
+                continue
+            ver = source.get_version(url)
+            logger.debug("ver: %s", ver)
+            if ver:
+                return ver
+            else:
+                logger.debug(f"Upstream: Could not find version on {source.name}")
+        if not meta_yaml.get("bad"):
+            logger.debug("Upstream: unknown source")
+        return False
+
+
+# It's expected that your environment provide this info.
+CONDA_FORGE_TICK_DEBUG = os.environ.get("CONDA_FORGE_TICK_DEBUG", False)
+
+
+def new_update_upstream_versions(
+    gx: nx.DiGraph, sources: Iterable[AbstractSource] = None
+) -> None:
+    sources = (
+        (PyPI(), CRAN(), NPM(), ROSDistro(), RawURL(), Github())
+        if sources is None
+        else sources
+    )
+
+    _all_nodes = [t for t in gx.nodes.items()]
+    random.shuffle(_all_nodes)
+
+    # Inspection the graph object and node update:
+    # print(f"Number of nodes: {len(gx.nodes)}")
+    Node_count = 0
+
+    to_update = {}
+    to_update["nodes"] = []
+    for node, node_attrs in _all_nodes:
+        # checking each node
+        with node_attrs["payload"] as attrs:
+            # rude exception
+            if node == "ca-policy-lcg":
+                to_update["nodes"].append({"id": str(node), "version": "False"})
+                Node_count += 1
+                continue
+
+            # verify the actual situation of the package;
+            actual_ver = str(attrs.get("version"))
+            if attrs.get("bad") or attrs.get("archived"):
+                logger.info(
+                    f"# {Node_count:<5} - {node:<30} - ver: {actual_ver:<10} - bad/archived"
+                )
+                Node_count += 1
+                continue
+            # New verison request
+            try:
+                new_version = get_latest_version(node, attrs, sources)
+            except Exception as e:
+                try:
+                    se = repr(e)
+                except Exception as ee:
+                    se = "Bad exception string: {}".format(ee)
+                logger.warning(
+                    f"Warning: Error getting upstream version of {node}: {se}"
+                )
+
+            logger.info(
+                f"# {Node_count:<5} - {node:<30} - ver: {actual_ver:<10} - new ver: {new_version}"
+            )
+            to_update["nodes"].append({"id": str(node), "version": str(new_version)})
+            Node_count += 1
+    return to_update
+
+
+def main(args: Any = None) -> None:
+    logger.info("cft :: conda_forge_tick")
+    if CONDA_FORGE_TICK_DEBUG:
+        setup_logger(logger, level="debug")
+    else:
+        setup_logger(logger)
+
+    logger.info("Reading graph")
+    # Graph enabled for inspection
+    gx = load_graph()
+
+    # call update
+    to_update = new_update_upstream_versions(gx)
+
+    logger.info("writing out file")
+    with open("new_version.json", "w") as outfile:
+        json.dump(to_update, outfile)
+
+
+if __name__ == "__main__":
+    main()

--- a/conda_forge_tick/new_update_versions.py
+++ b/conda_forge_tick/new_update_versions.py
@@ -92,9 +92,7 @@ def new_update_upstream_versions(
             if node == "ca-policy-lcg":
                 up_to["ca-policy-lcg"] = {
                     "bad": attrs.get("bad"),
-                    "new_version": False,
-                    "new_version_attempts": attrs.get("new_version_attempts"),
-                    "new_version_errors": attrs.get("new_version_errors")
+                    "new_version": False
                 }
                 Node_count += 1
                 continue
@@ -118,9 +116,7 @@ def new_update_upstream_versions(
                 )
             up_to[f"{node}"] = {
                 "bad": attrs.get("bad"),
-                "new_version": attrs.get("new_version"),
-                "new_version_attempts": attrs.get("new_version_attempts"),
-                "new_version_errors": attrs.get("new_version_errors")
+                "new_version": attrs.get("new_version")
             }
             Node_count += 1
     return up_to

--- a/conda_forge_tick/new_update_versions.py
+++ b/conda_forge_tick/new_update_versions.py
@@ -3,8 +3,9 @@ import logging
 import random
 import json
 import os
+import tqdm
 
-from conda_forge_tick.utils import setup_logger, load_graph
+from utils import setup_logger, load_graph
 from update_sources import (
     AbstractSource,
     PyPI,
@@ -24,7 +25,7 @@ from typing import (
 )
 
 # conda_forge_tick :: cft
-logger = logging.getLogger("cft._update_versions")
+logger = logging.getLogger("conda-forge-tick._update_versions")
 
 
 def get_latest_version(
@@ -43,8 +44,10 @@ def get_latest_version(
                 return ver
             else:
                 logger.debug(f"Upstream: Could not find version on {source.name}")
+                meta["bad"] = f"Upstream: Could not find version on {source.name}"
         if not meta_yaml.get("bad"):
             logger.debug("Upstream: unknown source")
+            meta["bad"] = "Upstream: unknown source"
         return False
 
 
@@ -68,28 +71,38 @@ def new_update_upstream_versions(
     # print(f"Number of nodes: {len(gx.nodes)}")
     Node_count = 0
 
-    to_update = {}
-    to_update["nodes"] = []
-    for node, node_attrs in _all_nodes:
+    to_update = []
+    for node, node_attrs in tqdm.tqdm(_all_nodes):
+        attrs = node_attrs["payload"]
+        if attrs.get("bad") or attrs.get("archived"):
+            attrs["new_version"] = False
+            continue
+        to_update.append((node, attrs))
+
+    up_to = {}
+    for node, node_attrs in to_update:
         # checking each node
-        with node_attrs["payload"] as attrs:
-            # rude exception
-            if node == "ca-policy-lcg":
-                to_update["nodes"].append({"id": str(node), "version": "False"})
-                Node_count += 1
-                continue
+        with node_attrs as attrs:
+            up_to = {}
 
             # verify the actual situation of the package;
             actual_ver = str(attrs.get("version"))
-            if attrs.get("bad") or attrs.get("archived"):
-                logger.info(
-                    f"# {Node_count:<5} - {node:<30} - ver: {actual_ver:<10} - bad/archived"
-                )
+
+            # rude exception
+            if node == "ca-policy-lcg":
+                up_to["ca-policy-lcg"] = {
+                    "bad": attrs.get("bad"),
+                    "new_version": False,
+                    "new_version_attempts": attrs.get("new_version_attempts"),
+                    "new_version_errors": attrs.get("new_version_errors")
+                }
                 Node_count += 1
                 continue
+
             # New verison request
             try:
                 new_version = get_latest_version(node, attrs, sources)
+                attrs["new_version"] = new_version or attrs["new_version"]
             except Exception as e:
                 try:
                     se = repr(e)
@@ -98,17 +111,22 @@ def new_update_upstream_versions(
                 logger.warning(
                     f"Warning: Error getting upstream version of {node}: {se}"
                 )
-
-            logger.info(
-                f"# {Node_count:<5} - {node:<30} - ver: {actual_ver:<10} - new ver: {new_version}"
-            )
-            to_update["nodes"].append({"id": str(node), "version": str(new_version)})
+                attrs["bad"] = "Upstream: Error getting upstream version"
+            else:
+                logger.info(
+                    f"# {Node_count:<5} - {node} - {attrs.get('version')} - {attrs.get('new_version')}",
+                )
+            up_to[f"{node}"] = {
+                "bad": attrs.get("bad"),
+                "new_version": attrs.get("new_version"),
+                "new_version_attempts": attrs.get("new_version_attempts"),
+                "new_version_errors": attrs.get("new_version_errors")
+            }
             Node_count += 1
-    return to_update
+    return up_to
 
 
 def main(args: Any = None) -> None:
-    logger.info("cft :: conda_forge_tick")
     if CONDA_FORGE_TICK_DEBUG:
         setup_logger(logger, level="debug")
     else:

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -1,0 +1,451 @@
+import abc
+import collections.abc
+import subprocess
+import re
+import logging
+import typing
+from typing import (
+    Any,
+    Optional,
+    Iterable,
+    Set,
+    Iterator,
+    List,
+)
+import yaml
+import feedparser
+import requests
+from conda.models.version import VersionOrder
+from conda_forge_tick.utils import parse_meta_yaml
+from hashing import hash_url
+
+# TODO: parse_version has bad type annotations
+from pkg_resources import parse_version
+
+CRAN_INDEX: Optional[dict] = None
+
+logger = logging.getLogger("cft._update_version.update_sources")
+
+
+def urls_from_meta(meta_yaml: "MetaYamlTypedDict") -> Set[str]:
+    source: "SourceTypedDict" = meta_yaml["source"]
+    sources: typing.List["SourceTypedDict"]
+    if isinstance(source, collections.abc.Mapping):
+        sources = [source]
+    else:
+        sources = typing.cast("typing.List[SourceTypedDict]", source)
+    urls = set()
+    for s in sources:
+        if "url" in s:
+            # if it is a list for instance
+            if not isinstance(s["url"], str):
+                urls.update(s["url"])
+            else:
+                urls.add(s["url"])
+    return urls
+
+
+def _split_alpha_num(ver: str) -> List[str]:
+    for i, c in enumerate(ver):
+        if c.isalpha():
+            return [ver[0:i], ver[i:]]
+    return [ver]
+
+
+def next_version(ver: str) -> Iterator[str]:
+    ver_split = []
+    ver_dot_split = ver.split(".")
+    n_dot = len(ver_dot_split)
+    for idot, sdot in enumerate(ver_dot_split):
+
+        ver_under_split = sdot.split("_")
+        n_under = len(ver_under_split)
+        for iunder, sunder in enumerate(ver_under_split):
+
+            ver_dash_split = sunder.split("-")
+            n_dash = len(ver_dash_split)
+            for idash, sdash in enumerate(ver_dash_split):
+
+                for el in _split_alpha_num(sdash):
+                    ver_split.append(el)
+
+                if idash < n_dash - 1:
+                    ver_split.append("-")
+
+            if iunder < n_under - 1:
+                ver_split.append("_")
+
+        if idot < n_dot - 1:
+            ver_split.append(".")
+
+    for k in reversed(range(len(ver_split))):
+        try:
+            t = int(ver_split[k])
+        except Exception:
+            continue
+        else:
+            ver_split[k] = str(t + 1)
+            yield "".join(ver_split)
+            ver_split[k] = "0"
+
+
+class AbstractSource(abc.ABC):
+    name: str
+
+    @abc.abstractmethod
+    def get_version(self, url: str) -> Optional[str]:
+        pass
+
+    @abc.abstractmethod
+    def get_url(self, url: str) -> Optional[str]:
+        pass
+
+
+class VersionFromFeed(AbstractSource):
+    ver_prefix_remove = ["release-", "releases%2F", "v_", "v.", "v"]
+    dev_vers = [
+        "rc",
+        "beta",
+        "alpha",
+        "dev",
+        "a",
+        "b",
+        "init",
+        "testing",
+        "test",
+        "pre",
+    ]
+
+    def get_version(self, url) -> Optional[str]:
+        data = feedparser.parse(url)
+        if data["bozo"] == 1:
+            return None
+        vers = []
+        for entry in data["entries"]:
+            ver = entry["link"].split("/")[-1]
+            for prefix in self.ver_prefix_remove:
+                if ver.startswith(prefix):
+                    ver = ver[len(prefix):]
+            if any(s in ver.lower() for s in self.dev_vers):
+                continue
+            # Extract vesion number starting at the first digit.
+            ver = re.search(r"(\d+[^\s]*)", ver).group(0)
+            vers.append(ver)
+        if vers:
+            return max(vers, key=lambda x: VersionOrder(x.replace("-", ".")))
+        else:
+            return None
+
+
+class PyPI(AbstractSource):
+    name = "pypi"
+
+    def get_url(self, meta_yaml) -> Optional[str]:
+        url_names = ["pypi.python.org", "pypi.org", "pypi.io"]
+        source_url = meta_yaml["url"]
+        if not any(s in source_url for s in url_names):
+            return None
+        pkg = meta_yaml["url"].split("/")[6]
+        return f"https://pypi.org/pypi/{pkg}/json"
+
+    def get_version(self, url) -> Optional[str]:
+        r = requests.get(url)
+        # If it is a pre-release don't give back the pre-release version
+        if not r.ok or parse_version(r.json()["info"]["version"].strip()).is_prerelease:
+            return False
+        return r.json()["info"]["version"].strip()
+
+
+class NPM(AbstractSource):
+    name = "npm"
+
+    def get_url(self, meta_yaml) -> Optional[str]:
+        if "registry.npmjs.org" not in meta_yaml["url"]:
+            return None
+        # might be namespaced
+        pkg = meta_yaml["url"].split("/")[3:-2]
+        return f"https://registry.npmjs.org/{'/'.join(pkg)}"
+
+    def get_version(self, url: str) -> Optional[str]:
+        r = requests.get(url)
+        if not r.ok:
+            return False
+        latest = r.json()["dist-tags"].get("latest", "").strip()
+        # If it is a pre-release don't give back the pre-release version
+        if not len(latest) or parse_version(latest).is_prerelease:
+            return False
+
+        return latest
+
+
+class CRAN(AbstractSource):
+    """The CRAN versions source.
+
+    Uses a local CRAN index instead of one request per package.
+
+    The index is lazy initialzed on first `get_url` call and kept in
+    memory on module level as `CRAN_INDEX` like a singelton. This way it
+    is shared on executor level and not serialized with every instance of
+    the CRAN class to allow efficient distributed execution with e.g.
+    dask.
+    """
+
+    name = "cran"
+    url_contains = "cran.r-project.org/src/contrib/Archive"
+    cran_url = "https://cran.r-project.org"
+
+    def init(self) -> None:
+        global CRAN_INDEX
+        if not CRAN_INDEX:
+            try:
+                session = requests.Session()
+                CRAN_INDEX = self._get_cran_index(session)
+                logger.debug("Cran source initialized")
+            except Exception:
+                logger.error("Cran initialization failed", exc_info=True)
+                CRAN_INDEX = {}
+
+    def _get_cran_index(self, session: requests.Session) -> dict:
+        # from conda_build/skeletons/cran.py:get_cran_index
+        logger.debug("Fetching cran index from %s", self.cran_url)
+        r = session.get(self.cran_url + "/src/contrib/")
+        r.raise_for_status()
+        records = {}
+        for p in re.findall(r'<td><a href="([^"]+)">\1</a></td>', r.text):
+            if p.endswith(".tar.gz") and "_" in p:
+                name, version = p.rsplit(".", 2)[0].split("_", 1)
+                records[name.lower()] = (name, version)
+        r = session.get(self.cran_url + "/src/contrib/Archive/")
+        r.raise_for_status()
+        for p in re.findall(r'<td><a href="([^"]+)/">\1/</a></td>', r.text):
+            if re.match(r"^[A-Za-z]", p):
+                records.setdefault(p.lower(), (p, None))
+        return records
+
+    def get_url(self, meta_yaml) -> Optional[str]:
+        self.init()
+        urls = meta_yaml["url"]
+        if not isinstance(meta_yaml["url"], list):
+            urls = [urls]
+        for url in urls:
+            if self.url_contains not in url:
+                continue
+            # alternatively: pkg = meta_yaml["name"].split("r-", 1)[-1]
+            pkg = url.split("/")[6].lower()
+            if pkg in CRAN_INDEX:
+                return CRAN_INDEX[pkg]
+            else:
+                return None
+        return None
+
+    def get_version(self, url) -> Optional[str]:
+        return str(url[1]).replace("-", "_") if url[1] else None
+
+ROS_DISTRO_INDEX: Optional[dict] = None
+
+class ROSDistro(AbstractSource):
+    name = "rosdistro"
+
+    def parse_idx(self, distro_name: str = "melodic") -> dict:
+        session = requests.Session()
+        res = session.get(
+            f"https://raw.githubusercontent.com/ros/rosdistro/master/{distro_name}/distribution.yaml",  # noqa
+        )
+        res.raise_for_status()
+        resd = yaml.load(res.text, Loader=yaml.SafeLoader)
+        repos = resd["repositories"]
+
+        result_dict: dict = {distro_name: {"reverse": {}, "forward": {}}}
+        for k, v in repos.items():
+            if not v.get("release"):
+                continue
+            if v["release"].get("packages"):
+                for p in v["release"]["packages"]:
+                    result_dict[distro_name]["reverse"][self.encode_ros_name(p)] = (
+                        k,
+                        p,
+                    )
+            else:
+                result_dict[distro_name]["reverse"][self.encode_ros_name(k)] = (k, k)
+        result_dict[distro_name]["forward"] = repos
+        return result_dict
+
+    def encode_ros_name(self, name: str) -> str:
+        new_name = name.replace("_", "-")
+        if new_name.startswith("ros-"):
+            return new_name
+        else:
+            return "ros-" + new_name
+
+    def init(self) -> None:
+        global ROS_DISTRO_INDEX
+        if not ROS_DISTRO_INDEX:
+            self.version_url_cache = {}
+            try:
+                ROS_DISTRO_INDEX = self.parse_idx("melodic")
+                logger.info("ROS Distro source initialized")
+            except Exception:
+                logger.error("ROS Distro initialization failed", exc_info=True)
+                ROS_DISTRO_INDEX = {}
+
+    def get_url(self, meta_yaml: "MetaYamlTypedDict") -> Optional[str]:
+        if not meta_yaml["name"].startswith("ros-"):
+            return None
+
+        self.init()
+
+        toplevel_package, package = ROS_DISTRO_INDEX["melodic"]["reverse"][
+            meta_yaml["name"]
+        ]
+
+        p_dict = ROS_DISTRO_INDEX["melodic"]["forward"][toplevel_package]
+        version = p_dict["release"]["version"]
+        tag_url = p_dict["release"]["tags"]["release"].format(
+            package=package, version=version,
+        )
+        url = p_dict["release"]["url"]
+
+        if url.endswith(".git"):
+            url = url[:-4]
+
+        final_url = f"{url}/archive/{tag_url}.tar.gz"
+        self.version_url_cache[final_url] = version.split("-")[0]
+
+        return final_url
+
+    def get_version(self, url):
+        return self.version_url_cache[url]
+
+def get_sha256(url: str) -> Optional[str]:
+    try:
+        return hash_url(url, timeout=120, hash_type="sha256")
+    except Exception as e:
+        logger.debug("url hashing exception: %s", repr(e))
+        return None
+
+
+def url_exists(url: str) -> bool:
+    try:
+        output = subprocess.check_output(
+            ["wget", "--spider", url], stderr=subprocess.STDOUT, timeout=1,
+        )
+    except Exception:
+        return False
+    # For FTP servers an exception is not thrown
+    if "No such file" in output.decode("utf-8"):
+        return False
+    if "not retrieving" in output.decode("utf-8"):
+        return False
+
+    return True
+
+
+def url_exists_swap_exts(url: str):
+    if url_exists(url):
+        return True, url
+
+    # TODO this is too expensive
+    # from conda_forge_tick.url_transforms import gen_transformed_urls
+    # for new_url in gen_transformed_urls(url):
+    #     if url_exists(new_url):
+    #         return True, new_url
+
+    return False, None
+
+class RawURL(AbstractSource):
+    name = "RawURL"
+
+    def get_url(self, meta_yaml) -> Optional[str]:
+        if "feedstock_name" not in meta_yaml:
+            return None
+        if "version" not in meta_yaml:
+            return None
+        # TODO: pull this from the graph itself
+        content = meta_yaml["raw_meta_yaml"]
+
+        # this while statment runs until a bad version is found
+        # then it uses the previous one
+        orig_urls = urls_from_meta(meta_yaml["meta_yaml"])
+        current_ver = meta_yaml["version"]
+        current_sha256 = None
+        orig_ver = current_ver
+        found = True
+        count = 0
+        max_count = 10
+        while found and count < max_count:
+            found = False
+            for next_ver in next_version(current_ver):
+                logger.debug("trying version: %s", next_ver)
+
+                new_content = content.replace(orig_ver, next_ver)
+                new_meta = parse_meta_yaml(new_content)
+                new_urls = urls_from_meta(new_meta)
+                if len(new_urls) == 0:
+                    logger.debug("No URL in meta.yaml")
+                    meta_yaml["bad"] = "Upstream: no url in yaml"
+                    return None
+
+                url_to_use = None
+                for url in urls_from_meta(new_meta):
+                    # this URL looks bad if these things happen
+                    if (
+                        str(new_meta["package"]["version"]) != next_ver
+                        or meta_yaml["url"] == url
+                        or url in orig_urls
+                    ):
+                        continue
+
+                    logger.debug("trying url: %s", url)
+                    _exists, _url_to_use = url_exists_swap_exts(url)
+                    if not _exists:
+                        logger.debug(
+                            "version %s does not exist for url %s", next_ver, url)
+                        continue
+                    else:
+                        url_to_use = _url_to_use
+
+                if url_to_use is not None:
+                    found = True
+                    count = count + 1
+                    current_ver = next_ver
+                    new_sha256 = get_sha256(url_to_use)
+                    if new_sha256 == current_sha256 or new_sha256 in new_content:
+                        return None
+                    current_sha256 = new_sha256
+                    logger.debug("version %s is ok for url %s", current_ver, url_to_use)
+                    break
+
+        if count == max_count:
+            return None
+        if current_ver != orig_ver:
+            logger.debug("using version %s", current_ver)
+            return current_ver
+        return None
+
+    def get_version(self, url: str) -> str:
+        return url
+
+
+class Github(VersionFromFeed):
+    name = "github"
+
+    def get_url(self, meta_yaml) -> Optional[str]:
+        if "github.com" not in meta_yaml["url"]:
+            return None
+        split_url = meta_yaml["url"].lower().split("/")
+        package_owner = split_url[split_url.index("github.com") + 1]
+        gh_package_name = split_url[split_url.index("github.com") + 2]
+        return f"https://github.com/{package_owner}/{gh_package_name}/releases.atom"
+
+
+class LibrariesIO(VersionFromFeed):
+    def get_url(self, meta_yaml) -> Optional[str]:
+        urls = meta_yaml["url"]
+        if not isinstance(meta_yaml["url"], list):
+            urls = [urls]
+        for url in urls:
+            if self.url_contains not in url:
+                continue
+            pkg = self.package_name(url)
+            return f"https://libraries.io/{self.name}/{pkg}/versions.atom"
+

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -26,6 +26,7 @@ CRAN_INDEX: Optional[dict] = None
 
 logger = logging.getLogger("conda-forge-tick._update_version.update_sources")
 
+
 def urls_from_meta(meta_yaml: "MetaYamlTypedDict") -> Set[str]:
     source: "SourceTypedDict" = meta_yaml["source"]
     sources: typing.List["SourceTypedDict"]
@@ -124,7 +125,7 @@ class VersionFromFeed(AbstractSource):
             ver = entry["link"].split("/")[-1]
             for prefix in self.ver_prefix_remove:
                 if ver.startswith(prefix):
-                    ver = ver[len(prefix):]
+                    ver = ver[len(prefix) :]
             if any(s in ver.lower() for s in self.dev_vers):
                 continue
             # Extract vesion number starting at the first digit.
@@ -240,7 +241,9 @@ class CRAN(AbstractSource):
     def get_version(self, url) -> Optional[str]:
         return str(url[1]).replace("-", "_") if url[1] else None
 
+
 ROS_DISTRO_INDEX: Optional[dict] = None
+
 
 class ROSDistro(AbstractSource):
     name = "rosdistro"
@@ -315,6 +318,7 @@ class ROSDistro(AbstractSource):
     def get_version(self, url):
         return self.version_url_cache[url]
 
+
 def get_sha256(url: str) -> Optional[str]:
     try:
         return hash_url(url, timeout=120, hash_type="sha256")
@@ -350,6 +354,7 @@ def url_exists_swap_exts(url: str):
     #         return True, new_url
 
     return False, None
+
 
 class RawURL(AbstractSource):
     name = "RawURL"
@@ -398,7 +403,8 @@ class RawURL(AbstractSource):
                     _exists, _url_to_use = url_exists_swap_exts(url)
                     if not _exists:
                         logger.debug(
-                            "version %s does not exist for url %s", next_ver, url)
+                            "version %s does not exist for url %s", next_ver, url
+                        )
                         continue
                     else:
                         url_to_use = _url_to_use
@@ -447,4 +453,3 @@ class LibrariesIO(VersionFromFeed):
                 continue
             pkg = self.package_name(url)
             return f"https://libraries.io/{self.name}/{pkg}/versions.atom"
-

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -24,8 +24,7 @@ from pkg_resources import parse_version
 
 CRAN_INDEX: Optional[dict] = None
 
-logger = logging.getLogger("cft._update_version.update_sources")
-
+logger = logging.getLogger("conda-forge-tick._update_version.update_sources")
 
 def urls_from_meta(meta_yaml: "MetaYamlTypedDict") -> Set[str]:
     source: "SourceTypedDict" = meta_yaml["source"]


### PR DESCRIPTION
As mentioned by @CJ-Wright and @beckermr this new PR aims some alterations on the original version of
`update_upstream_versions` code to generate a JSON file containing the required new versions outside the `graph` structure. Is also, now communicates with the others functions of that module.

Now, I've created a separate module for the upstream sources in the library. A test in a separate repo using Circle CI, was made with an good result (The code runs) [Circle Ci](https://app.circleci.com/pipelines/github/viniciusdc/ts-graph/46/workflows/cf6da52d-df5d-485d-9aaf-6c142ce10962/jobs/51).
There are still some missing alterations as: 
1. Some sources still do some  alterations directly to the `graph` structure;
2. As cited by CJ, I still need to implement it on the `cli.ssh` file to be read (and execute).
3. There is a missing feature, saliented by CJ that I (unfortunately) still could not set:
  
"Changes to make graph (or maybe the version bump code) to look at the source of new version numbers. (I think this is the main piece missing from this PR)"

So these are the next steps. (I would also like to apology myself for the late PR).