### PR TITLE
Allow automerge for version or migrations only

### DIFF
--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -261,7 +261,8 @@ class MigrationYaml(GraphMigrator):
         if (
             feedstock_ctx.attrs.get("conda-forge.yml", {})
             .get("bot", {})
-            .get("automerge", False) in {'migration', True}
+            .get("automerge", False)
+            in {"migration", True}
         ) and self.automerge:
             add_slug = "[bot-automerge] "
         else:

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -261,7 +261,7 @@ class MigrationYaml(GraphMigrator):
         if (
             feedstock_ctx.attrs.get("conda-forge.yml", {})
             .get("bot", {})
-            .get("automerge", False)
+            .get("automerge", False) in {'migration', True}
         ) and self.automerge:
             add_slug = "[bot-automerge] "
         else:

--- a/conda_forge_tick/migrators/version.py
+++ b/conda_forge_tick/migrators/version.py
@@ -634,7 +634,7 @@ class Version(Migrator):
         if (
             feedstock_ctx.attrs.get("conda-forge.yml", {})
             .get("bot", {})
-            .get("automerge", False)
+            .get("automerge", False) in {'version', True}
         ):
             add_slug = "[bot-automerge] "
         else:

--- a/conda_forge_tick/migrators/version.py
+++ b/conda_forge_tick/migrators/version.py
@@ -631,11 +631,9 @@ class Version(Migrator):
     def pr_title(self, feedstock_ctx: FeedstockContext) -> str:
         assert isinstance(feedstock_ctx.attrs["new_version"], str)
         # TODO: turn False to True when we default to automerge
-        if (
-            feedstock_ctx.attrs.get("conda-forge.yml", {})
-            .get("bot", {})
-            .get("automerge", False) in {'version', True}
-        ):
+        if feedstock_ctx.attrs.get("conda-forge.yml", {}).get("bot", {}).get(
+            "automerge", False,
+        ) in {"version", True}:
             add_slug = "[bot-automerge] "
         else:
             add_slug = ""


### PR DESCRIPTION
Note that this will need a PR in webservices to make the most of this and some advertising.

The hope here is that ABI migration PRs are more likely to break if there are any changes that need to be applied to the feedstock. Enabling migration automerge will greatly speed up uptake of pins, similar to the R 4.0 migration.

@beckermr @isuruf @scopatz