### PR TITLE
Changes to `max_workers`

### DIFF
--- a/conda_forge_tick/new_update_versions.py
+++ b/conda_forge_tick/new_update_versions.py
@@ -113,7 +113,7 @@ def _update_upstream_versions_process_pool(
     futures = {}
     # this has to be threads because the url hashing code uses a Pipe which
     # cannot be spawned from a process
-    with executor(kind="dask", max_workers=20) as pool:
+    with executor(kind="dask", max_workers=10) as pool:
         _all_nodes = [t for t in gx.nodes.items()]
         random.shuffle(_all_nodes)
 


### PR DESCRIPTION
Reduced the number of `workers` from 20 to 10. There were some memory problems with [Circle Ci](https://app.circleci.com/pipelines/github/regro/circle_worker/11168/workflows/88d4f002-22a5-4dbd-8848-e26a2c019099/jobs/27484).