### PR TITLE
Attempt to Update upstream version process pool 

### DIFF
--- a/conda_forge_tick/new_update_versions.py
+++ b/conda_forge_tick/new_update_versions.py
@@ -78,7 +78,7 @@ def _update_upstream_versions_sequential(
     # print(f"Number of nodes: {len(gx.nodes)}")
     node_count = 0
     to_update = []
-    for node, node_attrs in tqdm.tqdm(_all_nodes):
+    for node, node_attrs in _all_nodes:
         with node_attrs["payload"] as attrs:
             if attrs.get("bad") or attrs.get("archived"):
                 continue

--- a/conda_forge_tick/new_update_versions.py
+++ b/conda_forge_tick/new_update_versions.py
@@ -65,11 +65,6 @@ CONDA_FORGE_TICK_DEBUG = os.environ.get("CONDA_FORGE_TICK_DEBUG", False)
 def _update_upstream_versions_sequential(
     gx: nx.DiGraph, sources: Iterable[AbstractSource] = None,
 ) -> None:
-    sources = (
-        (PyPI(), CRAN(), NPM(), ROSDistro(), RawURL(), Github())
-        if sources is None
-        else sources
-    )
 
     _all_nodes = [t for t in gx.nodes.items()]
     random.shuffle(_all_nodes)
@@ -119,6 +114,20 @@ def _update_upstream_versions_sequential(
             node_count += 1
 
 
+def update_upstream_versions(
+    gx: nx.DiGraph, sources: Iterable[AbstractSource] = None,
+) -> None:
+    sources = (
+        (PyPI(), CRAN(), NPM(), ROSDistro(), RawURL(), Github())
+        if sources is None
+        else sources
+    )
+    updater = _update_upstream_versions_sequential
+
+    logger.info("Updating upstream versions")
+    updater(gx, sources)
+
+
 def main(args: Any = None) -> None:
     if CONDA_FORGE_TICK_DEBUG:
         setup_logger(logger, level="debug")
@@ -132,7 +141,7 @@ def main(args: Any = None) -> None:
     # Check if 'versions' folder exists or create a new one;
     os.makedirs("versions", exist_ok=True)
     # call update
-    _update_upstream_versions_sequential(gx)
+    update_upstream_versions(gx)
 
 
 if __name__ == "__main__":

--- a/conda_forge_tick/new_update_versions.py
+++ b/conda_forge_tick/new_update_versions.py
@@ -62,7 +62,7 @@ def get_latest_version(
 CONDA_FORGE_TICK_DEBUG = os.environ.get("CONDA_FORGE_TICK_DEBUG", False)
 
 
-def new_update_upstream_versions(
+def _update_upstream_versions_sequential(
     gx: nx.DiGraph, sources: Iterable[AbstractSource] = None,
 ) -> None:
     sources = (
@@ -132,7 +132,7 @@ def main(args: Any = None) -> None:
     # Check if 'versions' folder exists or create a new one;
     os.makedirs("versions", exist_ok=True)
     # call update
-    new_update_upstream_versions(gx)
+    _update_upstream_versions_sequential(gx)
 
 
 if __name__ == "__main__":

--- a/conda_forge_tick/new_update_versions.py
+++ b/conda_forge_tick/new_update_versions.py
@@ -27,6 +27,11 @@ def get_latest_version(
     name: str, payload_meta_yaml: Any, sources: Iterable[AbstractSource],
 ) -> dict:
     version_data = {}
+    # avoid
+    if name == "ca-policy-lcg":
+        version_data["new_version"] = False
+        return version_data
+
     with payload_meta_yaml as meta_yaml:
         for source in sources:
             logger.debug("source: %s", source.__class__.__name__)
@@ -78,12 +83,6 @@ def _update_upstream_versions_sequential(
         with node_attrs as attrs:
             version_data = {}
 
-            # avoid
-            if node == "ca-policy-lcg":
-                version_data["new_version"] = False
-                node_count += 1
-                continue
-
             # New version request
             try:
                 # check for latest version
@@ -122,10 +121,7 @@ def _update_upstream_versions_process_pool(
             with node_attrs["payload"] as attrs:
                 if attrs.get("bad") or attrs.get("archived"):
                     continue
-                # avoid
-                if node == "ca-policy-lcg":
-                    attrs["new_version"] = False
-                    continue
+
                 futures.update(
                     {
                         pool.submit(get_latest_version, node, attrs, sources): (

--- a/conda_forge_tick/new_update_versions.py
+++ b/conda_forge_tick/new_update_versions.py
@@ -17,15 +17,7 @@ from .update_sources import (
     RawURL,
     Github,
 )
-from typing import (
-    Any,
-    Optional,
-    Iterable,
-    Set,
-    Iterator,
-    List,
-    Dict,
-)
+from typing import Any, Iterable
 
 # conda_forge_tick :: cft
 logger = logging.getLogger("conda-forge-tick._update_versions")

--- a/conda_forge_tick/new_update_versions.py
+++ b/conda_forge_tick/new_update_versions.py
@@ -183,8 +183,11 @@ def update_upstream_versions(
         if sources is None
         else sources
     )
-    updater = _update_upstream_versions_sequential
-
+    updater = (
+        _update_upstream_versions_sequential
+        if CONDA_FORGE_TICK_DEBUG
+        else _update_upstream_versions_process_pool
+    )
     logger.info("Updating upstream versions")
     updater(gx, sources)
 

--- a/conda_forge_tick/new_update_versions.py
+++ b/conda_forge_tick/new_update_versions.py
@@ -2,10 +2,12 @@ import networkx as nx
 import logging
 import random
 import json
+import time
 import os
 import tqdm
+from concurrent.futures import as_completed
 
-from .utils import setup_logger, load_graph
+from .utils import setup_logger, load_graph, executor
 from .update_sources import (
     AbstractSource,
     PyPI,


### PR DESCRIPTION
Due to the expensive time consuming usage of the actual `update upstream version` I've inserted the `pool` mode, as also, implements the function to choose the mode accordingly to the current `CONDA_FORGE_TICK_DEBUG` status.
See as references the issue [#842 ] and PR's [#1048 , #1043 ].