### PR TITLE
Add pinning propogation to the mamba checks.

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -246,7 +246,7 @@ def run(
         "check_solvable",
         False,
     ):
-        solvable, errors = is_recipe_solvable(feedstock_dir)
+        solvable, errors, _ = is_recipe_solvable(feedstock_dir)
         if not solvable:
             pre_key = "pre_pr_migrator_status"
             if pre_key not in feedstock_ctx.attrs:

--- a/conda_forge_tick/mamba_solver.py
+++ b/conda_forge_tick/mamba_solver.py
@@ -238,6 +238,8 @@ def is_recipe_solvable(feedstock_dir) -> Tuple[bool, List[str], Dict[str, bool]]
         in the CI scripts.
     errors : list of str
         A list of errors from mamba. Empty if recipe is solvable.
+    solvable_by_variant : dict
+        A lookup by variant config that shows if a particular config is solvable
     """
 
     errors = []
@@ -249,7 +251,7 @@ def is_recipe_solvable(feedstock_dir) -> Tuple[bool, List[str], Dict[str, bool]]
             "This attempted migration is being reported as not solvable.",
         )
         logger.warning(errors[-1])
-        return False, errors
+        return False, errors, {}
 
     if not os.path.exists(os.path.join(feedstock_dir, "recipe", "meta.yaml")):
         errors.append(
@@ -257,7 +259,7 @@ def is_recipe_solvable(feedstock_dir) -> Tuple[bool, List[str], Dict[str, bool]]
             "someone should investigate!",
         )
         logger.warning(errors[-1])
-        return False, errors
+        return False, errors, {}
 
     solvable = True
     solvable_by_cbc = {}

--- a/conda_forge_tick/mamba_solver.py
+++ b/conda_forge_tick/mamba_solver.py
@@ -14,6 +14,7 @@ import logging
 import glob
 import functools
 import pprint
+from typing import Dict, Tuple, List
 
 from ruamel.yaml import YAML
 
@@ -217,7 +218,7 @@ def _mamba_factory(channels, platform):
     return MambaSolver(list(channels), platform)
 
 
-def is_recipe_solvable(feedstock_dir):
+def is_recipe_solvable(feedstock_dir) -> Tuple[bool, List[str], Dict[str, bool]]:
     """Compute if a recipe is solvable.
 
     We look through each of the conda build configs in the feedstock
@@ -259,6 +260,7 @@ def is_recipe_solvable(feedstock_dir):
         return False, errors
 
     solvable = True
+    solvable_by_cbc = {}
     for cbc_fname in cbcs:
         # we need to extract the platform (e.g., osx, linux) and arch (e.g., 64, aarm64)
         # conda smithy forms a string that is
@@ -282,8 +284,9 @@ def is_recipe_solvable(feedstock_dir):
         solvable = solvable and _solvable
         cbc_name = os.path.basename(cbc_fname).rsplit(".", maxsplit=1)[0]
         errors.extend([f"{cbc_name}: {e}" for e in _errors])
+        solvable_by_cbc[cbc_name] = _solvable
 
-    return solvable, errors
+    return solvable, errors, solvable_by_cbc
 
 
 def _clean_reqs(reqs, names):

--- a/conda_forge_tick/mamba_solver.py
+++ b/conda_forge_tick/mamba_solver.py
@@ -370,9 +370,15 @@ def _is_recipe_solvable_on_platform(recipe_dir, cbc_path, platform, arch):
             full_build_dep_versions = {
                 dep.split()[0]: " ".join(dep.split()[1:]) for dep in pin_deps
             }
-            pinned_req = [
-                get_pin_from_build(m, dep, full_build_dep_versions) for dep in reqs
-            ]
+            pinned_req = []
+            for dep in reqs:
+                try:
+                    pinned_req.append(
+                        get_pin_from_build(m, dep, full_build_dep_versions),
+                    )
+                except:
+                    # in case we couldn't apply pins for whatever reason, fall back to the req
+                    pinned_req.append(dep)
             return pinned_req
 
         run_req = m.get_value("requirements/run", [])

