### PR TITLE
REF use an allow list for curl

### DIFF
--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -1,6 +1,5 @@
 import abc
 import collections.abc
-import subprocess
 import re
 import logging
 import typing
@@ -344,27 +343,12 @@ def get_sha256(url: str) -> Optional[str]:
 
 def url_exists(url: str) -> bool:
     """
-    We use wget here, as opposed requests.head or something,
-    because github urls redirect with a 3XX code even if the file doesn't exist.
+    We use curl here, as opposed requests.head, because github urls redirect
+    with a 3XX code even if the file doesn't exist.
     """
     try:
-        output = subprocess.check_output(
-            ["wget", "--spider", url],
-            stderr=subprocess.STDOUT,
-            timeout=1,
-        )
-    except Exception:
-        return False
-    # For FTP servers an exception is not thrown
-    if "No such file" in output.decode("utf-8"):
-        return False
-    if (
-        "not retrieving"
-        in output.decode(
-            "utf-8",
-        )
-        and "Remote file exists" not in output.decode("utf-8")
-    ):
+        requests.head(url, allow_redirects=True).raise_for_status()
+    except requests.HTTPError:
         return False
 
     return True

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -349,8 +349,9 @@ def get_sha256(url: str) -> Optional[str]:
 
 def url_exists(url: str) -> bool:
     """
-    We use curl/wget here, as opposed requests.head, because github urls redirect
-    with a 3XX code even if the file doesn't exist.
+    We use curl/wget here, as opposed requests.head, because 
+     - github urls redirect with a 3XX code even if the file doesn't exist
+     - requests cannot handle ftp
     """
     if not any(slug in url for slug in CURL_ONLY_URL_SLUGS):
         try:

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -34,7 +34,7 @@ logger = logging.getLogger("conda_forge_tick._update_version.update_sources")
 
 CURL_ONLY_URL_SLUGS = [
     "https://eups.lsst.codes/",
-    "ftp://ftp.info-zip.org",
+    "ftp://ftp.info-zip.org/",
 ]
 
 

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -349,7 +349,7 @@ def get_sha256(url: str) -> Optional[str]:
 
 def url_exists(url: str) -> bool:
     """
-    We use curl here, as opposed requests.head, because github urls redirect
+    We use curl/wget here, as opposed requests.head, because github urls redirect
     with a 3XX code even if the file doesn't exist.
     """
     if not any(slug in url for slug in CURL_ONLY_URL_SLUGS):

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -343,6 +343,10 @@ def get_sha256(url: str) -> Optional[str]:
 
 
 def url_exists(url: str) -> bool:
