### PR TITLE
ENH set outputs again

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,7 @@ repos:
       - id: codespell
         args:
           - --ignore-words-list=rever,pring,pullrequest,pullrequests
+  # - repo: https://gitlab.com/pycqa/flake8
+  #   rev: 3.8.4
+  #   hooks:
+  #     - id: flake8

--- a/conda_forge_tick/audit.py
+++ b/conda_forge_tick/audit.py
@@ -19,12 +19,12 @@ from conda_forge_tick.git_utils import feedstock_url, fetch_repo
 from conda_forge_tick.utils import (
     load_graph,
     dump,
-    load_feedstock,
     load,
     executor,
     as_iterable,
     _get_source_code,
 )
+from conda_forge_tick.feedstock_parser import load_feedstock
 from conda_forge_tick.xonsh_utils import indir, env
 
 DEPFINDER_IGNORE = [

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -663,7 +663,9 @@ def create_migration_yaml_creator(migrators: MutableSequence[Migrator], gx: nx.D
         # TODO - we are grabbing one element almost at random here
         # the sorted call makes it stable at least?
         fs_name = next(
-            iter(sorted(gx.graph["outputs_lut"].get(package_name, {package_name}))),
+            iter(
+                sorted(gx.graph["outputs_lut"].get(package_name, {package_name})),
+            ),
         )
 
         if (

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -9,6 +9,25 @@ import logging
 import os
 import typing
 from subprocess import CalledProcessError
+from typing import (
+    Optional,
+    MutableSequence,
+    MutableSet,
+    Sequence,
+    Tuple,
+    Set,
+    Mapping,
+    MutableMapping,
+    Union,
+)
+
+if typing.TYPE_CHECKING:
+    from .cli import CLIArgs
+    from .migrators_types import (
+        MetaYamlTypedDict,
+        PackageName,
+        MigrationUidTypedDict,
+    )
 
 # from conda_forge_tick.profiler import profiling
 
@@ -24,20 +43,19 @@ import ruamel.yaml as yaml
 from uuid import uuid4
 
 from conda_forge_tick.audit import create_package_import_maps
-from conda_forge_tick.migrators.arch import OSXArm
-from conda_forge_tick.migrators.migration_yaml import (
-    MigrationYamlCreator,
-    create_rebuild_graph,
-)
-from .xonsh_utils import indir
+from conda_forge_tick.xonsh_utils import indir, env
 
-from conda_forge_tick.contexts import FeedstockContext
-from .git_utils import (
+from conda_forge_tick.contexts import (
+    FeedstockContext,
+    MigratorSessionContext,
+    MigratorContext,
+)
+from conda_forge_tick.git_utils import (
     get_repo,
     push_repo,
     is_github_api_limit_reached,
 )
-from .utils import (
+from conda_forge_tick.utils import (
     setup_logger,
     pluck,
     load_graph,
@@ -47,22 +65,13 @@ from .utils import (
     parse_meta_yaml,
     eval_cmd,
     sanitize_string,
+    frozen_to_json_friendly,
 )
-from .xonsh_utils import env
-from typing import (
-    Optional,
-    MutableSequence,
-    MutableSet,
-    Sequence,
-    Tuple,
-    Set,
-    Mapping,
-    MutableMapping,
-    Union,
+from conda_forge_tick.migrators.arch import OSXArm
+from conda_forge_tick.migrators.migration_yaml import (
+    MigrationYamlCreator,
+    create_rebuild_graph,
 )
-
-from conda_forge_tick.utils import frozen_to_json_friendly
-from conda_forge_tick.contexts import MigratorSessionContext, MigratorContext
 from conda_forge_tick.migrators import (
     Migrator,
     Version,
@@ -85,15 +94,7 @@ from conda_forge_tick.migrators import (
 
 from conda_forge_tick.mamba_solver import is_recipe_solvable
 
-if typing.TYPE_CHECKING:
-    from .cli import CLIArgs
-    from .migrators_types import (
-        MetaYamlTypedDict,
-        PackageName,
-        MigrationUidTypedDict,
-    )
-
-logger = logging.getLogger("conda_forge_tick.auto_tick")
+LOGGER = logging.getLogger("conda_forge_tick.auto_tick")
 
 PR_LIMIT = 5
 MAX_PR_LIMIT = 50
@@ -170,7 +171,7 @@ def run(
         base_branch=base_branch,
     )
     if not feedstock_dir or not repo:
-        logger.critical(
+        LOGGER.critical(
             "Failed to migrate %s, %s",
             feedstock_ctx.package_name,
             feedstock_ctx.attrs.get("bad"),
@@ -187,7 +188,7 @@ def run(
     migrate_return = migrator.migrate(recipe_dir, feedstock_ctx.attrs, **kwargs)
 
     if not migrate_return:
-        logger.critical(
+        LOGGER.critical(
             "Failed to migrate %s, %s",
             feedstock_ctx.package_name,
             feedstock_ctx.attrs.get("bad"),
@@ -209,13 +210,13 @@ def run(
             eval_cmd("git add --all .")
             eval_cmd(f"git commit -am '{msg}'")
         except CalledProcessError as e:
-            logger.info(
+            LOGGER.info(
                 "could not commit to feedstock - "
                 "likely no changes - error is '%s'" % (repr(e)),
             )
         if rerender:
             head_ref = eval_cmd("git rev-parse HEAD").strip()
-            logger.info("Rerendering the feedstock")
+            LOGGER.info("Rerendering the feedstock")
 
             eval_cmd(
                 "conda smithy rerender -c auto --no-check-uptodate",
@@ -313,7 +314,7 @@ def run(
 
     # If we've gotten this far then the node is good
     feedstock_ctx.attrs["bad"] = False
-    logger.info("Removing feedstock dir")
+    LOGGER.info("Removing feedstock dir")
     eval_cmd(f"rm -rf {feedstock_dir}")
     return migrate_return, ljpr
 
@@ -603,7 +604,7 @@ def migration_factory(
                 pr_limit=pr_limit,
             )
         else:
-            logger.warning("skipping migration %s because it is paused", __mname)
+            LOGGER.warning("skipping migration %s because it is paused", __mname)
 
 
 def _outside_pin_range(pin_spec, current_pin, new_version):
@@ -627,30 +628,42 @@ def create_migration_yaml_creator(migrators: MutableSequence[Migrator], gx: nx.D
             config=Config(**CB_CONFIG),
         )
     feedstocks_to_be_repinned = []
-    for k, package_pin_list in pinnings.items():
+    for pinning_name, package_pin_list in pinnings.items():
+        # there are three things:
+        # pinning_name - entry in pinning file
+        # package_name - the actual package, could differ via `-` -> `_`
+        #                from pinning_name
+        # feedstock_name - the feedstock the outputs the package
         # we need the package names for the migrator itself but need the
         # feedstock for everything else
-        package_name = k
+
         # exclude non-package keys
-        if k not in gx.nodes and k not in gx.graph["outputs_lut"]:
+        if pinning_name not in gx.graph["outputs_lut"]:
             # conda_build_config.yaml can't have `-` unlike our package names
-            k = k.replace("_", "-")
+            package_name = pinning_name.replace("_", "-")
+        else:
+            package_name = pinning_name
+
         # replace sub-packages with their feedstock names
-        k = gx.graph["outputs_lut"].get(k, k)
+        # TODO - we are grabbing one element almost at random here
+        # the sorted call makes it stable at least?
+        fs_name = next(
+            iter(sorted(gx.graph["outputs_lut"].get(package_name, {package_name}))),
+        )
 
         if (
-            (k in gx.nodes)
-            and not gx.nodes[k]["payload"].get("archived", False)
-            and gx.nodes[k]["payload"].get("version")
-            and k not in feedstocks_to_be_repinned
+            (fs_name in gx.nodes)
+            and not gx.nodes[fs_name]["payload"].get("archived", False)
+            and gx.nodes[fs_name]["payload"].get("version")
+            and fs_name not in feedstocks_to_be_repinned
         ):
 
             current_pins = list(map(str, package_pin_list))
-            current_version = str(gx.nodes[k]["payload"]["version"])
+            current_version = str(gx.nodes[fs_name]["payload"]["version"])
 
             # we need a special parsing for pinning stuff
             meta_yaml = parse_meta_yaml(
-                gx.nodes[k]["payload"]["raw_meta_yaml"],
+                gx.nodes[fs_name]["payload"]["raw_meta_yaml"],
                 for_pinning=True,
             )
 
@@ -664,11 +677,12 @@ def create_migration_yaml_creator(migrators: MutableSequence[Migrator], gx: nx.D
                     for p in build.get("run_exports", [{}])
                     # make certain not direct hard pin
                     if isinstance(p, MutableMapping)
-                    # if the pinned package is in an output of the parent feedstock
+                    # ensure the export is for this package
+                    and p.get("package_name", "") == package_name
+                    # ensure the pinned package is in an output of the parent feedstock
                     and (
-                        gx.graph["outputs_lut"].get(p.get("package_name", ""), "") == k
-                        # if the pinned package is the feedstock itself
-                        or p.get("package_name", "") == k
+                        fs_name
+                        in gx.graph["outputs_lut"].get(p.get("package_name", ""), set())
                     )
                 ]
                 if not exports:
@@ -681,8 +695,10 @@ def create_migration_yaml_creator(migrators: MutableSequence[Migrator], gx: nx.D
             # fall back to the pinning file or "x"
             if not pin_spec:
                 pin_spec = (
-                    pinnings["pin_run_as_build"].get(k, {}).get("max_pin", "x") or "x"
-                )
+                    pinnings["pin_run_as_build"]
+                    .get(pinning_name, {})
+                    .get("max_pin", "x")
+                ) or "x"
 
             current_pins = list(
                 map(lambda x: re.sub("[^0-9.]", "", x).rstrip("."), current_pins),
@@ -699,7 +715,7 @@ def create_migration_yaml_creator(migrators: MutableSequence[Migrator], gx: nx.D
                 current_pin,
                 current_version,
             ):
-                feedstocks_to_be_repinned.append(k)
+                feedstocks_to_be_repinned.append(fs_name)
                 print(
                     "    %s:\n"
                     "        curr version: %s\n"
@@ -710,11 +726,11 @@ def create_migration_yaml_creator(migrators: MutableSequence[Migrator], gx: nx.D
                 )
                 migrators.append(
                     MigrationYamlCreator(
-                        package_name,
+                        pinning_name,
                         current_version,
                         current_pin,
                         pin_spec,
-                        k,
+                        fs_name,
                         gx,
                     ),
                 )
@@ -940,10 +956,10 @@ def main(args: "CLIArgs") -> None:
 
         # version debugging info
         if isinstance(migrator, Version):
-            logger.info("possible version migrations:")
+            LOGGER.info("possible version migrations:")
             for node_name in possible_nodes:
                 with effective_graph.nodes[node_name]["payload"] as attrs:
-                    logger.info(
+                    LOGGER.info(
                         "    node|curr|new|attempts: %s|%s|%s|%d",
                         node_name,
                         attrs.get("version"),
@@ -991,7 +1007,7 @@ def main(args: "CLIArgs") -> None:
                 try:
                     for base_branch in base_branches:
                         print("\n", flush=True, end="")
-                        logger.info(
+                        LOGGER.info(
                             "%s%s IS MIGRATING %s:%s",
                             migrator.__class__.__name__.upper(),
                             extra_name,
@@ -1038,14 +1054,14 @@ def main(args: "CLIArgs") -> None:
                             if e.msg == "Repository was archived so is read-only.":
                                 attrs["archived"] = True
                             else:
-                                logger.critical(
+                                LOGGER.critical(
                                     "GITHUB ERROR ON FEEDSTOCK: %s",
                                     fctx.feedstock_name,
                                 )
                                 if is_github_api_limit_reached(e, mctx.gh):
                                     break
                         except URLError as e:
-                            logger.exception("URLError ERROR")
+                            LOGGER.exception("URLError ERROR")
                             attrs["bad"] = {
                                 "exception": str(e),
                                 "traceback": str(traceback.format_exc()).split("\n"),
@@ -1064,7 +1080,7 @@ def main(args: "CLIArgs") -> None:
                                 ),
                             )
                         except Exception as e:
-                            logger.exception("NON GITHUB ERROR")
+                            LOGGER.exception("NON GITHUB ERROR")
                             attrs["bad"] = {
                                 "exception": str(e),
                                 "traceback": str(traceback.format_exc()).split("\n"),
@@ -1090,7 +1106,7 @@ def main(args: "CLIArgs") -> None:
                         dump_graph(mctx.graph)
 
                     eval_cmd(f"rm -rf {mctx.rever_dir}/*")
-                    logger.info(os.getcwd())
+                    LOGGER.info(os.getcwd())
                     for f in glob.glob("/tmp/*"):
                         if f not in temp:
                             try:
@@ -1103,8 +1119,8 @@ def main(args: "CLIArgs") -> None:
 
         print("\n", flush=True)
 
-    logger.info("API Calls Remaining: %d", mctx.gh_api_requests_left)
-    logger.info("Done")
+    LOGGER.info("API Calls Remaining: %d", mctx.gh_api_requests_left)
+    LOGGER.info("Done")
 
 
 if __name__ == "__main__":

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -633,7 +633,7 @@ def create_migration_yaml_creator(migrators: MutableSequence[Migrator], gx: nx.D
         # pinning_name - entry in pinning file
         # package_name - the actual package, could differ via `-` -> `_`
         #                from pinning_name
-        # feedstock_name - the feedstock the outputs the package
+        # feedstock_name - the feedstock that outputs the package
         # we need the package names for the migrator itself but need the
         # feedstock for everything else
 

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -736,7 +736,7 @@ def create_migration_yaml_creator(migrators: MutableSequence[Migrator], gx: nx.D
                     "        curr version: %s\n"
                     "        curr pin: %s\n"
                     "        pin_spec: %s"
-                    % (package_name, current_version, current_pin, pin_spec),
+                    % (pinning_name, current_version, current_pin, pin_spec),
                     flush=True,
                 )
                 migrators.append(

--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -23,7 +23,7 @@ if typing.TYPE_CHECKING:
 
 from .utils import as_iterable, parse_meta_yaml
 
-LOOGER = logging.getLogger("conda_forge_tick.feedstock_parser")
+LOGGER = logging.getLogger("conda_forge_tick.feedstock_parser")
 
 PIN_SEP_PAT = re.compile(r" |>|<|=|\[")
 
@@ -47,7 +47,6 @@ def _get_requirements(
         requirememts.
     build, host, run : `bool`
         include (`True`) or not (`False`) requirements from these sections
-
     Returns
     -------
     reqs : `set`
@@ -115,7 +114,7 @@ def _fetch_static_repo(name, dest):
         f"https://github.com/conda-forge/{name}-feedstock/archive/master.zip",
     )
     if r.status_code != 200:
-        LOOGER.error(
+        LOGGER.error(
             f"Something odd happened when fetching feedstock {name}: {r.status_code}",
         )
         return r
@@ -146,7 +145,7 @@ def populate_feedstock_attributes(
     If the return is bad hand the response itself in so that it can be parsed
     for meaning.
     """
-    sub_graph.update({"feedstock_name": name, "bad": False})
+    sub_graph.update({"feedstock_name": name, "bad": False, "branch": "master"})
 
     if mark_not_archived:
         sub_graph.update({"archived": False})
@@ -246,7 +245,7 @@ def populate_feedstock_attributes(
     sorted_varient_yamls = [x for _, x in sorted(zip(plat_arch, varient_yamls))]
     yaml_dict = ChainDB(*sorted_varient_yamls)
     if not yaml_dict:
-        LOOGER.error(f"Something odd happened when parsing recipe {name}")
+        LOGGER.error(f"Something odd happened when parsing recipe {name}")
         sub_graph["bad"] = "make_graph: Could not parse"
         return sub_graph
 
@@ -269,7 +268,7 @@ def populate_feedstock_attributes(
         sub_graph["outputs_names"] = set(
             list({d.get("name", "") for d in yaml_dict["outputs"]}),
         )
-    # one output so grab its name
+    # add in single package name
     else:
         sub_graph["outputs_names"] = {meta_yaml["package"]["name"]}
 

--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -1,0 +1,347 @@
+import collections.abc
+import glob
+import hashlib
+import tempfile
+import typing
+import zipfile
+import logging
+from collections import defaultdict
+import os
+import re
+from typing import Union, Set, Optional
+
+import requests
+import yaml
+
+from requests.models import Response
+from xonsh.lib.collections import _convert_to_dict, ChainDB
+
+if typing.TYPE_CHECKING:
+    from mypy_extensions import TestTypedDict
+    from .migrators_types import PackageName, RequirementsTypedDict
+    from conda_forge_tick.migrators_types import MetaYamlTypedDict
+
+from .utils import as_iterable, parse_meta_yaml
+
+LOOGER = logging.getLogger("conda_forge_tick.feedstock_parser")
+
+PIN_SEP_PAT = re.compile(r" |>|<|=|\[")
+
+
+def _get_requirements(
+    meta_yaml: "MetaYamlTypedDict",
+    outputs: bool = True,
+    build: bool = True,
+    host: bool = True,
+    run: bool = True,
+) -> "Set[PackageName]":
+    """Get the list of recipe requirements from a meta.yaml dict
+
+    Parameters
+    ----------
+    meta_yaml: `dict`
+        a parsed meta YAML dict
+    outputs : `bool`
+        if `True` (default) return top-level requirements _and_ all
+        requirements in `outputs`, otherwise just return top-level
+        requirememts.
+    build, host, run : `bool`
+        include (`True`) or not (`False`) requirements from these sections
+
+    Returns
+    -------
+    reqs : `set`
+        the set of recipe requirements
+    """
+    kw = dict(build=build, host=host, run=run)
+    reqs = _parse_requirements(meta_yaml.get("requirements", {}), **kw)
+    outputs_ = meta_yaml.get("outputs", []) or [] if outputs else []
+    for output in outputs_:
+        for req in _parse_requirements(output.get("requirements", {}) or {}, **kw):
+            reqs.add(req)
+    return reqs
+
+
+def _parse_requirements(
+    req: Union[None, typing.List[str], "RequirementsTypedDict"],
+    build: bool = True,
+    host: bool = True,
+    run: bool = True,
+) -> typing.MutableSet["PackageName"]:
+    """Flatten a YAML requirements section into a list of names"""
+    if not req:  # handle None as empty
+        return set()
+    if isinstance(req, list):  # simple list goes to both host and run
+        reqlist = req if (host or run) else []
+    else:
+        _build = list(as_iterable(req.get("build", []) or [] if build else []))
+        _host = list(as_iterable(req.get("host", []) or [] if host else []))
+        _run = list(as_iterable(req.get("run", []) or [] if run else []))
+        reqlist = _build + _host + _run
+
+    packages = (PIN_SEP_PAT.split(x)[0].lower() for x in reqlist if x is not None)
+    return {typing.cast("PackageName", pkg) for pkg in packages}
+
+
+def _extract_requirements(meta_yaml):
+    strong_exports = False
+    requirements_dict = defaultdict(set)
+    for block in [meta_yaml] + meta_yaml.get("outputs", []) or []:
+        req: "RequirementsTypedDict" = block.get("requirements", {}) or {}
+        if isinstance(req, list):
+            requirements_dict["run"].update(set(req))
+            continue
+        for section in ["build", "host", "run"]:
+            requirements_dict[section].update(
+                list(as_iterable(req.get(section, []) or [])),
+            )
+        test: "TestTypedDict" = block.get("test", {})
+        requirements_dict["test"].update(test.get("requirements", []) or [])
+        requirements_dict["test"].update(test.get("requires", []) or [])
+        run_exports = (block.get("build", {}) or {}).get("run_exports", {})
+        if isinstance(run_exports, dict) and run_exports.get("strong"):
+            strong_exports = True
+    for k in list(requirements_dict.keys()):
+        requirements_dict[k] = {v for v in requirements_dict[k] if v}
+    req_no_pins = {
+        k: {PIN_SEP_PAT.split(x)[0].lower() for x in v}
+        for k, v in dict(requirements_dict).items()
+    }
+    return dict(requirements_dict), req_no_pins, strong_exports
+
+
+def _fetch_static_repo(name, dest):
+    r = requests.get(
+        f"https://github.com/conda-forge/{name}-feedstock/archive/master.zip",
+    )
+    if r.status_code != 200:
+        LOOGER.error(
+            f"Something odd happened when fetching feedstock {name}: {r.status_code}",
+        )
+        return r
+
+    zname = os.path.join(dest, f"{name}-feedstock-master.zip")
+
+    with open(zname, "wb") as fp:
+        fp.write(r.content)
+
+    z = zipfile.ZipFile(zname)
+    z.extractall(path=dest)
+    dest_dir = os.path.join(dest, os.path.split(z.namelist()[0])[0])
+    return dest_dir
+
+
+def populate_feedstock_attributes(
+    name: str,
+    sub_graph: typing.MutableMapping,
+    meta_yaml: typing.Union[str, Response] = "",
+    conda_forge_yaml: typing.Union[str, Response] = "",
+    mark_not_archived=False,
+    feedstock_dir=None,
+) -> typing.MutableMapping:
+    """Parse the various configuration information into something usable
+
+    Notes
+    -----
+    If the return is bad hand the response itself in so that it can be parsed
+    for meaning.
+    """
+    sub_graph.update({"feedstock_name": name, "bad": False})
+
+    if mark_not_archived:
+        sub_graph.update({"archived": False})
+
+    # handle all the raw strings
+    if isinstance(meta_yaml, Response):
+        sub_graph["bad"] = f"make_graph: {meta_yaml.status_code}"
+        return sub_graph
+    sub_graph["raw_meta_yaml"] = meta_yaml
+
+    # Get the conda-forge.yml
+    if isinstance(conda_forge_yaml, str):
+        sub_graph["conda-forge.yml"] = {
+            k: v
+            for k, v in yaml.safe_load(conda_forge_yaml).items()
+            if k
+            in {
+                "provider",
+                "min_r_ver",
+                "min_py_ver",
+                "max_py_ver",
+                "max_r_ver",
+                "compiler_stack",
+                "bot",
+            }
+        }
+
+    if (
+        feedstock_dir is not None
+        and len(glob.glob(os.path.join(feedstock_dir, ".ci_support", "*.yaml"))) > 0
+    ):
+        recipe_dir = os.path.join(feedstock_dir, "recipe")
+        ci_support_files = glob.glob(
+            os.path.join(feedstock_dir, ".ci_support", "*.yaml"),
+        )
+        varient_yamls = []
+        plat_arch = []
+        for cbc_path in ci_support_files:
+            cbc_name = os.path.basename(cbc_path)
+            cbc_name_parts = cbc_name.replace(".yaml", "").split("_")
+            plat = cbc_name_parts[0]
+            if len(cbc_name_parts) == 1:
+                arch = "64"
+            else:
+                if cbc_name_parts[1] in ["64", "aarch64", "ppc64le", "arm64"]:
+                    arch = cbc_name_parts[1]
+                else:
+                    arch = "64"
+            plat_arch.append((plat, arch))
+
+            varient_yamls.append(
+                parse_meta_yaml(
+                    meta_yaml,
+                    platform=plat,
+                    arch=arch,
+                    recipe_dir=recipe_dir,
+                    cbc_path=cbc_path,
+                ),
+            )
+
+            # sometimes the requirements come out to None and this ruins the
+            # aggregated meta_yaml
+            if "requirements" in varient_yamls[-1]:
+                for section in ["build", "host", "run"]:
+                    # We make sure to set a section only if it is actually in
+                    # the recipe. Adding a section when it is not there might
+                    # confuse migrators trying to move CB2 recipes to CB3.
+                    if section in varient_yamls[-1]["requirements"]:
+                        val = varient_yamls[-1]["requirements"].get(section, [])
+                        varient_yamls[-1]["requirements"][section] = val or []
+
+            # collapse them down
+            final_cfgs = {}
+            for plat_arch, varyml in zip(plat_arch, varient_yamls):
+                if plat_arch not in final_cfgs:
+                    final_cfgs[plat_arch] = []
+                final_cfgs[plat_arch].append(varyml)
+            for k in final_cfgs:
+                ymls = final_cfgs[k]
+                final_cfgs[k] = _convert_to_dict(ChainDB(*ymls))
+            plat_arch = []
+            varient_yamls = []
+            for k, v in final_cfgs.items():
+                plat_arch.append(k)
+                varient_yamls.append(v)
+    else:
+        plat_arch = [("win", "64"), ("osx", "64"), ("linux", "64")]
+        for k in set(sub_graph["conda-forge.yml"].get("provider", {})):
+            if "_" in k:
+                plat_arch.append(k.split("_"))
+        varient_yamls = [
+            parse_meta_yaml(meta_yaml, platform=plat, arch=arch)
+            for plat, arch in plat_arch
+        ]
+
+    # this makes certain that we have consistent ordering
+    sorted_varient_yamls = [x for _, x in sorted(zip(plat_arch, varient_yamls))]
+    yaml_dict = ChainDB(*sorted_varient_yamls)
+    if not yaml_dict:
+        LOOGER.error(f"Something odd happened when parsing recipe {name}")
+        sub_graph["bad"] = "make_graph: Could not parse"
+        return sub_graph
+
+    sub_graph["meta_yaml"] = _convert_to_dict(yaml_dict)
+    meta_yaml = sub_graph["meta_yaml"]
+
+    for k, v in zip(plat_arch, varient_yamls):
+        plat_arch_name = "_".join(k)
+        sub_graph[f"{plat_arch_name}_meta_yaml"] = v
+        _, sub_graph[f"{plat_arch_name}_requirements"], _ = _extract_requirements(v)
+
+    (
+        sub_graph["total_requirements"],
+        sub_graph["requirements"],
+        sub_graph["strong_exports"],
+    ) = _extract_requirements(meta_yaml)
+
+    # handle multi outputs
+    if "outputs" in yaml_dict:
+        sub_graph["outputs_names"] = set(
+            list({d.get("name", "") for d in yaml_dict["outputs"]}),
+        )
+    # one output so grab its name
+    else:
+        sub_graph["outputs_names"] = {meta_yaml["package"]["name"]}
+
+    # TODO: Write schema for dict
+    # TODO: remove this
+    req = _get_requirements(yaml_dict)
+    sub_graph["req"] = req
+
+    keys = [("package", "name"), ("package", "version")]
+    missing_keys = [k[1] for k in keys if k[1] not in yaml_dict.get(k[0], {})]
+    source = yaml_dict.get("source", [])
+    if isinstance(source, collections.abc.Mapping):
+        source = [source]
+    source_keys: Set[str] = set()
+    for s in source:
+        if not sub_graph.get("url"):
+            sub_graph["url"] = s.get("url")
+        source_keys |= s.keys()
+    for k in keys:
+        if k[1] not in missing_keys:
+            sub_graph[k[1]] = yaml_dict[k[0]][k[1]]
+    kl = list(sorted(source_keys & hashlib.algorithms_available, reverse=True))
+    if kl:
+        sub_graph["hash_type"] = kl[0]
+    return sub_graph
+
+
+def load_feedstock(
+    name: str,
+    sub_graph: typing.MutableMapping,
+    meta_yaml: Optional[str] = None,
+    conda_forge_yaml: Optional[str] = None,
+    mark_not_archived: bool = False,
+):
+    """Load a feedstock into subgraph based on its name, if meta_yaml and
+    conda_forge_yaml are provided
+
+    Parameters
+    ----------
+    name : str
+        Name of the feedstock
+    sub_graph : MutableMapping
+        The existing metadata if any
+    meta_yaml : Optional[str]
+        The string meta.yaml, overrides the file in the feedstock if provided
+    conda_forge_yaml : Optional[str]
+        The string conda-forge.yaml, overrides the file in the feedstock if provided
+    mark_not_archived
+
+    Returns
+    -------
+    sub_graph : MutableMapping
+        The sub_graph, now updated with the feedstock metadata
+    """
+    # pull down one copy of the repo
+    with tempfile.TemporaryDirectory() as tmpdir:
+        feedstock_dir = _fetch_static_repo(name, tmpdir)
+
+        if meta_yaml is None:
+            with open(os.path.join(feedstock_dir, "recipe", "meta.yaml")) as fp:
+                meta_yaml = fp.read()
+
+        if conda_forge_yaml is None:
+            with open(os.path.join(feedstock_dir, "conda-forge.yml")) as fp:
+                conda_forge_yaml = fp.read()
+
+        populate_feedstock_attributes(
+            name,
+            sub_graph,
+            meta_yaml=meta_yaml,
+            conda_forge_yaml=conda_forge_yaml,
+            mark_not_archived=mark_not_archived,
+            feedstock_dir=feedstock_dir,
+        )
+    return sub_graph

--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -27,6 +27,16 @@ LOGGER = logging.getLogger("conda_forge_tick.feedstock_parser")
 
 PIN_SEP_PAT = re.compile(r" |>|<|=|\[")
 
+CONDA_FORGE_YML_KEYS_TO_KEEP = (
+    "provider",
+    "min_r_ver",
+    "min_py_ver",
+    "max_py_ver",
+    "max_r_ver",
+    "compiler_stack",
+    "bot",
+)
+
 
 def _get_requirements(
     meta_yaml: "MetaYamlTypedDict",
@@ -161,16 +171,7 @@ def populate_feedstock_attributes(
         sub_graph["conda-forge.yml"] = {
             k: v
             for k, v in yaml.safe_load(conda_forge_yaml).items()
-            if k
-            in {
-                "provider",
-                "min_r_ver",
-                "min_py_ver",
-                "max_py_ver",
-                "max_r_ver",
-                "compiler_stack",
-                "bot",
-            }
+            if k in CONDA_FORGE_YML_KEYS_TO_KEEP
         }
 
     if (

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -497,7 +497,7 @@ def close_out_dirty_prs(
                 delete_branch(ctx=ctx, pr_json=pr_json, dry_run=dry_run)
                 pr_obj.refresh(True)
                 d = pr_obj.as_dict()
-                # This will cause the update_nodes_with_bot_rerun to trigger
+                # This will cause the _update_nodes_with_bot_rerun to trigger
                 # properly and shouldn't be overridden since
                 # this is the last function to run, the long term solution here
                 # is to add the bot to conda-forge and then

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -22,6 +22,7 @@ from conda_forge_tick.utils import (
     frozen_to_json_friendly,
     LazyJson,
 )
+from conda_forge_tick.make_graph import make_outputs_lut_from_graph
 from conda_forge_tick.contexts import MigratorContext, FeedstockContext
 
 if typing.TYPE_CHECKING:
@@ -451,11 +452,7 @@ class GraphMigrator(Migrator):
         if "outputs_lut" in self.graph.graph:
             self.outputs_lut = self.graph.graph["outputs_lut"]
         else:
-            self.outputs_lut = {
-                k: node_name
-                for node_name, node in self.graph.nodes.items()
-                for k in node.get("payload", {}).get("outputs_names", [])
-            }
+            self.outputs_lut = make_outputs_lut_from_graph(self.graph)
 
         self.name = name
         self.top_level = top_level or set()

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -1,11 +1,6 @@
-import collections.abc
 import datetime
-import glob
-import hashlib
-import tempfile
 import typing
 import copy
-import zipfile
 from collections.abc import Callable
 from collections import defaultdict
 import contextlib
@@ -13,7 +8,6 @@ import itertools
 import rapidjson as json
 import logging
 import os
-import re
 from typing import Any, Tuple, Iterable, Union, Optional, IO, Set
 from collections.abc import MutableMapping
 from concurrent.futures import (
@@ -26,18 +20,14 @@ import subprocess
 import github3
 import jinja2
 import boto3
-import requests
 import yaml
 
 import networkx as nx
-from requests.models import Response
-from xonsh.lib.collections import _convert_to_dict, ChainDB
 
 from . import sensitive_env
 
 if typing.TYPE_CHECKING:
-    from mypy_extensions import TypedDict, TestTypedDict
-    from .migrators_types import PackageName, RequirementsTypedDict
+    from mypy_extensions import TypedDict
     from conda_forge_tick.migrators_types import MetaYamlTypedDict
 
 
@@ -45,8 +35,6 @@ logger = logging.getLogger("conda_forge_tick.utils")
 
 T = typing.TypeVar("T")
 TD = typing.TypeVar("TD", bound=dict, covariant=True)
-
-pin_sep_pat = re.compile(r" |>|<|=|\[")
 
 PACKAGE_STUBS = [
     "_compiler_stub",
@@ -78,6 +66,100 @@ CB_CONFIG_PINNING = dict(
     cran_mirror="https://cran.r-project.org",
     datetime=datetime,
 )
+
+
+def render_meta_yaml(text: str, for_pinning=False, **kwargs) -> str:
+    """Render the meta.yaml with Jinja2 variables.
+
+    Parameters
+    ----------
+    text : str
+        The raw text in conda-forge feedstock meta.yaml file
+
+    Returns
+    -------
+    str
+        The text of the meta.yaml with Jinja2 variables replaced.
+
+    """
+
+    cfg = dict(**kwargs)
+
+    env = jinja2.Environment(undefined=NullUndefined)
+    if for_pinning:
+        cfg.update(**CB_CONFIG_PINNING)
+    else:
+        cfg.update(**CB_CONFIG)
+
+    return env.from_string(text).render(**cfg)
+
+
+def parse_meta_yaml(
+    text: str,
+    for_pinning=False,
+    platform=None,
+    arch=None,
+    recipe_dir=None,
+    cbc_path=None,
+    **kwargs: Any,
+) -> "MetaYamlTypedDict":
+    """Parse the meta.yaml.
+
+    Parameters
+    ----------
+    text : str
+        The raw text in conda-forge feedstock meta.yaml file
+
+    Returns
+    -------
+    dict :
+        The parsed YAML dict. If parsing fails, returns an empty dict.
+
+    """
+    from conda_build.config import Config
+    from conda_build.metadata import parse, ns_cfg
+
+    if (
+        recipe_dir is not None
+        and cbc_path is not None
+        and arch is not None
+        and platform is not None
+    ):
+        cbc = Config(
+            platform=platform,
+            arch=arch,
+            variant_config_files=[cbc_path],
+            **kwargs,
+        )
+
+        cfg_as_dict = ns_cfg(cbc)
+        with open(cbc_path) as fp:
+            _cfg_as_dict = yaml.safe_load(fp)
+        for k, v in _cfg_as_dict.items():
+            if (
+                isinstance(v, list)
+                and not isinstance(v, str)
+                and len(v) > 0
+                and k not in ["zip_keys", "pin_run_as_build"]
+            ):
+                v = v[0]
+
+            cfg_as_dict[k] = v
+    else:
+        _cfg = {}
+        _cfg.update(kwargs)
+        if platform is not None:
+            _cfg["platform"] = platform
+        if arch is not None:
+            _cfg["arch"] = arch
+        cbc = Config(**_cfg)
+        cfg_as_dict = {}
+
+    if for_pinning:
+        content = render_meta_yaml(text, for_pinning=for_pinning, **cfg_as_dict)
+    else:
+        content = render_meta_yaml(text, **cfg_as_dict)
+    return parse(content, cbc)
 
 
 def eval_cmd(cmd, **kwargs):
@@ -206,100 +288,6 @@ class LazyJson(MutableMapping):
         self._dump(purge=True)
 
 
-def render_meta_yaml(text: str, for_pinning=False, **kwargs) -> str:
-    """Render the meta.yaml with Jinja2 variables.
-
-    Parameters
-    ----------
-    text : str
-        The raw text in conda-forge feedstock meta.yaml file
-
-    Returns
-    -------
-    str
-        The text of the meta.yaml with Jinja2 variables replaced.
-
-    """
-
-    cfg = dict(**kwargs)
-
-    env = jinja2.Environment(undefined=NullUndefined)
-    if for_pinning:
-        cfg.update(**CB_CONFIG_PINNING)
-    else:
-        cfg.update(**CB_CONFIG)
-
-    return env.from_string(text).render(**cfg)
-
-
-def parse_meta_yaml(
-    text: str,
-    for_pinning=False,
-    platform=None,
-    arch=None,
-    recipe_dir=None,
-    cbc_path=None,
-    **kwargs: Any,
-) -> "MetaYamlTypedDict":
-    """Parse the meta.yaml.
-
-    Parameters
-    ----------
-    text : str
-        The raw text in conda-forge feedstock meta.yaml file
-
-    Returns
-    -------
-    dict :
-        The parsed YAML dict. If parsing fails, returns an empty dict.
-
-    """
-    from conda_build.config import Config
-    from conda_build.metadata import parse, ns_cfg
-
-    if (
-        recipe_dir is not None
-        and cbc_path is not None
-        and arch is not None
-        and platform is not None
-    ):
-        cbc = Config(
-            platform=platform,
-            arch=arch,
-            variant_config_files=[cbc_path],
-            **kwargs,
-        )
-
-        cfg_as_dict = ns_cfg(cbc)
-        with open(cbc_path) as fp:
-            _cfg_as_dict = yaml.safe_load(fp)
-        for k, v in _cfg_as_dict.items():
-            if (
-                isinstance(v, list)
-                and not isinstance(v, str)
-                and len(v) > 0
-                and k not in ["zip_keys", "pin_run_as_build"]
-            ):
-                v = v[0]
-
-            cfg_as_dict[k] = v
-    else:
-        _cfg = {}
-        _cfg.update(kwargs)
-        if platform is not None:
-            _cfg["platform"] = platform
-        if arch is not None:
-            _cfg["arch"] = arch
-        cbc = Config(**_cfg)
-        cfg_as_dict = {}
-
-    if for_pinning:
-        content = render_meta_yaml(text, for_pinning=for_pinning, **cfg_as_dict)
-    else:
-        content = render_meta_yaml(text, **cfg_as_dict)
-    return parse(content, cbc)
-
-
 def setup_logger(logger: logging.Logger, level: Optional[str] = "INFO") -> None:
     """Basic configuration for logging"""
     logger.setLevel(level.upper())
@@ -335,61 +323,6 @@ def pluck(G: nx.DiGraph, node_id: Any) -> None:
         )
         G.remove_node(node_id)
         G.add_edges_from(new_edges)
-
-
-def get_requirements(
-    meta_yaml: "MetaYamlTypedDict",
-    outputs: bool = True,
-    build: bool = True,
-    host: bool = True,
-    run: bool = True,
-) -> "Set[PackageName]":
-    """Get the list of recipe requirements from a meta.yaml dict
-
-    Parameters
-    ----------
-    meta_yaml: `dict`
-        a parsed meta YAML dict
-    outputs : `bool`
-        if `True` (default) return top-level requirements _and_ all
-        requirements in `outputs`, otherwise just return top-level
-        requirememts.
-    build, host, run : `bool`
-        include (`True`) or not (`False`) requirements from these sections
-
-    Returns
-    -------
-    reqs : `set`
-        the set of recipe requirements
-    """
-    kw = dict(build=build, host=host, run=run)
-    reqs = _parse_requirements(meta_yaml.get("requirements", {}), **kw)
-    outputs_ = meta_yaml.get("outputs", []) or [] if outputs else []
-    for output in outputs_:
-        for req in _parse_requirements(output.get("requirements", {}) or {}, **kw):
-            reqs.add(req)
-    return reqs
-
-
-def _parse_requirements(
-    req: Union[None, typing.List[str], "RequirementsTypedDict"],
-    build: bool = True,
-    host: bool = True,
-    run: bool = True,
-) -> typing.MutableSet["PackageName"]:
-    """Flatten a YAML requirements section into a list of names"""
-    if not req:  # handle None as empty
-        return set()
-    if isinstance(req, list):  # simple list goes to both host and run
-        reqlist = req if (host or run) else []
-    else:
-        _build = list(as_iterable(req.get("build", []) or [] if build else []))
-        _host = list(as_iterable(req.get("host", []) or [] if host else []))
-        _run = list(as_iterable(req.get("run", []) or [] if run else []))
-        reqlist = _build + _host + _run
-
-    packages = (pin_sep_pat.split(x)[0].lower() for x in reqlist if x is not None)
-    return {typing.cast("PackageName", pkg) for pkg in packages}
 
 
 @contextlib.contextmanager
@@ -636,272 +569,6 @@ def as_iterable(iterable_or_scalar):
         return iterable_or_scalar
     else:
         return (iterable_or_scalar,)
-
-
-def extract_requirements(meta_yaml):
-    strong_exports = False
-    requirements_dict = defaultdict(set)
-    for block in [meta_yaml] + meta_yaml.get("outputs", []) or []:
-        req: "RequirementsTypedDict" = block.get("requirements", {}) or {}
-        if isinstance(req, list):
-            requirements_dict["run"].update(set(req))
-            continue
-        for section in ["build", "host", "run"]:
-            requirements_dict[section].update(
-                list(as_iterable(req.get(section, []) or [])),
-            )
-        test: "TestTypedDict" = block.get("test", {})
-        requirements_dict["test"].update(test.get("requirements", []) or [])
-        requirements_dict["test"].update(test.get("requires", []) or [])
-        run_exports = (block.get("build", {}) or {}).get("run_exports", {})
-        if isinstance(run_exports, dict) and run_exports.get("strong"):
-            strong_exports = True
-    for k in list(requirements_dict.keys()):
-        requirements_dict[k] = {v for v in requirements_dict[k] if v}
-    req_no_pins = {
-        k: {pin_sep_pat.split(x)[0].lower() for x in v}
-        for k, v in dict(requirements_dict).items()
-    }
-    return dict(requirements_dict), req_no_pins, strong_exports
-
-
-def _fetch_static_repo(name, dest):
-    r = requests.get(
-        f"https://github.com/conda-forge/{name}-feedstock/archive/master.zip",
-    )
-    if r.status_code != 200:
-        logger.error(
-            f"Something odd happened when fetching feedstock {name}: {r.status_code}",
-        )
-        return r
-
-    zname = os.path.join(dest, f"{name}-feedstock-master.zip")
-
-    with open(zname, "wb") as fp:
-        fp.write(r.content)
-
-    z = zipfile.ZipFile(zname)
-    z.extractall(path=dest)
-    dest_dir = os.path.join(dest, os.path.split(z.namelist()[0])[0])
-    return dest_dir
-
-
-def populate_feedstock_attributes(
-    name: str,
-    sub_graph: typing.MutableMapping,
-    meta_yaml: typing.Union[str, Response] = "",
-    conda_forge_yaml: typing.Union[str, Response] = "",
-    mark_not_archived=False,
-    feedstock_dir=None,
-) -> typing.MutableMapping:
-    """Parse the various configuration information into something usable
-
-    Notes
-    -----
-    If the return is bad hand the response itself in so that it can be parsed
-    for meaning.
-    """
-    sub_graph.update({"feedstock_name": name, "bad": False})
-
-    if mark_not_archived:
-        sub_graph.update({"archived": False})
-
-    # handle all the raw strings
-    if isinstance(meta_yaml, Response):
-        sub_graph["bad"] = f"make_graph: {meta_yaml.status_code}"
-        return sub_graph
-    sub_graph["raw_meta_yaml"] = meta_yaml
-
-    # Get the conda-forge.yml
-    if isinstance(conda_forge_yaml, str):
-        sub_graph["conda-forge.yml"] = {
-            k: v
-            for k, v in yaml.safe_load(conda_forge_yaml).items()
-            if k
-            in {
-                "provider",
-                "min_r_ver",
-                "min_py_ver",
-                "max_py_ver",
-                "max_r_ver",
-                "compiler_stack",
-                "bot",
-            }
-        }
-
-    if (
-        feedstock_dir is not None
-        and len(glob.glob(os.path.join(feedstock_dir, ".ci_support", "*.yaml"))) > 0
-    ):
-        recipe_dir = os.path.join(feedstock_dir, "recipe")
-        ci_support_files = glob.glob(
-            os.path.join(feedstock_dir, ".ci_support", "*.yaml"),
-        )
-        varient_yamls = []
-        plat_arch = []
-        for cbc_path in ci_support_files:
-            cbc_name = os.path.basename(cbc_path)
-            cbc_name_parts = cbc_name.replace(".yaml", "").split("_")
-            plat = cbc_name_parts[0]
-            if len(cbc_name_parts) == 1:
-                arch = "64"
-            else:
-                if cbc_name_parts[1] in ["64", "aarch64", "ppc64le", "arm64"]:
-                    arch = cbc_name_parts[1]
-                else:
-                    arch = "64"
-            plat_arch.append((plat, arch))
-
-            varient_yamls.append(
-                parse_meta_yaml(
-                    meta_yaml,
-                    platform=plat,
-                    arch=arch,
-                    recipe_dir=recipe_dir,
-                    cbc_path=cbc_path,
-                ),
-            )
-
-            # sometimes the requirements come out to None and this ruins the
-            # aggregated meta_yaml
-            if "requirements" in varient_yamls[-1]:
-                for section in ["build", "host", "run"]:
-                    # We make sure to set a section only if it is actually in
-                    # the recipe. Adding a section when it is not there might
-                    # confuse migrators trying to move CB2 recipes to CB3.
-                    if section in varient_yamls[-1]["requirements"]:
-                        val = varient_yamls[-1]["requirements"].get(section, [])
-                        varient_yamls[-1]["requirements"][section] = val or []
-
-            # collapse them down
-            final_cfgs = {}
-            for plat_arch, varyml in zip(plat_arch, varient_yamls):
-                if plat_arch not in final_cfgs:
-                    final_cfgs[plat_arch] = []
-                final_cfgs[plat_arch].append(varyml)
-            for k in final_cfgs:
-                ymls = final_cfgs[k]
-                final_cfgs[k] = _convert_to_dict(ChainDB(*ymls))
-            plat_arch = []
-            varient_yamls = []
-            for k, v in final_cfgs.items():
-                plat_arch.append(k)
-                varient_yamls.append(v)
-    else:
-        plat_arch = [("win", "64"), ("osx", "64"), ("linux", "64")]
-        for k in set(sub_graph["conda-forge.yml"].get("provider", {})):
-            if "_" in k:
-                plat_arch.append(k.split("_"))
-        varient_yamls = [
-            parse_meta_yaml(meta_yaml, platform=plat, arch=arch)
-            for plat, arch in plat_arch
-        ]
-
-    # this makes certain that we have consistent ordering
-    sorted_varient_yamls = [x for _, x in sorted(zip(plat_arch, varient_yamls))]
-    yaml_dict = ChainDB(*sorted_varient_yamls)
-    if not yaml_dict:
-        logger.error(f"Something odd happened when parsing recipe {name}")
-        sub_graph["bad"] = "make_graph: Could not parse"
-        return sub_graph
-
-    sub_graph["meta_yaml"] = _convert_to_dict(yaml_dict)
-    meta_yaml = sub_graph["meta_yaml"]
-
-    for k, v in zip(plat_arch, varient_yamls):
-        plat_arch_name = "_".join(k)
-        sub_graph[f"{plat_arch_name}_meta_yaml"] = v
-        _, sub_graph[f"{plat_arch_name}_requirements"], _ = extract_requirements(v)
-
-    (
-        sub_graph["total_requirements"],
-        sub_graph["requirements"],
-        sub_graph["strong_exports"],
-    ) = extract_requirements(meta_yaml)
-
-    # handle multi outputs
-    if "outputs" in yaml_dict:
-        sub_graph["outputs_names"] = sorted(
-            list({d.get("name", "") for d in yaml_dict["outputs"]}),
-        )
-    # if the feedstock and meta.yaml disagree on the name count it as an output
-    # so the edges work properly. This also invalidates any outputs if the
-    # outputs were removed from the meta.yaml
-    else:
-        sub_graph["outputs_names"] = [meta_yaml["package"]["name"]]
-
-    # TODO: Write schema for dict
-    # TODO: remove this
-    req = get_requirements(yaml_dict)
-    sub_graph["req"] = req
-
-    keys = [("package", "name"), ("package", "version")]
-    missing_keys = [k[1] for k in keys if k[1] not in yaml_dict.get(k[0], {})]
-    source = yaml_dict.get("source", [])
-    if isinstance(source, collections.abc.Mapping):
-        source = [source]
-    source_keys: Set[str] = set()
-    for s in source:
-        if not sub_graph.get("url"):
-            sub_graph["url"] = s.get("url")
-        source_keys |= s.keys()
-    for k in keys:
-        if k[1] not in missing_keys:
-            sub_graph[k[1]] = yaml_dict[k[0]][k[1]]
-    kl = list(sorted(source_keys & hashlib.algorithms_available, reverse=True))
-    if kl:
-        sub_graph["hash_type"] = kl[0]
-    return sub_graph
-
-
-def load_feedstock(
-    name: str,
-    sub_graph: typing.MutableMapping,
-    meta_yaml: Optional[str] = None,
-    conda_forge_yaml: Optional[str] = None,
-    mark_not_archived: bool = False,
-):
-    """Load a feedstock into subgraph based on its name, if meta_yaml and
-    conda_forge_yaml are provided
-
-    Parameters
-    ----------
-    name : str
-        Name of the feedstock
-    sub_graph : MutableMapping
-        The existing metadata if any
-    meta_yaml : Optional[str]
-        The string meta.yaml, overrides the file in the feedstock if provided
-    conda_forge_yaml : Optional[str]
-        The string conda-forge.yaml, overrides the file in the feedstock if provided
-    mark_not_archived
-
-    Returns
-    -------
-    sub_graph : MutableMapping
-        The sub_graph, now updated with the feedstock metadata
-    """
-    # pull down one copy of the repo
-    with tempfile.TemporaryDirectory() as tmpdir:
-        feedstock_dir = _fetch_static_repo(name, tmpdir)
-
-        if meta_yaml is None:
-            with open(os.path.join(feedstock_dir, "recipe", "meta.yaml")) as fp:
-                meta_yaml = fp.read()
-
-        if conda_forge_yaml is None:
-            with open(os.path.join(feedstock_dir, "conda-forge.yml")) as fp:
-                conda_forge_yaml = fp.read()
-
-        populate_feedstock_attributes(
-            name,
-            sub_graph,
-            meta_yaml=meta_yaml,
-            conda_forge_yaml=conda_forge_yaml,
-            mark_not_archived=mark_not_archived,
-            feedstock_dir=feedstock_dir,
-        )
-    return sub_graph
 
 
 def _get_source_code(recipe_dir):

--- a/tests/test_feedstock_parser.py
+++ b/tests/test_feedstock_parser.py
@@ -1,0 +1,16 @@
+from conda_forge_tick.feedstock_parser import _get_requirements
+
+
+def test_get_requirements():
+    meta_yaml = {
+        "requirements": {"build": ["1", "2"], "host": ["2", "3"]},
+        "outputs": [
+            {"requirements": {"host": ["4"]}},
+            {"requirements": {"run": ["5"]}},
+            {"requirements": ["6"]},
+        ],
+    }
+    assert _get_requirements({}) == set()
+    assert _get_requirements(meta_yaml) == {"1", "2", "3", "4", "5", "6"}
+    assert _get_requirements(meta_yaml, outputs=False) == {"1", "2", "3"}
+    assert _get_requirements(meta_yaml, host=False) == {"1", "2", "5", "6"}

--- a/tests/test_migration_yaml_migration.py
+++ b/tests/test_migration_yaml_migration.py
@@ -12,8 +12,8 @@ from conda_forge_tick.contexts import MigratorSessionContext, MigratorContext
 from conda_forge_tick.utils import (
     parse_meta_yaml,
     frozen_to_json_friendly,
-    populate_feedstock_attributes,
 )
+from conda_forge_tick.feedstock_parser import populate_feedstock_attributes
 from conda_forge_tick.migrators import MigrationYamlCreator, merge_migrator_cbc
 from conda_forge_tick.xonsh_utils import eval_xonsh, indir
 

--- a/tests/test_migrators.py
+++ b/tests/test_migrators.py
@@ -26,9 +26,8 @@ from conda_forge_tick.migrators.disabled.legacy import (
 from conda_forge_tick.utils import (
     parse_meta_yaml,
     frozen_to_json_friendly,
-    populate_feedstock_attributes,
 )
-
+from conda_forge_tick.feedstock_parser import populate_feedstock_attributes
 from xonsh.lib import subprocess
 from xonsh.lib.os import indir
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -6,7 +6,7 @@ def test_env_is_protected_against_malicious_recipes(tmpdir, caplog, env_setup):
     from conda_forge_tick.xonsh_utils import indir
     import logging
 
-    from conda_forge_tick.utils import populate_feedstock_attributes
+    from conda_forge_tick.feedstock_parser import populate_feedstock_attributes
 
     malicious_recipe = """\
     {% set version = "0" %}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import os
 import json
 import pickle
 
-from conda_forge_tick.utils import LazyJson, get_requirements, dumps
+from conda_forge_tick.utils import LazyJson, dumps
 
 
 def test_lazy_json(tmpdir):
@@ -46,18 +46,3 @@ def test_lazy_json(tmpdir):
         assert ff.read() == dumps(
             {"hi": "globe", "lst": ["universe"] * 4, "lst2": ["universe"] * 2},
         )
-
-
-def test_get_requirements():
-    meta_yaml = {
-        "requirements": {"build": ["1", "2"], "host": ["2", "3"]},
-        "outputs": [
-            {"requirements": {"host": ["4"]}},
-            {"requirements": {"run": ["5"]}},
-            {"requirements": ["6"]},
-        ],
-    }
-    assert get_requirements({}) == set()
-    assert get_requirements(meta_yaml) == {"1", "2", "3", "4", "5", "6"}
-    assert get_requirements(meta_yaml, outputs=False) == {"1", "2", "3"}
-    assert get_requirements(meta_yaml, host=False) == {"1", "2", "5", "6"}


### PR DESCRIPTION
This is a follow on to #1122 by @CJ-Wright. I have copied bits of code from there and made some slight changes to how it works. We now keep all outputs in the lut and (at least attempt) to always put requirements through it to find feedstocks in the graph. 