### PR TITLE
ENH skip cycles for solvable checks

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -236,6 +236,10 @@ def run(
 
     if (
         migrator.check_solvable
+        # we always let stuff in cycles go
+        and feedstock_ctx.attrs["name"] not in getattr(migrator, "cycles", set())
+        # we always let stuff at the top go
+        and feedstock_ctx.attrs["name"] not in getattr(migrator, "top_level", set())
         # for solveability always assume automerge is on.
         and feedstock_ctx.attrs["conda-forge.yml"].get("bot", {}).get("automerge", True)
     ) or feedstock_ctx.attrs["conda-forge.yml"].get("bot", {}).get(


### PR DESCRIPTION
We should skip the top-level and cycles for solvable checks.