### PR TITLE
REF run non-errored PRs first

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -302,6 +302,7 @@ def run(
                 None,
             ),
         )
+        pre_key = "pre_pr_migrator_status"
         if not solvable:
             _solver_err_str = "not solvable ({}): {}: {}".format(
                 ('<a href="' + os.getenv("CIRCLE_BUILD_URL", "") + '">bot CI job</a>'),
@@ -319,7 +320,6 @@ def run(
                 # higher priority
                 feedstock_ctx.attrs["new_version_attempts"][_new_ver] -= 0.8
 
-            pre_key = "pre_pr_migrator_status"
             if pre_key not in feedstock_ctx.attrs:
                 feedstock_ctx.attrs[pre_key] = {}
             feedstock_ctx.attrs[pre_key][migrator_name] = sanitize_string(
@@ -327,6 +327,12 @@ def run(
             )
             eval_cmd(f"rm -rf {feedstock_dir}")
             return False, False
+        else:
+            if (
+                pre_key in feedstock_ctx.attrs
+                and migrator_name in feedstock_ctx.attrs[pre_key]
+            ):
+                feedstock_ctx.attrs[pre_key].pop(migrator_name)
 
     # TODO: Better annotation here
     pr_json: typing.Union[MutableMapping, None, bool]

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -414,9 +414,25 @@ class MigrationYamlCreator(Migrator):
         total_graph: nx.DiGraph,
     ) -> Sequence["PackageName"]:
         """Run the order by number of decedents, ties are resolved by package name"""
+
+        if hasattr(self, "name"):
+            assert isinstance(self.name, str)
+            migrator_name = self.name.lower().replace(" ", "")
+        else:
+            migrator_name = self.__class__.__name__.lower()
+
+        def _has_error(node):
+            if migrator_name in total_graph.nodes[node]["payload"].get(
+                "pre_pr_migrator_status",
+                {},
+            ):
+                return 0
+            else:
+                return 1
+
         return sorted(
             graph,
-            key=lambda x: (len(nx.descendants(total_graph, x)), x),
+            key=lambda x: (_has_error(x), len(nx.descendants(total_graph, x)), x),
             reverse=True,
         )
 


### PR DESCRIPTION
This PR changes the ordering of yaml rebuilds to run PRs without errors first. This should help us cope with time limits when lots of things are not solvable.