### PR TITLE
Version migrator update with new filter extension

### DIFF
--- a/conda_forge_tick/migrators/version.py
+++ b/conda_forge_tick/migrators/version.py
@@ -432,9 +432,11 @@ class Version(Migrator):
                     for h in attrs.get("PRed", set())
                 )
                 # ...
-                or check_version_matches_cadence(str(attrs.get("version")),
-                                                 str(attrs["new_version"]),
-                                                 attrs["conda-forge.yml"].get("bot"))
+                or check_version_matches_cadence(
+                    str(attrs.get("version")),
+                    str(attrs["new_version"]),
+                    attrs["conda-forge.yml"].get("bot"),
+                )
             )
         except conda.exceptions.InvalidVersionSpec as e:
             warnings.warn(


### PR DESCRIPTION
The goal here is to perform a regular expression match between the new_version from get_latest_version and the current version strings using (when available) a given pattern. As an attempt/solution to decrease the opened PR's of each new update. 