### PR TITLE
Fix profiler gen folder names

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -731,7 +731,7 @@ def _compute_time_per_migrator(mctx):
     return num_nodes, time_per_migrator, tot_time_per_migrator
 
 
-@profiling
+@profiling('auto_tick')
 def main(args: "CLIArgs") -> None:
     # start profiler
     profile_profiler = cProfile.Profile()

--- a/conda_forge_tick/cli.xsh
+++ b/conda_forge_tick/cli.xsh
@@ -30,6 +30,8 @@ def deploy(args):
                 ['git', 'add', 'audits/depfinder/*'],
                 ['git', 'add', 'versions/*'],
                 ['git', 'add', 'profiler/*'],
+                ['git', 'add', 'profiler/make_graph/*']
+                ['git', 'add', 'profiler/auto_tick/*']
                 ['git', 'add', 'mappings/*'],
                 ['git', 'add', 'mappings/pypi/*'],
                 ['git', 'commit', '-am', f'"Update Graph {$CIRCLE_BUILD_URL}"']]:

--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -259,7 +259,7 @@ def update_nodes_with_new_versions(gx):
             attrs.update(version_data)
 
 
-@profiling
+@profiling('make_graph')
 def main(args: "CLIArgs") -> None:
     setup_logger(logger)
 

--- a/conda_forge_tick/profiler.py
+++ b/conda_forge_tick/profiler.py
@@ -20,24 +20,27 @@ class Profiled(Profile):
         self.disable()
 
 
-def profiling(f):
-    @wraps(f)
-    def wrapper(*args, **kwargs):
-        # Profile dump information
-        # get current time
-        now = datetime.now()
-        current_time = now.strftime("%d-%m-%Y") + "_" + now.strftime("%H_%M_%S")
-        # process name -- aka profiler sub-folder
-        process_name = os.path.basename(inspect.getfile(f)).replace(".py", "")
-        # check dir
-        os.makedirs(f"profiler/{process_name}", exist_ok=True)
+def profiling(name: str = None):
+    def _profiling(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            # Profile dump information
+            # get current time
+            now = datetime.now()
+            current_time = now.strftime("%d-%m-%Y") + "_" + now.strftime("%H_%M_%S")
+            # process name -- aka profiler sub-folder
+            process_name = name
+            # check dir
+            os.makedirs(f"profiler/{process_name}", exist_ok=True)
 
-        profiled = Profiled()  # Create class instance.
-        with profiled():
-            out = f(*args, **kwargs)
-        # save stats into file
-        profiled.dump_stats(f"profiler/{process_name}/{current_time}")
+            profiled = Profiled()  # Create class instance.
+            with profiled():
+                out = f(*args, **kwargs)
+            # save stats into file
+            profiled.dump_stats(f"profiler/{process_name}/{current_time}")
 
-        return out
+            return out
 
-    return wrapper
+        return wrapper
+
+    return _profiling


### PR DESCRIPTION
Attempt to solve the problem with the missing folders of the respective processes under `profiler`.