### PR TITLE
Add default for CONDA_BUILD_CROSS_COMPILATION

### DIFF
--- a/conda_forge_tick/migrators/cross_compile.py
+++ b/conda_forge_tick/migrators/cross_compile.py
@@ -127,7 +127,7 @@ class GuardTestingMigrator(CrossCompilationMigratorBase):
                 ):
                     lines.insert(
                         i,
-                        'if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" ]]; then\n',
+                        'if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" ]]; then\n',
                     )
                     insert_after = i + 1
                     while len(lines) > insert_after and lines[insert_after].endswith(

--- a/tests/test_cross_compile.py
+++ b/tests/test_cross_compile.py
@@ -1040,7 +1040,7 @@ def test_make_check(tmpdir):
         "#!/bin/bash\n",
         "# Get an updated config.sub and config.guess\n",
         "cp $BUILD_PREFIX/share/gnuconfig/config.* ./support\n",
-        'if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" ]]; then\n',
+        'if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" ]]; then\n',
         "make check\n",
         "fi\n",
     ]
@@ -1068,7 +1068,7 @@ def test_cmake(tmpdir):
     expected = [
         "#!/bin/bash\n",
         "cmake ${CMAKE_ARGS} ..\n",
-        'if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" ]]; then\n',
+        'if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" ]]; then\n',
         "ctest\n",
         "fi\n",
     ]


### PR DESCRIPTION
The `GuardTestingMigrator` did not have a default for `CONDA_BUILD_CROSS_COMPILATION`,
which probably caused builds failing with `unbound variable` messages.

On my machine the tests in `test_cross_compile.py` pass. (All tests pass except for some URLs that don't exist.)

This hopefully fixes #1424.