--- a/conda_forge_tick/mamba_solver.py
+++ b/conda_forge_tick/mamba_solver.py
@@ -280,7 +280,8 @@ def is_recipe_solvable(feedstock_dir):
             arch,
         )
         solvable = solvable and _solvable
-        errors.extend(["f{cbc_fname}: {e}" for e in _errors])
+        cbc_name = os.path.basename(cbc_fname).rsplit(".", maxsplit=1)[0]
+        errors.extend([f"{cbc_name}: {e}" for e in _errors])
 
     return solvable, errors
 
@@ -299,8 +300,6 @@ def _is_recipe_solvable_on_platform(recipe_dir, cbc_path, platform, arch):
 
     with open(cbc_path) as fp:
         cbc_cfg = parser.load(fp.read())
-
-    cbc_name = os.path.basename(cbc_path).rsplit(".", maxsplit=1)[0]
 
     if "channel_sources" in cbc_cfg:
         channel_sources = cbc_cfg["channel_sources"][0].split(",")
@@ -354,7 +353,7 @@ def _is_recipe_solvable_on_platform(recipe_dir, cbc_path, platform, arch):
             _solvable, _err = mamba_solver.solve(build_req)
             solvable = solvable and _solvable
             if _err is not None:
-                errors.append(cbc_name + ": " + _err)
+                errors.append(_err)
 
         host_req = m.get_value("requirements/host", [])
         if host_req:
@@ -362,7 +361,7 @@ def _is_recipe_solvable_on_platform(recipe_dir, cbc_path, platform, arch):
             _solvable, _err = mamba_solver.solve(host_req)
             solvable = solvable and _solvable
             if _err is not None:
-                errors.append(cbc_name + ": " + _err)
+                errors.append(_err)
 
         def apply_pins(reqs):
             from conda_build.render import get_pin_from_build
@@ -383,7 +382,7 @@ def _is_recipe_solvable_on_platform(recipe_dir, cbc_path, platform, arch):
             _solvable, _err = mamba_solver.solve(run_req)
             solvable = solvable and _solvable
             if _err is not None:
