### PR TITLE
Add R host dependencies to build for cross-compiling

### DIFF
--- a/conda_forge_tick/migrators/cross_compile.py
+++ b/conda_forge_tick/migrators/cross_compile.py
@@ -332,6 +332,23 @@ class CrossRBaseMigrator(CrossCompilationMigratorBase):
                         " " * nspaces
                         + "- cross-r-base {{ r_base }}  # [build_platform != target_platform]\n",
                     )
+                    # Add host R requirements to build
+                    host_reqs = attrs.get("requirements", {}).get("host", set())
+                    r_host_reqs = [
+                        req
+                        for req in host_reqs
+                        if req.startswith("r-") and req != "r-base"
+                    ]
+                    for r_req in r_host_reqs:
+                        # Ensure nice formatting
+                        post_nspaces = max(0, 25 - len(r_req))
+                        new_lines.append(
+                            " " * nspaces
+                            + "- "
+                            + r_req
+                            + " " * post_nspaces
+                            + "  # [build_platform != target_platform]\n",
+                        )
                     in_req = False
                     previous_was_build = False
                 if "requirements:" in line:

--- a/tests/test_cross_compile.py
+++ b/tests/test_cross_compile.py
@@ -206,8 +206,10 @@ requirements:
     - {{ posix }}zip               # [win]
   host:
     - r-base
+    - r-rlang
   run:
     - r-base
+    - r-rlang
     - {{ native }}gcc-libs         # [win]
 
 test:
@@ -256,6 +258,7 @@ build:
 requirements:
   build:
     - cross-r-base {{ r_base }}  # [build_platform != target_platform]
+    - r-rlang                    # [build_platform != target_platform]
     - {{ compiler('c') }}              # [not win]
     - {{ compiler('m2w64_c') }}        # [win]
     - {{ posix }}filesystem        # [win]
@@ -265,8 +268,10 @@ requirements:
     - {{ posix }}zip               # [win]
   host:
     - r-base
+    - r-rlang
   run:
     - r-base
+    - r-rlang
     - {{ native }}gcc-libs         # [win]
 
 test:


### PR DESCRIPTION
As requested by @isuruf in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1495#issuecomment-840023155