### PR TITLE
ENH enable mirgations of build keys w/ compilers

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -454,7 +454,7 @@ def add_rebuild_migration_yaml(
     # build section in its place.
 
     feedstock_names = {output_to_feedstock.get(p, p) for p in package_names}
-    feedstock_names = {p for p in package_names if p in gx.nodes} - excluded_feedstocks
+    feedstock_names = {p for p in feedstock_names if p in gx.nodes} - excluded_feedstocks
 
     top_level = {
         node

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -459,8 +459,7 @@ def add_rebuild_migration_yaml(
     top_level = {
         node
         for node in {
-            gx.successors(feedstock_name)
-            for feedstock_name in feedstock_names
+            gx.successors(feedstock_name) for feedstock_name in feedstock_names
         }
         if (node in total_graph) and len(list(total_graph.predecessors(node))) == 0
     }

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -537,9 +537,8 @@ def migration_factory(
             package_names = set(migrator_config.get("override_cbc_keys"))
         else:
             package_names = (
-                (set(loaded_yaml) | {ly.replace("_", "-") for ly in loaded_yaml})
-                & all_package_names
-            )
+                set(loaded_yaml) | {ly.replace("_", "-") for ly in loaded_yaml}
+            ) & all_package_names
         package_names = package_names - excluded_feedstocks
 
         if not paused:

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -454,7 +454,9 @@ def add_rebuild_migration_yaml(
     # build section in its place.
 
     feedstock_names = {output_to_feedstock.get(p, p) for p in package_names}
-    feedstock_names = {p for p in feedstock_names if p in gx.nodes} - excluded_feedstocks
+    feedstock_names = {
+        p for p in feedstock_names if p in gx.nodes
+    } - excluded_feedstocks
 
     top_level = {
         node

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -534,7 +534,7 @@ def migration_factory(
         pr_limit = min(migrator_config.pop("pr_limit", pr_limit), MAX_PR_LIMIT)
 
         if "override_cbc_keys" in migrator_config:
-            package_names = set(migrator_config.get("package_names"))
+            package_names = set(migrator_config.get("override_cbc_keys"))
         else:
             package_names = (
                 (set(loaded_yaml) | {ly.replace("_", "-") for ly in loaded_yaml})

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -461,7 +461,7 @@ def add_rebuild_migration_yaml(
 
     if "override_cbc_keys" not in config:
         # this will fail if we've not used keys in the cbc that are actual
-        # packages in the graph - this we skip it in that case
+        # packages in the graph - thus we skip it in that case
         package_names = {
             p if p in gx.nodes else output_to_feedstock[p] for p in package_names
         } - excluded_feedstocks

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -10,12 +10,7 @@ import os
 import typing
 from subprocess import SubprocessError, CalledProcessError
 
-from datetime import datetime
-import cProfile
-import pstats
-import io
-
-from conda_forge_tick.profiler import profiling
+# from conda_forge_tick.profiler import profiling
 
 import networkx as nx
 from conda.models.version import VersionOrder
@@ -739,11 +734,8 @@ def _compute_time_per_migrator(mctx):
     return num_nodes, time_per_migrator, tot_time_per_migrator
 
 
-@profiling
+# @profiling
 def main(args: "CLIArgs") -> None:
-    # start profiler
-    profile_profiler = cProfile.Profile()
-    profile_profiler.enable()
 
     # logging
     from .xonsh_utils import env
@@ -962,27 +954,6 @@ def main(args: "CLIArgs") -> None:
             mctx.gh.rate_limit()["resources"]["core"]["remaining"],
         )
     logger.info("Done")
-
-    # stop profiler
-    profile_profiler.disable()
-
-    # human readable
-    s_stream = io.StringIO()
-
-    # TODO: There are other ways to do this, with more freedom
-    profile_stats = pstats.Stats(profile_profiler, stream=s_stream).sort_stats(
-        "tottime",
-    )
-    profile_stats.print_stats()
-
-    # get current time
-    now = datetime.now()
-    current_time = now.strftime("%d-%m-%Y") + "_" + now.strftime("%H_%M_%S")
-
-    # output to data
-    os.makedirs("profiler", exist_ok=True)
-    with open(f"profiler/{current_time}.txt", "w+") as f:
-        f.write(s_stream.getvalue())
 
 
 if __name__ == "__main__":

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -417,7 +417,6 @@ def create_rebuild_graph(
     package_names: Sequence[str],
     excluded_feedstocks: MutableSet[str] = None,
     include_noarch: bool = False,
-    include_by_build_only: bool = False,
 ) -> nx.DiGraph:
     total_graph = copy.deepcopy(gx)
     excluded_feedstocks = set() if excluded_feedstocks is None else excluded_feedstocks
@@ -430,10 +429,7 @@ def create_rebuild_graph(
         requirements = attrs.get("requirements", {})
         host = requirements.get("host", set())
         build = requirements.get("build", set())
-        if include_by_build_only:
-            bh = build
-        else:
-            bh = host or build
+        bh = host or build
         inclusion_criteria = bh & set(package_names) and (
             include_noarch
             or ("noarch" not in attrs.get("meta_yaml", {}).get("build", {}))

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -21,6 +21,7 @@ if typing.TYPE_CHECKING:
     from ..migrators_types import (
         MigrationUidTypedDict,
         AttrsTypedDict,
+        PackageName,
     )
 
 logger = logging.getLogger("conda_forge_tick.migrators.migration_yaml")
@@ -416,6 +417,7 @@ def create_rebuild_graph(
     package_names: Sequence[str],
     excluded_feedstocks: MutableSet[str] = None,
     include_noarch: bool = False,
+    include_by_build_only: bool = False,
 ) -> nx.DiGraph:
     total_graph = copy.deepcopy(gx)
     excluded_feedstocks = set() if excluded_feedstocks is None else excluded_feedstocks
@@ -428,7 +430,10 @@ def create_rebuild_graph(
         requirements = attrs.get("requirements", {})
         host = requirements.get("host", set())
         build = requirements.get("build", set())
-        bh = host or build
+        if include_by_build_only:
+            bh = build
+        else:
+            bh = host or build
         inclusion_criteria = bh & set(package_names) and (
             include_noarch
             or ("noarch" not in attrs.get("meta_yaml", {}).get("build", {}))

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -15,7 +15,7 @@ import logging
 import os
 import re
 from typing import Any, Tuple, Iterable, Union, Optional, IO, Set
-from collections.abc import MutableMapping, Set
+from collections.abc import MutableMapping
 from concurrent.futures import (
     ProcessPoolExecutor,
     ThreadPoolExecutor,
@@ -831,7 +831,8 @@ def load_feedstock(
     conda_forge_yaml: Optional[str] = None,
     mark_not_archived: bool = False,
 ):
-    """Load a feedstock into subgraph based on its name, if meta_yaml and conda_forge_yaml are provided
+    """Load a feedstock into subgraph based on its name, if meta_yaml and
+    conda_forge_yaml are provided
 
     Parameters
     ----------


### PR DESCRIPTION
This PR enables migrations of compilers via two new features in the migration yaml.

1. You can now add an `include_by_build_only` key which cases the bot to only look at build sections when figuring out if it should include a node in the graph. The bot still uses host+run+test for making edges.

2. You can now add an `override_cbc_keys` key which is a list of things that should appear in host/build for a package to be included in the migration. This will allow folks to list things like `fortran_compiler_stub` when migrating against the `fortran_compiler_version` key, for example.

This will also help the CUDA 11 migration if I am not mistaken. 

xref: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/794
xref: https://github.com/conda-forge/conda-forge.github.io/issues/1160