-                errors.append(cbc_name + ": " + _err)
+                errors.append(_err)
 
         tst_req = (
             m.get_value("test/requires", [])
@@ -395,6 +394,6 @@ def _is_recipe_solvable_on_platform(recipe_dir, cbc_path, platform, arch):
             _solvable, _err = mamba_solver.solve(tst_req)
             solvable = solvable and _solvable
             if _err is not None:
-                errors.append(cbc_name + ": " + _err)
+                errors.append(_err)
 
     return solvable, errors

--- a/tests/test_mamba_solvable.py
+++ b/tests/test_mamba_solvable.py
@@ -1,6 +1,8 @@
 import os
 
+import pathlib
 import pytest
+import shutil
 
 from conda_forge_tick.mamba_solver import is_recipe_solvable, _norm_spec
 
@@ -8,13 +10,22 @@ from conda_forge_tick.mamba_solver import is_recipe_solvable, _norm_spec
 FEEDSTOCK_DIR = os.path.join(os.path.dirname(__file__), "test_feedstock")
 
 
-def test_is_recipe_solvable_ok():
-    recipe_file = os.path.join(FEEDSTOCK_DIR, "recipe", "meta.yaml")
+@pytest.fixture()
+def feedstock_dir(tmp_path):
+    ci_support = tmp_path / ".ci_support"
+    ci_support.mkdir(exist_ok=True)
+    src_ci_support = pathlib.Path(FEEDSTOCK_DIR) / ".ci_support"
+    for fn in os.listdir(src_ci_support):
+        shutil.copy(src_ci_support / fn, ci_support / fn)
+    return str(tmp_path)
+
+
+def test_is_recipe_solvable_ok(feedstock_dir):
+    recipe_file = os.path.join(feedstock_dir, "recipe", "meta.yaml")
     os.makedirs(os.path.dirname(recipe_file), exist_ok=True)
-    try:
-        with open(recipe_file, "w") as fp:
-            fp.write(
-                """\
+    with open(recipe_file, "w") as fp:
+        fp.write(
+            """\
 {% set name = "cf-autotick-bot-test-package" %}
 {% set version = "0.9" %}
 
@@ -51,22 +62,67 @@ extra:
     - beckermr
     - conda-forge/bot
 """,
-            )
-        assert is_recipe_solvable(FEEDSTOCK_DIR)[0]
-    finally:
-        try:
-            os.remove(recipe_file)
-        except Exception:
-            pass
+        )
+    assert is_recipe_solvable(feedstock_dir)[0]
 
 
-def test_is_recipe_solvable_notok():
-    recipe_file = os.path.join(FEEDSTOCK_DIR, "recipe", "meta.yaml")
+def test_unsolvable_for_particular_python(feedstock_dir):
+    recipe_file = os.path.join(feedstock_dir, "recipe", "meta.yaml")
     os.makedirs(os.path.dirname(recipe_file), exist_ok=True)
-    try:
-        with open(recipe_file, "w") as fp:
-            fp.write(
-                """\
+    with open(recipe_file, "w") as fp:
+        fp.write(
+            """\
+{% set name = "cf-autotick-bot-test-package" %}
+{% set version = "0.9" %}
+
+package:
+    name: {{ name|lower }}
+    version: {{ version }}
+
+source:
+    path: .
+
+build:
+    number: 8
+
+requirements:
+    host:
+    - python
+    - pip
+    run:
+    - python
+    - asyncpg
+
+test:
+    commands:
+    - echo "works!"
+
+about:
+    home: https://github.com/regro/cf-scripts
+    license: BSD-3-Clause
+    license_family: BSD
+    license_file: LICENSE
+    summary: testing feedstock for the regro-cf-autotick-bot
+
+extra:
+    recipe-maintainers:
+    - beckermr
+    - conda-forge/bot
+""",
+        )
+    solvable, errors, solvable_by_variant = is_recipe_solvable(feedstock_dir)
+    print(solvable_by_variant)
+    assert not solvable
+    # we don't have asyncpg for this variant so this is an expected failure
+    assert not solvable_by_variant["linux_aarch64_python3.6.____cpython"]
+
+
+def test_is_recipe_solvable_notok(feedstock_dir):
+    recipe_file = os.path.join(feedstock_dir, "recipe", "meta.yaml")
+    os.makedirs(os.path.dirname(recipe_file), exist_ok=True)
+    with open(recipe_file, "w") as fp:
+        fp.write(
+            """\
 {% set name = "cf-autotick-bot-test-package" %}
 {% set version = "0.9" %}
 
@@ -104,13 +160,8 @@ extra:
     - beckermr
     - conda-forge/bot
 """,
-            )
-        assert not is_recipe_solvable(FEEDSTOCK_DIR)[0]
-    finally:
-        try:
-            os.remove(recipe_file)
-        except Exception:
-            pass
+        )
+    assert not is_recipe_solvable(feedstock_dir)[0]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mamba_solvable.py
+++ b/tests/test_mamba_solvable.py
@@ -115,6 +115,8 @@ extra:
     assert not solvable
     # we don't have asyncpg for this variant so this is an expected failure
     assert not solvable_by_variant["linux_aarch64_python3.6.____cpython"]
+    # But we do have this one
+    assert solvable_by_variant["linux_ppc64le_python3.6.____cpython"]
 
 
 def test_is_recipe_solvable_notok(feedstock_dir):


### PR DESCRIPTION
This will ensure that we don't issue a PR when not all python versions
have a valid run environment