### PR TITLE
Verify version order

### DIFF
--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -205,7 +205,9 @@ def make_graph(
 def update_nodes_with_bot_rerun(gx):
     """Go through all the open PRs and check if they are rerun"""
     for i, (name, node) in enumerate(gx.nodes.items()):
-        logger.info(f"node: {i} memory usage: {psutil.Process().memory_info().rss // 1024 ** 2}MB")
+        logger.info(
+            f"node: {i} memory usage: {psutil.Process().memory_info().rss // 1024 ** 2}MB",
+        )
         with node["payload"] as payload:
             for migration in payload.get("PRed", []):
                 try:

--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -28,7 +28,7 @@ def verify(version: str, next_version: str):
     """This function takes two versions strings and compare them.
     If either of these match, then the version bump is performed if they don't match, then it won't."""
 
-    pattern = r'\d+\.\d+\.[02468]'
+    pattern = r"\d+\.\d+\.[02468]"
     split_version = re.match(pattern, next_version)
     if split_version.group() > version:
         return True
@@ -96,8 +96,8 @@ def _update_upstream_versions_sequential(
             # check for latest version
             new_version = get_latest_version(node, attrs, sources)["new_version"]
             # if new_version is inferior or not totally released we set new_version value as version
-            if not verify(attrs.get('version'), new_version):
-                new_version = attrs.get('version')
+            if not verify(attrs.get("version"), new_version):
+                new_version = attrs.get("version")
             version_data.update(new_version)
         except Exception as e:
             try:

--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -4,6 +4,7 @@ import random
 import json
 import time
 import os
+import re
 import tqdm
 from concurrent.futures import as_completed
 
@@ -21,6 +22,17 @@ from typing import Any, Iterable
 
 # conda_forge_tick :: cft
 logger = logging.getLogger("conda-forge-tick._update_versions")
+
+
+def verify(version: str, next_version: str):
+    """This function takes two versions strings and compare them.
+    If either of these match, then the version bump is performed if they don't match, then it won't."""
+
+    pattern = r'\d+\.\d+\.[02468]'
+    split_version = re.match(pattern, next_version)
+    if split_version.group() > version:
+        return True
+    return False
 
 
 def get_latest_version(
@@ -82,7 +94,11 @@ def _update_upstream_versions_sequential(
         # New version request
         try:
             # check for latest version
-            version_data.update(get_latest_version(node, attrs, sources))
+            new_version = get_latest_version(node, attrs, sources)["new_version"]
+            # if new_version is inferior or not totally released we set new_version value as version
+            if not verify(attrs.get('version'), new_version):
+                new_version = attrs.get('version')
+            version_data.update(new_version)
         except Exception as e:
             try:
                 se = repr(e)

--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -29,10 +29,10 @@ def version_match(version, new_version: str, payload):
         If either of these match, then the version bump is performed if they don't match, then it won't."""
     # Example pattern \d+\.\d+\.[02468] TODO need to add an standard version parser when there isn't any given pattern
 
-    yml = payload.__getitem__('conda-forge.yml')
-    with yml['bot'] as bot:
-        if bot['version_pattern']:
-            split_version = re.match(bot.get('version_pattern'), new_version)
+    yml = payload.__getitem__("conda-forge.yml")
+    with yml["bot"] as bot:
+        if bot["version_pattern"]:
+            split_version = re.match(bot.get("version_pattern"), new_version)
             if split_version.group() > version:
                 return True
         else:

--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -29,7 +29,7 @@ def version_match(version, new_version: str, payload):
         If either of these match, then the version bump is performed if they don't match, then it won't."""
     # Example pattern \d+\.\d+\.[02468] TODO need to add an standard version parser when there isn't any given pattern
 
-    yml = payload.__getitem__("conda-forge.yml")
+    yml = payload["conda-forge.yml"]
     with yml["bot"] as bot:
         if bot["version_pattern"]:
             split_version = re.match(bot.get("version_pattern"), new_version)


### PR DESCRIPTION
inspects the `new_version` from `get_latest_version` and the current `version` strings, performing a regular expression match between them.

The goal here is to perform a string parse/ordering action inside the `new_version` string (when necessary e.g. the multiple releases of Vim) as a matter of solution to decrease the opened PR's of each new update. Also there is an open issue 1152 and this could be a solution.