### PR TITLE
ENH compute archived from admin-migrations

### DIFF
--- a/conda_forge_tick/all_feedstocks.py
+++ b/conda_forge_tick/all_feedstocks.py
@@ -2,6 +2,7 @@ import datetime
 import os
 from typing import Any, List
 
+import requests
 import github3
 import logging
 
@@ -21,7 +22,7 @@ def get_all_feedstocks_from_github() -> List[str]:
                 name = name.split("-feedstock")[0]
                 logger.info(name)
                 names.append(name)
-    except github3.GitHubError as e:
+    except github3.GitHubError:
         msg = ["Github rate limited. "]
         c = gh.rate_limit()["resources"]["core"]
         if c["remaining"] == 0:
@@ -38,7 +39,12 @@ def get_all_feedstocks_from_github() -> List[str]:
 def get_all_feedstocks(cached: bool = False) -> List[str]:
     if cached:
         logger.info("reading names")
-        with open("names.txt", "r") as f:
+        if os.path.exists("active_feedstocks.txt"):
+            fname = "active_feedstocks.txt"
+        else:
+            fname = "names.txt"
+
+        with open(fname, "r") as f:
             names = f.read().split()
         return names
 
@@ -48,8 +54,24 @@ def get_all_feedstocks(cached: bool = False) -> List[str]:
 
 def main(args: Any = None) -> None:
     setup_logger(logger)
-    names = get_all_feedstocks(cached=False)
-    with open("names.txt", "w") as f:
+    try:
+        logger.info("fetching active feedstocks from admin-migrations")
+        r = requests.get(
+            "https://raw.githubusercontent.com/conda-forge/admin-migrations/"
+            "master/data/all_feedstocks.json"
+        )
+        if r.status_code != 200:
+            r.raise_for_status()
+
+        names = r.json()["active"]
+        fname = "active_feedstocks.txt"
+    except Exception as e:
+        logger.critical("admin-migrations all feedstocks failed: %s", repr(e))
+        logger.critical("defaulting to the local version")
+        names = get_all_feedstocks(cached=False)
+        fname = "names.txt"
+
+    with open(fname, "w") as f:
         for name in names:
             f.write(name)
             f.write("\n")

--- a/conda_forge_tick/all_feedstocks.py
+++ b/conda_forge_tick/all_feedstocks.py
@@ -39,12 +39,7 @@ def get_all_feedstocks_from_github() -> List[str]:
 def get_all_feedstocks(cached: bool = False) -> List[str]:
     if cached:
         logger.info("reading names")
-        if os.path.exists("active_feedstocks.txt"):
-            fname = "active_feedstocks.txt"
-        else:
-            fname = "names.txt"
-
-        with open(fname, "r") as f:
+        with open("names.txt", "r") as f:
             names = f.read().split()
         return names
 
@@ -64,14 +59,16 @@ def main(args: Any = None) -> None:
             r.raise_for_status()
 
         names = r.json()["active"]
-        fname = "active_feedstocks.txt"
+        with open("names_are_active.flag", "w") as fp:
+            fp.write("yes")
     except Exception as e:
         logger.critical("admin-migrations all feedstocks failed: %s", repr(e))
         logger.critical("defaulting to the local version")
         names = get_all_feedstocks(cached=False)
-        fname = "names.txt"
+        with open("names_are_active.flag", "w") as fp:
+            fp.write("no")
 
-    with open(fname, "w") as f:
+    with open("names.txt", "w") as f:
         for name in names:
             f.write(name)
             f.write("\n")

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -857,14 +857,11 @@ def main(args: "CLIArgs") -> None:
                         )
 
                 except github3.GitHubError as e:
-                    if e.msg == "Repository was archived so is read-only.":
-                        attrs["archived"] = True
-                    else:
-                        logger.critical(
-                            "GITHUB ERROR ON FEEDSTOCK: %s", fctx.feedstock_name,
-                        )
-                        if is_github_api_limit_reached(e, mctx.gh):
-                            break
+                    logger.critical(
+                        "GITHUB ERROR ON FEEDSTOCK: %s", fctx.feedstock_name,
+                    )
+                    if is_github_api_limit_reached(e, mctx.gh):
+                        break
                 except URLError as e:
                     logger.exception("URLError ERROR")
                     attrs["bad"] = {

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -857,11 +857,14 @@ def main(args: "CLIArgs") -> None:
                         )
 
                 except github3.GitHubError as e:
