### PR TITLE
Check for solvable more frequently

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -231,7 +231,8 @@ def run(
     if (
         (
             migrator.check_solvable
-            and feedstock_ctx.attrs["conda-forge.yml"].get("bot", {}).get("automerge")
+            # for solveability always assume automerge is on.
+            and feedstock_ctx.attrs["conda-forge.yml"].get("bot", {}).get("automerge", True)
         )
         or feedstock_ctx.attrs["conda-forge.yml"]
         .get("bot", {})


### PR DESCRIPTION
Since we want to always check for solvability when doing migrations, actually do so.