### PR TITLE
BUG only purge the data in memory when leaving the context manager

### DIFF
--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -174,13 +174,14 @@ class LazyJson(MutableMapping):
                 print(os.listdir("."))
                 raise
 
-    def _dump(self) -> None:
+    def _dump(self, purge=False) -> None:
         self._load()
         with open(self.file_name, "w") as f:
             dump(self.data, f)
-        # this evicts the josn from memory and trades i/o for mem
-        # the bot uses too much mem if we don't do this
-        self.data = None
+        if purge:
+            # this evicts the josn from memory and trades i/o for mem
+            # the bot uses too much mem if we don't do this
+            self.data = None
 
     def __getitem__(self, item: Any) -> Any:
         self._load()
@@ -202,7 +203,7 @@ class LazyJson(MutableMapping):
         return self
 
     def __exit__(self, *args: Any) -> Any:
-        self._dump()
+        self._dump(purge=True)
 
 
 def render_meta_yaml(text: str, for_pinning=False, **kwargs) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,6 +25,19 @@ def test_lazy_json(tmpdir):
     assert not getattr(lj2, "data", None)
     assert lj2["hi"] == "globe"
 
+    with lj as attrs:
+        attrs.setdefault("lst", []).append("universe")
+    with open(f) as ff:
+        assert ff.read() == dumps({"hi": "globe", "lst": ["universe"]})
+
+    with lj as attrs:
+        attrs.setdefault("lst", []).append("universe")
+        with lj as attrs_again:
+            attrs_again.setdefault("lst", []).append("universe")
+            attrs.setdefault("lst", []).append("universe")
+    with open(f) as ff:
+        assert ff.read() == dumps({"hi": "globe", "lst": ["universe"] * 4})
+
 
 def test_get_requirements():
     meta_yaml = {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -38,6 +38,15 @@ def test_lazy_json(tmpdir):
     with open(f) as ff:
         assert ff.read() == dumps({"hi": "globe", "lst": ["universe"] * 4})
 
+    with lj as attrs:
+        with lj as attrs_again:
+            attrs_again.setdefault("lst2", []).append("universe")
+            attrs.setdefault("lst2", []).append("universe")
+    with open(f) as ff:
+        assert ff.read() == dumps(
+            {"hi": "globe", "lst": ["universe"] * 4, "lst2": ["universe"] * 2},
+        )
+
 
 def test_get_requirements():
     meta_yaml = {


### PR DESCRIPTION
This should fix #1269. Without this fix, setdefault does not work in the context manager and that is causing us to loose PRs when the initial list is empty, i.e. when a feedstock is brandnew.