### PR TITLE
PROD close migrations with all PRs issued after 14 days instead of 30

### DIFF
--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -528,7 +528,7 @@ class GraphMigrator(Migrator):
                     if ts is not None:
                         now = datetime.datetime.now(datetime.timezone.utc)
                         ts = dateutil.parser.parse(ts)
-                        if now - ts < datetime.timedelta(days=30):
+                        if now - ts < datetime.timedelta(days=14):
                             LOGGER.debug(
                                 "node %s has PR %s open for %s",
                                 node,


### PR DESCRIPTION
This PR would close migrations issued at 14 days after all PRs are issued instead of our current 30. Lots of stuff is lingering and 30 feels too long now. I am also hoping this will help with the bot's memory footprint and overall performance, but that seems much less likely. 