### PR TITLE
ENH make sure feedstock is not using new OS version stuff

### DIFF
--- a/conda_forge_tick/migrators/cos7.py
+++ b/conda_forge_tick/migrators/cos7.py
@@ -1,6 +1,7 @@
 import re
 import typing
 from typing import Any
+from ruamel.yaml import YAML
 
 from conda_forge_tick.xonsh_utils import indir
 from conda_forge_tick.migrators.core import MiniMigrator
@@ -66,11 +67,17 @@ class Cos7Config(MiniMigrator):
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
         with indir(recipe_dir):
             cfg = "conda_build_config.yaml"
+            
+            yaml = YAML()
+            yaml.indent(mapping=2, sequence=4, offset=2)
+            with open("../conda-forge.yml", "r) as fp:
+                cfyml = yaml.load(fp.read())
 
-            with open(cfg) as fp:
-                lines = fp.readlines()
+            if os.path.exists(cfg) and cfyml.get("os_version", {}).get("linux_64", None) != "cos7":
+                with open(cfg) as fp:
+                    lines = fp.readlines()
 
-            _munge_cos7_lines(lines)
+                _munge_cos7_lines(lines)
 
-            with open(cfg, "w") as fp:
-                fp.write("".join(lines))
+                with open(cfg, "w") as fp:
+                    fp.write("".join(lines))

--- a/conda_forge_tick/migrators/cos7.py
+++ b/conda_forge_tick/migrators/cos7.py
@@ -1,3 +1,4 @@
+import os
 import re
 import typing
 from typing import Any

--- a/conda_forge_tick/migrators/cos7.py
+++ b/conda_forge_tick/migrators/cos7.py
@@ -67,7 +67,7 @@ class Cos7Config(MiniMigrator):
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
         with indir(recipe_dir):
             cfg = "conda_build_config.yaml"
-            
+
             yaml = YAML()
             yaml.indent(mapping=2, sequence=4, offset=2)
             with open("../conda-forge.yml", "r) as fp:

--- a/conda_forge_tick/migrators/cos7.py
+++ b/conda_forge_tick/migrators/cos7.py
@@ -70,8 +70,11 @@ class Cos7Config(MiniMigrator):
 
             yaml = YAML()
             yaml.indent(mapping=2, sequence=4, offset=2)
-            with open("../conda-forge.yml") as fp:
-                cfyml = yaml.load(fp.read())
+            if os.path.exists("../conda-forge.yml"):
+                with open("../conda-forge.yml") as fp:
+                    cfyml = yaml.load(fp.read())
+            else:
+                cfyml = {}
 
             if (
                 os.path.exists(cfg)

--- a/conda_forge_tick/migrators/cos7.py
+++ b/conda_forge_tick/migrators/cos7.py
@@ -70,7 +70,7 @@ class Cos7Config(MiniMigrator):
 
             yaml = YAML()
             yaml.indent(mapping=2, sequence=4, offset=2)
-            with open("../conda-forge.yml", "r) as fp:
+            with open("../conda-forge.yml", "r") as fp:
                 cfyml = yaml.load(fp.read())
 
             if os.path.exists(cfg) and cfyml.get("os_version", {}).get("linux_64", None) != "cos7":

--- a/conda_forge_tick/migrators/cos7.py
+++ b/conda_forge_tick/migrators/cos7.py
@@ -70,10 +70,13 @@ class Cos7Config(MiniMigrator):
 
             yaml = YAML()
             yaml.indent(mapping=2, sequence=4, offset=2)
-            with open("../conda-forge.yml", "r") as fp:
+            with open("../conda-forge.yml") as fp:
                 cfyml = yaml.load(fp.read())
 
-            if os.path.exists(cfg) and cfyml.get("os_version", {}).get("linux_64", None) != "cos7":
+            if (
+                os.path.exists(cfg)
+                and cfyml.get("os_version", {}).get("linux_64", None) != "cos7"
+            ):
                 with open(cfg) as fp:
                     lines = fp.readlines()
 


### PR DESCRIPTION
This PR makes sure the migrator for cos7 doesn't muck with feedstocks using the new os_version stuff.