### PR TITLE
ENH compute recently closed migrations

### DIFF
--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -305,7 +305,8 @@ def _compute_recently_closed(total_status, old_closed_status, old_total_status):
         k: (
             k
             + " closed at "
-            + datetime.datetime.fromtimestamp(v).isoformat().replace("T", " ") + " UTC"
+            + datetime.datetime.fromtimestamp(v).isoformat().replace("T", " ")
+            + " UTC"
         )
         for k, v in closed_status.items()
     }

--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -7,6 +7,8 @@ from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import time
 
+import dateutil.parser
+import datetime
 import networkx as nx
 from graphviz import Source
 import tempfile
@@ -293,9 +295,20 @@ def _compute_recently_closed(total_status, old_closed_status, old_total_status):
     closed_status = {m: now for m in set(old_total_status) - set(total_status)}
 
     # grab anything rcent from previous stuff
-    for m, tm in old_closed_status.items():
+    for m, nm in old_closed_status.items():
+        tm = int(dateutil.parser.parse(nm.split(" closed at ", 1)[1]).timestamp())
         if m not in total_status and now - tm < two_weeks:
             closed_status[m] = tm
+
+    # now make it pretty
+    closed_status = {
+        k: (
+            k
+            + " closed at "
+            + datetime.datetime.fromtimestamp(v).isoformat().replace("T", " ") + " UTC"
+        )
+        for k, v in closed_status.items()
+    }
 
     return closed_status
 

--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -290,10 +290,7 @@ def _compute_recently_closed(total_status, old_closed_status, old_total_status):
     two_weeks = 14 * 24 * 60 * 60
 
     # grab any new stuff
-    closed_status = {
-        m: now
-        for m in set(old_total_status) - set(total_status)
-    }
+    closed_status = {m: now for m in set(old_total_status) - set(total_status)}
 
     # grab anything rcent from previous stuff
     for m, tm in old_closed_status.items():
@@ -313,12 +310,12 @@ def main(args: Any = None) -> None:
 
     # cache these for later
     if os.path.exists("status/closed_status.json"):
-        with open("status/closed_status.json", "r") as fp:
+        with open("status/closed_status.json") as fp:
             old_closed_status = json.load(fp)
     else:
         old_closed_status = {}
 
-    with open("status/total_status.json", "r") as fp:
+    with open("status/total_status.json") as fp:
         old_total_status = json.load(fp)
 
     mctx, *_, migrators = initialize_migrators()
@@ -398,7 +395,9 @@ def main(args: Any = None) -> None:
         json.dump(total_status, f, sort_keys=True, indent=2)
 
     closed_status = _compute_recently_closed(
-        total_status, old_closed_status, old_total_status
+        total_status,
+        old_closed_status,
+        old_total_status,
     )
     with open("./status/closed_status.json", "w") as f:
         json.dump(closed_status, f, sort_keys=True, indent=2)


### PR DESCRIPTION
This PR computes recently closed migrations. It compares the old status json to the new one and records anything not present. It then adds in stuff already closed in a two week window. Due to the way it works, it will be several weeks before the status page will get populated with these.