### PR TITLE
BUG fix string bug in mamba solver

### DIFF
--- a/conda_forge_tick/mamba_solver.py
+++ b/conda_forge_tick/mamba_solver.py
@@ -279,6 +279,13 @@ def _get_run_exports(link_tuple):
                 run_exports = {}
 
             for key in DEFAULT_RUN_EXPORTS:
+                if key in run_exports:
+                    logger.debug(
+                        "RUN EXPORT: %s %s %s",
+                        pkg,
+                        key,
+                        run_exports.get(key, []),
+                    )
                 run_exports[key] = set(run_exports.get(key, []))
 
         except Exception as e:
@@ -451,10 +458,27 @@ class MambaSolver:
                                 self.run_exports[link_tuple] = copy.deepcopy(
                                     DEFAULT_RUN_EXPORTS,
                                 )
+                                if isinstance(rx, str):
+                                    # some packages have a single string
+                                    # eg pyqt
+                                    rx = [rx]
+
                                 for k in rx:
                                     if k in DEFAULT_RUN_EXPORTS:
+                                        logger.debug(
+                                            "RUN EXPORT: %s %s %s",
+                                            name,
+                                            k,
+                                            rx[k],
+                                        )
                                         self.run_exports[link_tuple][k].update(rx[k])
                                     else:
+                                        logger.debug(
+                                            "RUN EXPORT: %s %s %s",
+                                            name,
+                                            "weak",
+                                            [k],
+                                        )
                                         self.run_exports[link_tuple]["weak"].add(k)
 
                         elif version in cd_rx and FAST_RUN_EXPORTS:

--- a/tests/test_mamba_solvable.py
+++ b/tests/test_mamba_solvable.py
@@ -257,7 +257,7 @@ def test_arrow_solvable(tmp_path):
 
 
 def test_guiqwt_solvable(tmp_path):
-    """this has been throwing errors so test it"""
+    """test for run exports as a single string in pyqt"""
     feedstock_dir = clone_and_checkout_repo(
         tmp_path,
         "https://github.com/conda-forge/guiqwt-feedstock",

--- a/tests/test_mamba_solvable.py
+++ b/tests/test_mamba_solvable.py
@@ -256,6 +256,18 @@ def test_arrow_solvable(tmp_path):
     assert solvable
 
 
+def test_guiqwt_solvable(tmp_path):
+    """this has been throwing errors so test it"""
+    feedstock_dir = clone_and_checkout_repo(
+        tmp_path,
+        "https://github.com/conda-forge/guiqwt-feedstock",
+        ref="master",
+    )
+    solvable, errors, solvable_by_variant = is_recipe_solvable(feedstock_dir)
+    pprint.pprint(solvable_by_variant)
+    assert solvable
+
+
 def test_grpcio_solvable(tmp_path):
     """grpcio has a runtime dep on openssl which has strange pinning things in it"""
     feedstock_dir = clone_and_checkout_repo(


### PR DESCRIPTION
Sometimes libcfgraph has the run export as a single string. This catches that.