### PR TITLE
REF simplify solver check logic

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -293,12 +293,6 @@ def run(
                 # we always let stuff at the top go
                 and feedstock_ctx.attrs["name"]
                 not in getattr(migrator, "top_level", set())
-                # for solveability always assume automerge is on.
-                and (
-                    feedstock_ctx.attrs["conda-forge.yml"]
-                    .get("bot", {})
-                    .get("automerge", True)
-                )
             )
             or feedstock_ctx.attrs["conda-forge.yml"]
             .get("bot", {})


### PR DESCRIPTION
This PR proposes simpler solver check logic. We have settled on a policy (through our actions and time) of

1. All migrators have solver checks on by default except versions.
2. We allow migrators to turn off their solver checks.
3. We allow people to opt-in to all solver checks.