### PR TITLE
Add typing-extensions to static name mapping

### DIFF
--- a/conda_forge_tick/pypi_name_mapping_static.yaml
+++ b/conda_forge_tick/pypi_name_mapping_static.yaml
@@ -71,3 +71,7 @@
 - pypi_name: torch
   import_name: torch
   conda_name: pytorch
+
+- pypi_name: typing-extensions
+  import_name: typing_extensions
+  conda_name: typing_extensions


### PR DESCRIPTION
The recipe for typing_extensions outputs packages `typing_extensions` and `typing-extensions`,

https://github.com/conda-forge/typing_extensions-feedstock/blob/8305f3481ddaf8b0f21d2ffd48dbe3b27d1991ad/recipe/meta.yaml#L16-L40

 but the name mapper does not appear to pick up the latter.