### PR TITLE
run pre-commit as a GHA

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,20 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+    - name: set PY
+      run: echo "::set-env name=PY::$(python --version --version | sha256sum | cut -d' ' -f1)"
+    - uses: actions/cache@v1
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+    - uses: pre-commit/action@v1.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,13 +19,3 @@ repos:
     rev: v1.5.0
     hooks:
       - id: add-trailing-comma
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.761
-    hooks:
-      - id: mypy
-        args:
-          - --strict
-        exclude: >
-            (?x)^(
-                docs/.*
-            )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,9 +6,10 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: stable
     hooks:
-      - id: black
+    - id: black
+      language_version: python3
   - repo: https://github.com/asottile/pyupgrade
     rev: v1.25.2
     hooks:


### PR DESCRIPTION
This adds a GitHub Action as a CI service to check for the pre-commit hooks. It should help when reviewing style (black) and other hooks present in the `.pre-commit-config.yaml` file. Note that, at the moment, there are massive failures with the `mypy` and `check-yaml` hooks. Not sure they are real failures though.

PS: I can send a new commit fixing the style but I wanted to ask if that is OK first b/c it will be a massive commit.