### PR TITLE
exclude the pkgs being migrated themselves

### DIFF
--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -471,6 +471,8 @@ def create_rebuild_graph(
 ) -> nx.DiGraph:
     total_graph = copy.deepcopy(gx)
     excluded_feedstocks = set() if excluded_feedstocks is None else excluded_feedstocks
+    # Always exclude the packages themselves from the migration
+    excluded_feedstocks.update({gx.graph['outputs_lut'].get(node, node) for node in package_names})
 
     included_nodes = set()
 

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -473,7 +473,7 @@ def create_rebuild_graph(
     excluded_feedstocks = set() if excluded_feedstocks is None else excluded_feedstocks
     # Always exclude the packages themselves from the migration
     for node in package_names:
-        excluded_feedstocks.update(gx.graph["outputs_lut"].get(node, node))
+        excluded_feedstocks.update(gx.graph["outputs_lut"].get(node, {node}))
 
     included_nodes = set()
 

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -472,7 +472,9 @@ def create_rebuild_graph(
     total_graph = copy.deepcopy(gx)
     excluded_feedstocks = set() if excluded_feedstocks is None else excluded_feedstocks
     # Always exclude the packages themselves from the migration
-    excluded_feedstocks.update({gx.graph['outputs_lut'].get(node, node) for node in package_names})
+    excluded_feedstocks.update(
+        {gx.graph["outputs_lut"].get(node, node) for node in package_names},
+    )
 
     included_nodes = set()
 

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -472,9 +472,8 @@ def create_rebuild_graph(
     total_graph = copy.deepcopy(gx)
     excluded_feedstocks = set() if excluded_feedstocks is None else excluded_feedstocks
     # Always exclude the packages themselves from the migration
-    excluded_feedstocks.update(
-        {gx.graph["outputs_lut"].get(node, node) for node in package_names},
-    )
+    for node in package_names:
+        excluded_feedstocks.update(gx.graph["outputs_lut"].get(node, node))
 
     included_nodes = set()
 


### PR DESCRIPTION
@beckermr I think this fixes the migrate arrow-cpp pr into arrow-cpp branches.