### PR TITLE
Expand grayskull pypi mapping to include common matches

### DIFF
--- a/conda_forge_tick/pypi_name_mapping.py
+++ b/conda_forge_tick/pypi_name_mapping.py
@@ -173,14 +173,9 @@ def convert_to_grayskull_style_yaml(
 ) -> Dict[str, Dict[str, str]]:
     """Convert our list style mapping to the pypi-centric version
     required by grayskull"""
-    mismatch = [
-        x
-        for x in package_mappings
-        if (x["pypi_name"] != x["conda_name"] or x["pypi_name"] != x["import_name"])
-    ]
     grayskull_fmt = {
         x["pypi_name"]: {k: v for k, v in x.items() if x != "pypi_name"}
-        for x in sorted(mismatch, key=lambda x: x["pypi_name"])
+        for x in sorted(package_mappings, key=lambda x: x["pypi_name"])
     }
     return grayskull_fmt
 


### PR DESCRIPTION
Instead of constraining grayskull mappings to only cases where there are mismatches, returrn the whole set. 

This should allow some degree of detection of the case where there is a pypi package `A` and a conda package `A` and the two have nothing in common.