### PR TITLE
run upstream update if bad is from upstream update

### DIFF
--- a/conda_forge_tick/new_update_versions.py
+++ b/conda_forge_tick/new_update_versions.py
@@ -74,7 +74,9 @@ def _update_upstream_versions_sequential(
     to_update = []
     for node, node_attrs in _all_nodes:
         with node_attrs["payload"] as attrs:
-            if attrs.get("bad") or attrs.get("archived"):
+            if (attrs.get("bad") and "Upstream" not in attrs["bad"]) or attrs.get(
+                "archived",
+            ):
                 continue
             to_update.append((node, attrs))
 
@@ -119,7 +121,9 @@ def _update_upstream_versions_process_pool(
 
         for node, node_attrs in tqdm.tqdm(_all_nodes):
             with node_attrs["payload"] as attrs:
-                if attrs.get("bad") or attrs.get("archived"):
+                if (attrs.get("bad") and "Upstream" not in attrs["bad"]) or attrs.get(
+                    "archived",
+                ):
                     continue
 
                 futures.update(


### PR DESCRIPTION
@beckermr @viniciusdc

I think this fixes the issues that a few maintainers have experienced with missing bot updates

closes https://github.com/regro/cf-scripts/issues/1072 (I think)