### PR TITLE
DEP remove explicit pinning stuff since not needed

### DIFF
--- a/tests/test_mamba_solvable.py
+++ b/tests/test_mamba_solvable.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 import shutil
 from textwrap import dedent
+import subprocess
 
 import pytest
 
@@ -134,14 +135,11 @@ extra:
 
 
 def clone_and_checkout_repo(base_path: pathlib.Path, origin_url: str, ref: str):
-    from conda_forge_tick.git_xonsh_utils import fetch_repo
-
-    fetch_repo(
-        feedstock_dir=str(base_path / "repo"),
-        origin=origin_url,
-        upstream=origin_url,
-        branch=ref,
+    subprocess.run(
+        f"cd {base_path} && git clone --depth=1 {origin_url} repo",
+        shell=True,
     )
+
     return str(base_path / "repo")
 
 


### PR DESCRIPTION
This should fix the jpeg errors and avoid us having to maintain a list of openssl-like version schemes.