### PR TITLE
Changes to auto_tick profiler.

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -922,8 +922,8 @@ def main(args: "CLIArgs") -> None:
     prof.disable()
 
     # output to data
-    os.makedirs("profiler", exist_ok=True)
-    prof.dump_stats(f"profiler/auto_tick_{current_time}.")
+    os.makedirs("profiler/auto_tick", exist_ok=True)
+    prof.dump_stats(f"profiler/auto_tick/{current_time}.")
 
 
 if __name__ == "__main__":

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -721,9 +721,13 @@ def _compute_time_per_migrator(mctx):
 
 
 def main(args: "CLIArgs") -> None:
+    # get current time
+    now = datetime.now()
+    current_time = now.strftime("%d-%m-%Y") + "_" + now.strftime("%H_%M_%S")
+
     # start profiler
-    profile_profiler = cProfile.Profile()
-    profile_profiler.enable()
+    prof = cProfile.Profile()
+    prof.enable()
 
     # logging
     from .xonsh_utils import env
@@ -917,25 +921,11 @@ def main(args: "CLIArgs") -> None:
     logger.info("Done")
 
     # stop profiler
-    profile_profiler.disable()
-
-    # human readable
-    s_stream = io.StringIO()
-
-    # TODO: There are other ways to do this, with more freedom
-    profile_stats = pstats.Stats(profile_profiler, stream=s_stream).sort_stats(
-        "tottime",
-    )
-    profile_stats.print_stats()
-
-    # get current time
-    now = datetime.now()
-    current_time = now.strftime("%d-%m-%Y") + "_" + now.strftime("%H_%M_%S")
+    prof.disable()
 
     # output to data
     os.makedirs("profiler", exist_ok=True)
-    with open(f"profiler/{current_time}.txt", "w+") as f:
-        f.write(s_stream.getvalue())
+    prof.dump_stats(f"profiler/auto_tick_{current_time}.")
 
 
 if __name__ == "__main__":

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -12,8 +12,6 @@ from subprocess import SubprocessError, CalledProcessError
 
 from datetime import datetime
 import cProfile
-import pstats
-import io
 
 import networkx as nx
 from conda.models.version import VersionOrder


### PR DESCRIPTION
I've opted for `prof` instead of `profile_profiler`, removed the `print_stats` statements (and correlated). I will try  to use `dump_stats`  to enable further visualization of the information (if needed), and as the last update I've put a script/function name at the profile name to facilitate the inspection  and search for the any necessary files (principally when we have multiple profiler running).