### PR TITLE
BUG fix requirement aggregation for Nones

### DIFF
--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -765,8 +765,9 @@ def populate_feedstock_attributes(
             # aggregated meta_yaml
             if "requirements" in varient_yamls[-1]:
                 for section in ["build", "host", "run"]:
-                    val = varient_yamls[-1]["requirements"].get(section, [])
-                    varient_yamls[-1]["requirements"][section] = val or []
+                    if section in varient_yamls[-1]["requirements"]:
+                        val = varient_yamls[-1]["requirements"].get(section, [])
+                        varient_yamls[-1]["requirements"][section] = val or []
 
             # collapse them down
             final_cfgs = {}

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -761,6 +761,13 @@ def populate_feedstock_attributes(
                 ),
             )
 
+            # sometimes the requirements come out to None and this ruins the
+            # aggregated meta_yaml
+            if "requirements" in varient_yamls[-1]:
+                for section in ["build", "host", "run"]:
+                    val = varient_yamls[-1]["requirements"].get(section, [])
+                    varient_yamls[-1]["requirements"][section] = val or []
+
             # collapse them down
             final_cfgs = {}
             for plat_arch, varyml in zip(plat_arch, varient_yamls):

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -765,6 +765,9 @@ def populate_feedstock_attributes(
             # aggregated meta_yaml
             if "requirements" in varient_yamls[-1]:
                 for section in ["build", "host", "run"]:
+                    # We make sure to set a section only if it is actually in
+                    # the recipe. Adding a section when it is not there might
+                    # confuse migrators trying to move CB2 recipes to CB3.
                     if section in varient_yamls[-1]["requirements"]:
                         val = varient_yamls[-1]["requirements"].get(section, [])
                         varient_yamls[-1]["requirements"][section] = val or []


### PR DESCRIPTION
It turns out when we use ChainDB for requirement aggregation, it makes a mess when aggregating `None` with lists. We get a `None` for a requirements section in some cases like this

```
requirements:
  build:
    - blah   # [not win]
```

When the selectors are evaluated, it leaves

```
requirements:
  build:
```

which results in a `None` for `build`. 

This PR fixes this issue by setting `None`s to empty lists if we find them.