### PR TITLE
Add pytorch pypi_name_mapping_static.yaml

### DIFF
--- a/conda_forge_tick/pypi_name_mapping_static.yaml
+++ b/conda_forge_tick/pypi_name_mapping_static.yaml
@@ -67,3 +67,7 @@
 - pypi_name: duckdb
   import_name: duckdb
   conda_name: python-duckdb
+
+- pypi_name: torch
+  import_name: torch
+  conda_name: pytorch


### PR DESCRIPTION
See naming difference here: https://pytorch.org/get-started/locally/