### PR TITLE
BUG make sure to always add pinnings in the included nodes

### DIFF
--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -505,6 +505,7 @@ def create_rebuild_graph(
 
     # all nodes have the conda-forge-pinning as child package
     total_graph.add_edges_from([(n, "conda-forge-pinning") for n in total_graph.nodes])
+    included_nodes.add("conda-forge-pinning")  # it does not get added above
 
     # finally remove all nodes that should not be built from the graph
     for node in list(total_graph.nodes):


### PR DESCRIPTION
This PR makes sure to always include the pinnings feedstock in the included nodes for rebuilds. The bot is not issuing PRs to close migrations, and I think this is why. 