### PR TITLE
DEP disable migrators we no longer need

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -83,7 +83,6 @@ from conda_forge_tick.migrators import (
     MigrationYaml,
     Replacement,
     ArchRebuild,
-    MatplotlibBase,
     CondaForgeYAMLCleanup,
     ExtraJinja2KeysCleanup,
     Jinja2VarsCleanup,
@@ -97,7 +96,6 @@ from conda_forge_tick.migrators import (
     DuplicateLinesCleanup,
     Cos7Config,
     PipWheelMigrator,
-    RebuildBroken,
     GraphMigrator,
     CrossCompilationForARMAndPower,
 )
@@ -452,18 +450,6 @@ def _host_run_test_dependencies(meta_yaml: "MetaYamlTypedDict") -> Set["PackageN
     _ = meta_yaml["requirements"]
     rq = (_["host"] or _["build"]) | _["run"] | _["test"]
     return typing.cast("Set[PackageName]", rq)
-
-
-def add_rebuild_broken_migrator(
-    migrators: MutableSequence[Migrator],
-    gx: nx.DiGraph,
-):
-    migrators.append(
-        RebuildBroken(
-            outputs_lut=gx.graph["outputs_lut"],
-            pr_limit=PR_LIMIT,
-        ),
-    )
 
 
 def add_replacement_migrator(
@@ -922,17 +908,8 @@ def initialize_migrators(
 
     migrators = []
 
-    add_rebuild_broken_migrator(migrators, gx)
     add_arch_migrate(migrators, gx)
     migration_factory(migrators, gx)
-    add_replacement_migrator(
-        migrators,
-        gx,
-        "matplotlib",
-        "matplotlib-base",
-        ("Unless you need `pyqt`, recipes should depend only on " "`matplotlib-base`."),
-        alt_migrator=MatplotlibBase,
-    )
     create_migration_yaml_creator(migrators=migrators, gx=gx)
     print("rebuild migration graph sizes:", flush=True)
     for m in migrators:

--- a/tests/test_yaml/version_multisrclistnoup.yaml
+++ b/tests/test_yaml/version_multisrclistnoup.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://github.com/google/protobuf/archive/v{{ version }}/libprotobuf-v{{ version }}.tar.gz
+  - url: https://github.com/protocolbuffers/protobuf/releases/download/v{{ version }}/protobuf-all-{{ version }}.tar.gz
     sha256: e8c7601439dbd4489fe5069c33d374804990a56c2f710e00227ee5d8fd650e67
     patches:
       - 0001-remove-Werror-from-test-flags.patch  # [ppc64le or aarch64]

--- a/tests/test_yaml/version_multisrclistnoup_correct.yaml
+++ b/tests/test_yaml/version_multisrclistnoup_correct.yaml
@@ -5,8 +5,8 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://github.com/google/protobuf/archive/v{{ version }}/libprotobuf-v{{ version }}.tar.gz
-    sha256: cf754718b0aa945b00550ed7962ddc167167bd922b842199eeb6505e6f344852
+  - url: https://github.com/protocolbuffers/protobuf/releases/download/v{{ version }}/protobuf-all-{{ version }}.tar.gz
+    sha256: 954536082306f50e3aa19ab70b356bd242d8408d7d8ca709e9c67a79a9020721
     patches:
       - 0001-remove-Werror-from-test-flags.patch  # [ppc64le or aarch64]
   # these are git submodules from the 3.10.1 release


### PR DESCRIPTION
This PR closes some custom migrators we no longer need.