### PR TITLE
Revert "only new versions"

### DIFF
--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -11,7 +11,6 @@ from typing import List, Optional
 import json
 import networkx as nx
 import requests
-from conda.models.version import VersionOrder
 from requests import Response
 
 from conda_forge_tick.profiler import profiling
@@ -243,16 +242,8 @@ def update_nodes_with_new_versions(gx):
     for file in list_files:
         node = str(file).replace(".json", "")
         with open(f"./versions/{file}") as json_file:
-            version_data: typing.Dict = json.load(json_file)
+            version_data = json.load(json_file)
         with gx.nodes[f"{node}"]["payload"] as attrs:
-            # don't update the version if it isn't newer
-            if version_data["new_version"]:
-                version_data["new_version"] = max(
-                    [version_data["new_version"], attrs["new_version"]],
-                    key=lambda x: VersionOrder(x.replace("-", ".")),
-                )
-            else:
-                version_data.pop("new_version")
             attrs.update(version_data)
 
 


### PR DESCRIPTION
Reverts regro/cf-scripts#1099

@CJ-Wright This has a bug. Killed the bot.