### PR TITLE
ENH swallow errors in license migrator

### DIFF
--- a/conda_forge_tick/migrators/license.py
+++ b/conda_forge_tick/migrators/license.py
@@ -160,13 +160,12 @@ def _scrape_license_string(pkg):
                     meta_yaml.append(line)
 
                 if line.startswith("# License:"):
-                    d["cran_license"] = line[len("# License:"):].strip()
+                    d["cran_license"] = line[len("# License:") :].strip()
 
     cmeta = CondaMetaYAML("".join(meta_yaml))
 
     d["license_file"] = [
-        lf
-        for lf in cmeta.meta.get("about", {}).get("license_file", [])
+        lf for lf in cmeta.meta.get("about", {}).get("license_file", [])
     ]
     if len(d["license_file"]) == 0:
         d["license_file"] = None

--- a/conda_forge_tick/migrators/license.py
+++ b/conda_forge_tick/migrators/license.py
@@ -160,11 +160,14 @@ def _scrape_license_string(pkg):
                     meta_yaml.append(line)
 
                 if line.startswith("# License:"):
-                    d["cran_license"] = line[len("# License:") :].strip()
+                    d["cran_license"] = line[len("# License:"):].strip()
 
     cmeta = CondaMetaYAML("".join(meta_yaml))
 
-    d["license_file"] = [l for l in cmeta.meta.get("about", {}).get("license_file", [])]
+    d["license_file"] = [
+        lf
+        for lf in cmeta.meta.get("about", {}).get("license_file", [])
+    ]
     if len(d["license_file"]) == 0:
         d["license_file"] = None
 
@@ -259,7 +262,10 @@ class LicenseMigrator(MiniMigrator):
             _do_r_license_munging(name, recipe_dir)
             return
 
-        cb_work_dir = _get_source_code(recipe_dir)
+        try:
+            cb_work_dir = _get_source_code(recipe_dir)
+        except Exception:
+            return
         if cb_work_dir is None:
             return
         with indir(cb_work_dir):


### PR DESCRIPTION
This PR will swallow download errors in the license mini-migrator.

cc @CJ-Wright 