+    """
+    We use wget here, as opposed requests.head or something,
+    because github urls redirect with a 3XX code even if the file doesn't exist.
+    """
     try:
         output = subprocess.check_output(
             ["wget", "--spider", url],
@@ -354,7 +358,10 @@ def url_exists(url: str) -> bool:
     # For FTP servers an exception is not thrown
     if "No such file" in output.decode("utf-8"):
         return False
-    if "not retrieving" in output.decode("utf-8"):
+    if (
+        "not retrieving" in output.decode("utf-8") and
+        "Remote file exists" not in output.decode("utf-8")
+    ):
         return False
 
     return True

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -1,5 +1,6 @@
 import abc
 import collections.abc
+import subprocess
 import re
 import logging
 import typing
@@ -347,8 +348,12 @@ def url_exists(url: str) -> bool:
     with a 3XX code even if the file doesn't exist.
     """
     try:
-        requests.head(url, allow_redirects=True).raise_for_status()
-    except requests.HTTPError:
+        subprocess.run(
+            ["curl", "-fsLI", url],
+            capture_output=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
         return False
 
     return True

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -359,8 +359,11 @@ def url_exists(url: str) -> bool:
     if "No such file" in output.decode("utf-8"):
         return False
     if (
-        "not retrieving" in output.decode("utf-8") and
-        "Remote file exists" not in output.decode("utf-8")
+        "not retrieving"
+        in output.decode(
+            "utf-8",
+        )
+        and "Remote file exists" not in output.decode("utf-8")
     ):
         return False
 

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -349,7 +349,7 @@ def get_sha256(url: str) -> Optional[str]:
 
 def url_exists(url: str) -> bool:
     """
-    We use curl/wget here, as opposed requests.head, because 
+    We use curl/wget here, as opposed requests.head, because
      - github urls redirect with a 3XX code even if the file doesn't exist
      - requests cannot handle ftp
     """

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -32,6 +32,11 @@ CRAN_INDEX: Optional[dict] = None
 
 logger = logging.getLogger("conda_forge_tick._update_version.update_sources")
 
+CURL_ONLY_URL_SLUGS = [
+    "https://eups.lsst.codes/",
+    "ftp://ftp.info-zip.org",
+]
+
 
 def urls_from_meta(meta_yaml: "MetaYamlTypedDict") -> Set[str]:
     source: "SourceTypedDict" = meta_yaml["source"]
@@ -347,16 +352,33 @@ def url_exists(url: str) -> bool:
     We use curl here, as opposed requests.head, because github urls redirect
     with a 3XX code even if the file doesn't exist.
     """
-    try:
-        subprocess.run(
-            ["curl", "-fsLI", url],
-            capture_output=True,
-            check=True,
-        )
-    except subprocess.CalledProcessError:
-        return False
+    if not any(slug in url for slug in CURL_ONLY_URL_SLUGS):
+        try:
+            output = subprocess.check_output(
+                ["wget", "--spider", url],
+                stderr=subprocess.STDOUT,
+                timeout=1,
+            )
+        except Exception:
+            return False
+        # For FTP servers an exception is not thrown
+        if "No such file" in output.decode("utf-8"):
+            return False
+        if "not retrieving" in output.decode("utf-8"):
+            return False
 
-    return True
+        return True
+    else:
+        try:
+            subprocess.run(
+                ["curl", "-fsLI", url],
+                capture_output=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError:
+            return False
+
+        return True
 
 
 def url_exists_swap_exts(url: str):

--- a/tests/test_url_exists.py
+++ b/tests/test_url_exists.py
@@ -3,11 +3,17 @@ import pytest
 from conda_forge_tick.update_sources import url_exists
 
 
-@pytest.mark.parametrize("url,exists", [
-    ("https://github.com/beckermr/pizza-cutter/archive/0.2.2.tar.gz", True)
-    ("https://github.com/beckermr/pizza-cutter/archive/0.2.3454794.tar.gz", False),
-    ("http://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-7.6p1.tar.gz", True),
-    ("https://eups.lsst.codes/stack/src/tags/w_2021_07.list", True),
-])
+@pytest.mark.parametrize(
+    "url,exists",
+    [
+        ("https://github.com/beckermr/pizza-cutter/archive/0.2.2.tar.gz", True),
+        ("https://github.com/beckermr/pizza-cutter/archive/0.2.3454794.tar.gz", False),
+        (
+            "http://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-7.6p1.tar.gz",
+            True,
+        ),
+        ("https://eups.lsst.codes/stack/src/tags/w_2021_07.list", True),
+    ],
+)
 def test_url_exists(url, exists):
     assert url_exists(url) is exists

--- a/tests/test_url_exists.py
+++ b/tests/test_url_exists.py
@@ -13,6 +13,26 @@ from conda_forge_tick.update_sources import url_exists
             True,
         ),
         ("https://eups.lsst.codes/stack/src/tags/w_2021_07.list", True),
+        (
+            "https://downloads.sourceforge.net/project/healpix/Healpix_3.31/Healpix_3.31_2016Aug26.tar.gz",  # noqa
+            True,
+        ),
+        (
+            "https://downloads.sourceforge.net/project/healpix/Healpix_3.345/Healpix_3.345_2016Aug26.tar.gz",  # noqa
+            False,
+        ),
+        (
+            "http://spams-devel.gforge.inria.fr/hitcounter2.php?file/38351/spams-2.6.2.5.tar.gz",  # noqa
+            True,
+        ),
+        (
+            "https://github.com/Kitware/CMake/releases/download/v3.19.4/cmake-3.19.4.tar.gz",  # noqa
+            True,
+        ),
+        (
+            "https://github.com/Kitware/CMake/releases/download/v3.19.4435784/cmake-3.19.4435784.tar.gz",  # noqa
+            False,
+        ),
     ],
 )
 def test_url_exists(url, exists):

--- a/tests/test_url_exists.py
+++ b/tests/test_url_exists.py
@@ -33,6 +33,14 @@ from conda_forge_tick.update_sources import url_exists
             "https://github.com/Kitware/CMake/releases/download/v3.19.4435784/cmake-3.19.4435784.tar.gz",  # noqa
             False,
         ),
+        (
+            "ftp://ftp.info-zip.org/pub/infozip/src/zip30.tgz",
+            True,
+        ),
+        (
+            "ftp://ftp.info-zip.org/pub/infozip/src/zip33879130.tgz",
+            False,
+        ),
     ],
 )
 def test_url_exists(url, exists):

--- a/tests/test_url_exists.py
+++ b/tests/test_url_exists.py
@@ -1,0 +1,13 @@
+import pytest
+
+from conda_forge_tick.update_sources import url_exists
+
+
+@pytest.mark.parametrize("url,exists", [
+    ("https://github.com/beckermr/pizza-cutter/archive/0.2.2.tar.gz", True)
+    ("https://github.com/beckermr/pizza-cutter/archive/0.2.3454794.tar.gz", False),
+    ("http://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-7.6p1.tar.gz", True),
+    ("https://eups.lsst.codes/stack/src/tags/w_2021_07.list", True),
+])
+def test_url_exists(url, exists):
+    assert url_exists(url) is exists

--- a/tests/test_url_exists.py
+++ b/tests/test_url_exists.py
@@ -22,7 +22,11 @@ from conda_forge_tick.update_sources import url_exists
             False,
         ),
         (
-            "http://spams-devel.gforge.inria.fr/hitcounter2.php?file/38351/spams-2.6.2.5.tar.gz",  # noqa
+            "http://spams-devel.gforge.inria.fr/hitcounter2.php?file/38351/spams-2.34832948372903465.tar.gz",  # noqa
+            False,
+        ),
+        (
+            "http://spams-devel.gforge.inria.fr/hitcounter2.php?file=37237/spams-python-v2.6.1-svn2017-12-08.tar.gz",  # noqa
             True,
         ),
         (


### PR DESCRIPTION
Here is a version of #1348 that we can merge right away. I have put in a specific list of things that use the new `curl`-based test. everything else uses the old `wget`-based one. This should satisfy all parties.

@CJ-Wright want to do the honors?

cc @isuruf 

closes #1348 