-                    logger.critical(
-                        "GITHUB ERROR ON FEEDSTOCK: %s", fctx.feedstock_name,
-                    )
-                    if is_github_api_limit_reached(e, mctx.gh):
-                        break
+                    if e.msg == "Repository was archived so is read-only.":
+                        attrs["archived"] = True
+                    else:
+                        logger.critical(
+                            "GITHUB ERROR ON FEEDSTOCK: %s", fctx.feedstock_name,
+                        )
+                        if is_github_api_limit_reached(e, mctx.gh):
+                            break
                 except URLError as e:
                     logger.exception("URLError ERROR")
                     attrs["bad"] = {

--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -74,6 +74,7 @@ def populate_feedstock_attributes(
     sub_graph: LazyJson,
     meta_yaml: typing.Union[str, Response] = "",
     conda_forge_yaml: typing.Union[str, Response] = "",
+    mark_not_archived=False,
     # build_sh: typing.Union[str, Response] = "",
     # pre_unlink: typing.Union[str, Response] = "",
     # post_link: typing.Union[str, Response] = "",
@@ -88,6 +89,10 @@ def populate_feedstock_attributes(
     for meaning.
     """
     sub_graph.update({"feedstock_name": name, "bad": False})
+
+    if mark_not_archived:
+        sub_graph.update({"archived": False})
+
     # handle all the raw strings
     if isinstance(meta_yaml, Response):
         sub_graph["bad"] = f"make_graph: {meta_yaml.status_code}"
@@ -182,7 +187,7 @@ def populate_feedstock_attributes(
     return sub_graph
 
 
-def get_attrs(name: str, i: int) -> LazyJson:
+def get_attrs(name: str, i: int, mark_not_archived=False) -> LazyJson:
     # These fetches could be done via async/multiprocessing
     meta_yaml = _fetch_file(name, "recipe/meta.yaml")
     conda_forge_yaml = _fetch_file(name, "conda-forge.yml")
@@ -191,16 +196,21 @@ def get_attrs(name: str, i: int) -> LazyJson:
     with lzj as sub_graph:
         populate_feedstock_attributes(
             name, sub_graph, meta_yaml=meta_yaml, conda_forge_yaml=conda_forge_yaml,
+            mark_not_archived=mark_not_archived,
         )
     return lzj
 
 
 def _build_graph_process_pool(
     gx: nx.DiGraph, names: List[str], new_names: List[str],
+    mark_not_archived=False
 ) -> None:
     with executor("thread", max_workers=20) as pool:
         futures = {
-            pool.submit(get_attrs, name, i): name for i, name in enumerate(names)
+            pool.submit(
+                get_attrs, name, i,
+                mark_not_archived=mark_not_archived
+            ): name for i, name in enumerate(names)
         }
         logger.info("submitted all nodes")
 
@@ -233,10 +243,12 @@ def _build_graph_process_pool(
 
 def _build_graph_sequential(
     gx: nx.DiGraph, names: List[str], new_names: List[str],
+    mark_not_archived=False
 ) -> None:
     for i, name in enumerate(names):
         try:
-            sub_graph = {"payload": get_attrs(name, i)}
+            sub_graph = {
+                "payload": get_attrs(name, i, mark_not_archived=mark_not_archived)}
         except Exception as e:
             logger.error(f"Error adding {name} to the graph: {e}")
         else:
@@ -246,7 +258,11 @@ def _build_graph_sequential(
                 gx.nodes[name].update(**sub_graph)
 
 
-def make_graph(names: List[str], gx: Optional[nx.DiGraph] = None) -> nx.DiGraph:
+def make_graph(
+    names: List[str],
+    gx: Optional[nx.DiGraph] = None,
+    mark_not_archived=False
+) -> nx.DiGraph:
     logger.info("reading graph")
 
     if gx is None:
@@ -266,7 +282,7 @@ def make_graph(names: List[str], gx: Optional[nx.DiGraph] = None) -> nx.DiGraph:
 
     debug = env.get("CONDA_FORGE_TICK_DEBUG", False)
     builder = _build_graph_sequential if debug else _build_graph_process_pool
-    builder(gx, total_names, new_names)
+    builder(gx, total_names, new_names, mark_not_archived=mark_not_archived)
     logger.info("feedstock fetch loop completed")
 
     gx2 = deepcopy(gx)
@@ -328,7 +344,7 @@ def update_nodes_with_bot_rerun(gx):
                 if (
                     pr_json
                     and not migration['data']['bot_rerun']
-                    and "bot-rerun" in [l["name"] for l in pr_json.get("labels", [])]
+                    and "bot-rerun" in [lb["name"] for lb in pr_json.get("labels", [])]
                 ):
                     migration['data']['bot_rerun'] = time.time()
                     logger.info(
@@ -346,7 +362,11 @@ def main(args: "CLIArgs") -> None:
         gx = load_graph()
     else:
         gx = None
-    gx = make_graph(names, gx)
+    gx = make_graph(
+        names,
+        gx,
+        mark_not_archived=os.path.exists("active_feedstocks.txt"),
+    )
     print(
         "nodes w/o payload:",
         [k for k, v in gx.nodes.items() if "payload" not in v],

--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -357,6 +357,12 @@ def update_nodes_with_bot_rerun(gx):
 def main(args: "CLIArgs") -> None:
     setup_logger(logger)
 
+    mark_not_archived = False
+    if os.path.exists("names_are_active.flag"):
+        with open("names_are_active.flag", "r") as fp:
+            if fp.read().strip() == "yes":
+                mark_not_archived = True
+
     names = get_all_feedstocks(cached=True)
     if os.path.exists("graph.json"):
         gx = load_graph()
@@ -365,7 +371,7 @@ def main(args: "CLIArgs") -> None:
     gx = make_graph(
         names,
         gx,
-        mark_not_archived=os.path.exists("active_feedstocks.txt"),
+        mark_not_archived=mark_not_archived,
     )
     print(
         "nodes w/o payload:",


### PR DESCRIPTION
This PR pulls a list of non-archived feedstocks from the admin-migrations repo. It then uses that list and correctly sets archived on each feedstock.