### PR TITLE
ENH ship rerender errors for version PRs anyways

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -235,7 +235,21 @@ def run(
                 if not isinstance(migrator, Version):
                     raise
                 else:
-                    make_rerender_comment = True
+                    # for check solvable or automerge, we always raise rerender errors
+                    if feedstock_ctx.attrs["conda-forge.yml"].get("bot", {}).get(
+                        "check_solvable",
+                        False,
+                    ) or (
+                        feedstock_ctx.attrs["conda-forge.yml"]
+                        .get("bot", {})
+                        .get(
+                            "automerge",
+                            False,
+                        )
+                    ):
+                        raise
+                    else:
+                        make_rerender_comment = True
 
             # If we tried to run the MigrationYaml and rerender did nothing (we only
             # bumped the build number and dropped a yaml file in migrations) bail

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -54,6 +54,7 @@ from conda_forge_tick.git_utils import (
     get_repo,
     push_repo,
     is_github_api_limit_reached,
+    comment_on_pr,
 )
 from conda_forge_tick.utils import (
     setup_logger,
@@ -226,11 +227,15 @@ def run(
                     "conda smithy rerender -c auto --no-check-uptodate",
                     timeout=300,
                 )
+                make_rerender_comment = False
             except Exception as e:
                 # I am trying this bit of code to force these errors
                 # to be surfaced in the logs at the right time.
                 print(f"RERENDER ERROR: {e}", flush=True)
-                raise
+                if not isinstance(migrator, Version):
+                    raise
+                else:
+                    make_rerender_comment = True
 
             # If we tried to run the MigrationYaml and rerender did nothing (we only
             # bumped the build number and dropped a yaml file in migrations) bail
@@ -350,6 +355,19 @@ def run(
                 # If we just push to the existing PR then do nothing to the json
                 pr_json = False
                 ljpr = False
+
+    if pr_json and pr_json["state"] != "closed" and make_rerender_comment:
+        comment_on_pr(
+            pr_json,
+            """\
+Hi! This feedstock was not able to be rerendered after the version update changes. I
+have pushed the version update changes anyways and am trying to rerender again with this
+comment. Hopefully you all can fix this!
+
+@conda-forge-admin rerender""",
+            repo,
+        )
+
     if pr_json:
         ljpr = LazyJson(
             os.path.join(migrator.ctx.session.prjson_dir, str(pr_json["id"]) + ".json"),

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -600,6 +600,22 @@ def push_repo(
     return trim_pr_josn_keys(pr_dict)
 
 
+def comment_on_pr(pr_json, comment, repo):
+    """Make a comment on a PR.
+
+    Parameters
+    ----------
+    pr_json : dict
+        A dict-like json blob with the PR information
+    comment : str
+        The comment to make.
+    repo : github3.repos.Repository
+        The feedstock repo as a github3 object.
+    """
+    pr_obj = repo.pull_request(pr_json["number"])
+    pr_obj.create_comment(comment)
+
+
 @backoff.on_exception(
     backoff.expo,
     (RequestException, Timeout),


### PR DESCRIPTION
This PR has the bot ship PRs for versions that hash properly but cannot be rerendered locally. Hopefully, this will mean we let more maintainers know about possible version bumps and they can fix the rerendering errors.

closes #1370 