### PR TITLE
Add "git" to list of dev_vers strings that cause version to be ignored.

### DIFF
--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -133,6 +133,7 @@ class VersionFromFeed(AbstractSource):
         "testing",
         "test",
         "pre",
+        "git",
     ]
 
     def get_version(self, url) -> Optional[str]:


### PR DESCRIPTION
For example, gnuradio tagged the master branch with 3.10.0.0git as a development version after a 3.9.0.0 release, but the bot picked up this tag as a new release. (No PR was issued because, predictably, there was not a corresponding release tarball.) Even now with a 3.9.1.0 release, the bot is stuck on 3.10.0.0git because it is higher. To fix that particular issue even after/if this commit is accepted, I'm guessing the graph will need to be fixed [here](https://github.com/regro/cf-graph-countyfair/blob/455feb52dd97877205d0c4c056c7004310de3869/node_attrs/gnuradio.json#L5695).

I don't think anyone would use "git" in a version string and not have it mean a development version, so it seems like a safe change to me.