### PR TITLE
BUG enable proper copy for context

### DIFF
--- a/conda_forge_tick/audit.py
+++ b/conda_forge_tick/audit.py
@@ -367,12 +367,12 @@ def compute_depfinder_accuracy(bad_inspection):
             count["cf_under_specified"] += 1
         else:
             count["cf_over_specified"] += 1
-    df = pd.DataFrame.from_dict(count, orient='index').T
+    df = pd.DataFrame.from_dict(count, orient="index").T
     df.to_csv(
         "audits/depfinder_accuracy.csv",
         mode="a",
         header=not os.path.exists("audits/depfinder_accuracy.csv"),
-        index=False
+        index=False,
     )
 
 

--- a/conda_forge_tick/contexts.py
+++ b/conda_forge_tick/contexts.py
@@ -79,7 +79,7 @@ class MigratorContext:
                     continue
 
                 # use a copy to avoid i/o
-                attrs = copy.deepcopy(self.session.graph.nodes[node].get("payload", {}))
+                attrs = copy.deepcopy(self.session.graph.nodes[node]["payload"].data)
                 base_branches = self.migrator.get_possible_feedstock_branches(attrs)
                 filters = []
                 for base_branch in base_branches:

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -146,29 +146,34 @@ class LazyJson(MutableMapping):
             os.makedirs(os.path.split(self.file_name)[0], exist_ok=True)
             with open(self.file_name, "w") as f:
                 dump({}, f)
-        self.data: Optional[dict] = None
+        self._data: Optional[dict] = None
+
+    @property
+    def data(self):
+        self._load()
+        return self._data
 
     def __len__(self) -> int:
         self._load()
-        assert self.data is not None
-        return len(self.data)
+        assert self._data is not None
+        return len(self._data)
 
     def __iter__(self) -> typing.Iterator[Any]:
         self._load()
-        assert self.data is not None
-        yield from self.data
+        assert self._data is not None
+        yield from self._data
 
     def __delitem__(self, v: Any) -> None:
         self._load()
-        assert self.data is not None
-        del self.data[v]
+        assert self._data is not None
+        del self._data[v]
         self._dump()
 
     def _load(self) -> None:
-        if self.data is None:
+        if self._data is None:
             try:
                 with open(self.file_name) as f:
-                    self.data = load(f)
+                    self._data = load(f)
             except FileNotFoundError:
                 print(os.getcwd())
                 print(os.listdir("."))
@@ -177,21 +182,21 @@ class LazyJson(MutableMapping):
     def _dump(self, purge=False) -> None:
         self._load()
         with open(self.file_name, "w") as f:
-            dump(self.data, f)
+            dump(self._data, f)
         if purge:
             # this evicts the josn from memory and trades i/o for mem
             # the bot uses too much mem if we don't do this
-            self.data = None
+            self._data = None
 
     def __getitem__(self, item: Any) -> Any:
         self._load()
-        assert self.data is not None
-        return self.data[item]
+        assert self._data is not None
+        return self._data[item]
 
     def __setitem__(self, key: Any, value: Any) -> None:
         self._load()
-        assert self.data is not None
-        self.data[key] = value
+        assert self._data is not None
+        self._data[key] = value
         self._dump()
 
     def __getstate__(self) -> dict:

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -201,7 +201,7 @@ class LazyJson(MutableMapping):
 
     def __getstate__(self) -> dict:
         state = self.__dict__.copy()
-        state["data"] = None
+        state["_data"] = None
         return state
 
     def __enter__(self) -> "LazyJson":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,7 +22,7 @@ def test_lazy_json(tmpdir):
         assert ff.read() == dumps({"hi": "globe"})
     p = pickle.dumps(lj)
     lj2 = pickle.loads(p)
-    assert not getattr(lj2, "data", None)
+    assert not getattr(lj2, "_data", None)
     assert lj2["hi"] == "globe"
 
     with lj as attrs:


### PR DESCRIPTION
This adds a property to LazyJson that always has the data. I am using it to make a copy of the data in the context classes.