### PR TITLE
REF use pushd instead of xonsh

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
             --cov=tests \
             --cov-config=.coveragerc \
             --cov-report term \
-            -n 4 tests
+            tests
           codecov -X gcov
 
       - name: build docs

--- a/conda_forge_tick/audit.py
+++ b/conda_forge_tick/audit.py
@@ -31,7 +31,8 @@ from conda_forge_tick.utils import (
     yaml_safe_load,
 )
 from conda_forge_tick.feedstock_parser import load_feedstock
-from conda_forge_tick.xonsh_utils import indir, env
+from conda_forge_tick.xonsh_utils import env
+from conda_forge_tick.utils import pushd
 
 RUNTIME_MINUTES = 45
 
@@ -81,7 +82,7 @@ PACKAGES_BY_IMPORT_OVERRIDE = {
 
 def extract_deps_from_source(recipe_dir):
     cb_work_dir = _get_source_code(recipe_dir)
-    with indir(cb_work_dir):
+    with pushd(cb_work_dir):
         return simple_import_to_pkg_map(
             cb_work_dir,
             builtins=BUILTINS,

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -44,7 +44,8 @@ from urllib.error import URLError
 import github3
 from uuid import uuid4
 
-from conda_forge_tick.xonsh_utils import indir, env
+from conda_forge_tick.xonsh_utils import env
+from conda_forge_tick.utils import pushd
 
 from conda_forge_tick.contexts import (
     FeedstockContext,
@@ -243,7 +244,7 @@ def run(
 
     # rerender, maybe
     diffed_files: typing.List[str] = []
-    with indir(feedstock_dir), env.swap(RAISE_SUBPROC_ERROR=False):
+    with pushd(feedstock_dir), env.swap(RAISE_SUBPROC_ERROR=False):
         msg = migrator.commit_message(feedstock_ctx)  # noqa
         try:
             eval_cmd("git add --all .")
@@ -679,7 +680,7 @@ def migration_factory(
         "conda-forge",
         "migrations",
     )
-    with indir(migrations_loc):
+    with pushd(migrations_loc):
         for yaml_file in glob.glob("*.y*ml"):
             with open(yaml_file) as f:
                 yaml_contents = f.read()
@@ -765,7 +766,7 @@ def create_migration_yaml_creator(migrators: MutableSequence[Migrator], gx: nx.D
             pluck(cfp_gx, node)
 
     print("pinning migrations", flush=True)
-    with indir(os.environ["CONDA_PREFIX"]):
+    with pushd(os.environ["CONDA_PREFIX"]):
         pinnings = parse_config_file(
             "conda_build_config.yaml",
             config=Config(**CB_CONFIG),

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -15,7 +15,8 @@ import github3.exceptions
 import github3.repos
 
 from doctr.travis import run_command_hiding_token as doctr_run
-from .xonsh_utils import env, indir
+from .xonsh_utils import env
+from .utils import pushd
 
 from requests.exceptions import Timeout, RequestException
 from .contexts import GithubContext, FeedstockContext, MigratorSessionContext
@@ -198,7 +199,7 @@ def fetch_repo(*, feedstock_dir, origin, upstream, branch, base_branch="main"):
         return subprocess.run(cmd, shell=True, check=True)
 
     quiet = "--quiet"
-    with indir(feedstock_dir):
+    with pushd(feedstock_dir):
         if reset_hard:
             _run_git_cmd("git reset --hard HEAD")
 
@@ -615,7 +616,7 @@ def push_repo(
         The dict representing the PR, can be used with `from_json`
         to create a PR instance.
     """
-    with indir(feedstock_dir), env.swap(RAISE_SUBPROC_ERROR=False):
+    with pushd(feedstock_dir), env.swap(RAISE_SUBPROC_ERROR=False):
         # Setup push from doctr
         # Copyright (c) 2016 Aaron Meurer, Gil Forsyth
         token = session_ctx.github_password

--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -13,7 +13,7 @@ from conda_forge_tick.utils import (
     yaml_safe_load,
     yaml_safe_dump,
 )
-from conda_forge_tick.xonsh_utils import indir
+from conda_forge_tick.utils import pushd
 from conda_forge_tick.make_graph import get_deps_from_outputs_lut
 from .migration_yaml import all_noarch
 
@@ -73,7 +73,7 @@ class ArchRebuild(GraphMigrator):
 
         assert not self.check_solvable, "We don't want to check solvability for aarch!"
         # We are constraining the scope of this migrator
-        with indir("../conda-forge-pinning-feedstock/recipe/migrations"), open(
+        with pushd("../conda-forge-pinning-feedstock/recipe/migrations"), open(
             "arch_rebuild.txt",
         ) as f:
             self.target_packages = set(f.read().split())
@@ -116,7 +116,7 @@ class ArchRebuild(GraphMigrator):
     def migrate(
         self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any
     ) -> "MigrationUidTypedDict":
-        with indir(recipe_dir + "/.."):
+        with pushd(recipe_dir + "/.."):
             self.set_build_number("recipe/meta.yaml")
             with open("conda-forge.yml") as f:
                 y = yaml_safe_load(f)
@@ -221,7 +221,7 @@ class OSXArm(GraphMigrator):
             self.graph.remove_nodes_from(nx.descendants(self.graph, excluded_dep))
 
         # We are constraining the scope of this migrator
-        with indir("../conda-forge-pinning-feedstock/recipe/migrations"), open(
+        with pushd("../conda-forge-pinning-feedstock/recipe/migrations"), open(
             "osx_arm64.txt",
         ) as f:
             self.target_packages = set(f.read().split())
@@ -265,7 +265,7 @@ class OSXArm(GraphMigrator):
     def migrate(
         self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any
     ) -> "MigrationUidTypedDict":
-        with indir(recipe_dir + "/.."):
+        with pushd(recipe_dir + "/.."):
             self.set_build_number("recipe/meta.yaml")
             with open("conda-forge.yml") as f:
                 y = yaml_safe_load(f)

--- a/conda_forge_tick/migrators/conda_forge_yaml_cleanup.py
+++ b/conda_forge_tick/migrators/conda_forge_yaml_cleanup.py
@@ -3,7 +3,7 @@ import typing
 from typing import Any
 from ruamel.yaml import YAML
 
-from conda_forge_tick.xonsh_utils import indir
+from conda_forge_tick.utils import pushd
 from conda_forge_tick.migrators.core import MiniMigrator
 
 if typing.TYPE_CHECKING:
@@ -30,7 +30,7 @@ class CondaForgeYAMLCleanup(MiniMigrator):
             return True
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             cfg_path = os.path.join("..", "conda-forge.yml")
             yaml = YAML()
             yaml.indent(mapping=2, sequence=4, offset=2)

--- a/conda_forge_tick/migrators/cos7.py
+++ b/conda_forge_tick/migrators/cos7.py
@@ -4,7 +4,7 @@ import typing
 from typing import Any
 from ruamel.yaml import YAML
 
-from conda_forge_tick.xonsh_utils import indir
+from conda_forge_tick.utils import pushd
 from conda_forge_tick.migrators.core import MiniMigrator
 
 if typing.TYPE_CHECKING:
@@ -66,7 +66,7 @@ class Cos7Config(MiniMigrator):
             return True
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             cfg = "conda_build_config.yaml"
 
             yaml = YAML()

--- a/conda_forge_tick/migrators/cross_compile.py
+++ b/conda_forge_tick/migrators/cross_compile.py
@@ -7,7 +7,7 @@ from conda_forge_tick.utils import (
     yaml_safe_dump,
 )
 
-from conda_forge_tick.xonsh_utils import indir
+from conda_forge_tick.utils import pushd
 from conda_forge_tick.utils import _get_source_code
 from conda_forge_tick.migrators.core import MiniMigrator
 
@@ -48,7 +48,7 @@ class UpdateConfigSubGuessMigrator(CrossCompilationMigratorBase):
         if cb_work_dir is None:
             return
         directories = set()
-        with indir(cb_work_dir):
+        with pushd(cb_work_dir):
             for dp, dn, fn in os.walk("."):
                 for f in fn:
                     if f != "config.sub":
@@ -59,7 +59,7 @@ class UpdateConfigSubGuessMigrator(CrossCompilationMigratorBase):
         if not directories:
             return
 
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             if not os.path.exists("build.sh"):
                 return
             with open("build.sh") as f:
@@ -115,7 +115,7 @@ class UpdateConfigSubGuessMigrator(CrossCompilationMigratorBase):
 
 class GuardTestingMigrator(CrossCompilationMigratorBase):
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             if not os.path.exists("build.sh"):
                 return
             with open("build.sh") as f:
@@ -156,7 +156,7 @@ class CrossPythonMigrator(CrossCompilationMigratorBase):
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
         host_reqs = attrs.get("requirements", {}).get("host", set())
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             with open("meta.yaml") as f:
                 lines = f.readlines()
             in_reqs = False
@@ -212,7 +212,7 @@ class UpdateCMakeArgsMigrator(CrossCompilationMigratorBase):
         return "cmake" not in build_reqs
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             if not os.path.exists("build.sh"):
                 return
             with open("build.sh") as f:
@@ -260,7 +260,7 @@ class Build2HostMigrator(MiniMigrator):
             return True
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             with open("meta.yaml") as fp:
                 meta_yaml = fp.readlines()
 
@@ -289,7 +289,7 @@ class NoCondaInspectMigrator(MiniMigrator):
             return True
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             with open("meta.yaml") as fp:
                 meta_yaml = fp.readlines()
 
@@ -322,7 +322,7 @@ class CrossRBaseMigrator(CrossCompilationMigratorBase):
             return True
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             with open("meta.yaml") as fp:
                 meta_yaml = fp.readlines()
 
@@ -376,7 +376,7 @@ class CrossCompilationForARMAndPower(MiniMigrator):
         return False
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             if not os.path.exists("../conda-forge.yml"):
                 name = attrs.get("feedstock_name")
                 LOGGER.info(f"no conda-forge.yml for {name}")

--- a/conda_forge_tick/migrators/disabled/legacy.py
+++ b/conda_forge_tick/migrators/disabled/legacy.py
@@ -14,7 +14,7 @@ from conda_smithy.update_cb3 import update_cb3
 from conda_forge_tick.contexts import FeedstockContext
 from conda_forge_tick.migrators.core import Migrator, GraphMigrator
 from conda_forge_tick.utils import UniversalSet, yaml_safe_load, yaml_safe_dump
-from conda_forge_tick.xonsh_utils import indir
+from conda_forge_tick.utils import pushd
 
 from rever.tools import eval_version, replace_in_file
 
@@ -50,7 +50,7 @@ class JS(Migrator):
     def migrate(
         self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any
     ) -> "MigrationUidTypedDict":
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             for f, p, n in self.patterns:
                 p = eval_version(p)
                 n = eval_version(n)
@@ -118,7 +118,7 @@ class Compiler(Migrator):
     def migrate(
         self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any
     ) -> "MigrationUidTypedDict":
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             content, self.messages = update_cb3("meta.yaml", self.cfp)
             with open("meta.yaml", "w") as f:
                 f.write(content)
@@ -206,7 +206,7 @@ class Noarch(Migrator):
     def migrate(
         self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any
     ) -> "MigrationUidTypedDict":
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             build_idx = [l.rstrip() for l in attrs["raw_meta_yaml"].split("\n")].index(
                 "build:",
             )
@@ -320,7 +320,7 @@ class NoarchR(Noarch):
         """,
         ).format(r_pkg_name=r_pkg_name)
 
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             if noarch:
                 with open("build.sh", "w") as f:
                     f.writelines(r_noarch_build_sh)
@@ -417,7 +417,7 @@ class Rebuild(GraphMigrator):
     def migrate(
         self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any
     ) -> "MigrationUidTypedDict":
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             self.set_build_number("meta.yaml")
         return super().migrate(recipe_dir, attrs)
 
@@ -584,7 +584,7 @@ class BlasRebuild(Rebuild):
         )
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs):
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             # Update build number
             # Remove blas related packages and features
             with open("meta.yaml") as f:
@@ -654,7 +654,7 @@ class RBaseRebuild(Rebuild):
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs):
         # Set the provider to Azure only
-        with indir(recipe_dir + "/.."):
+        with pushd(recipe_dir + "/.."):
             if os.path.exists("conda-forge.yml"):
                 with open("conda-forge.yml") as f:
                     y = yaml_safe_load(f)
@@ -666,7 +666,7 @@ class RBaseRebuild(Rebuild):
             with open("conda-forge.yml", "w") as f:
                 yaml_safe_dump(y, f)
 
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             with open("meta.yaml") as f:
                 text = f.read()
 

--- a/conda_forge_tick/migrators/duplicate_lines.py
+++ b/conda_forge_tick/migrators/duplicate_lines.py
@@ -2,7 +2,7 @@ import typing
 from typing import Any
 import re
 
-from conda_forge_tick.xonsh_utils import indir
+from conda_forge_tick.utils import pushd
 from conda_forge_tick.migrators.core import MiniMigrator
 
 if typing.TYPE_CHECKING:
@@ -28,7 +28,7 @@ class DuplicateLinesCleanup(MiniMigrator):
         return True
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             with open("meta.yaml") as fp:
                 raw_yaml = fp.read()
 

--- a/conda_forge_tick/migrators/extra_jinj2a_keys_cleanup.py
+++ b/conda_forge_tick/migrators/extra_jinj2a_keys_cleanup.py
@@ -2,7 +2,7 @@ import re
 import typing
 from typing import Any
 
-from conda_forge_tick.xonsh_utils import indir
+from conda_forge_tick.utils import pushd
 from conda_forge_tick.migrators.core import MiniMigrator
 
 if typing.TYPE_CHECKING:
@@ -57,7 +57,7 @@ class ExtraJinja2KeysCleanup(MiniMigrator):
             yield line
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             with open("meta.yaml") as fp:
                 lines = fp.readlines()
 

--- a/conda_forge_tick/migrators/jinja2_vars_cleanup.py
+++ b/conda_forge_tick/migrators/jinja2_vars_cleanup.py
@@ -2,7 +2,7 @@ import re
 import typing
 from typing import Any
 
-from conda_forge_tick.xonsh_utils import indir
+from conda_forge_tick.utils import pushd
 from conda_forge_tick.migrators.core import MiniMigrator
 
 if typing.TYPE_CHECKING:
@@ -37,7 +37,7 @@ class Jinja2VarsCleanup(MiniMigrator):
         return _should_filter(attrs.get("raw_meta_yaml", ""))
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             with open("meta.yaml") as fp:
                 raw_yaml = fp.read()
 

--- a/conda_forge_tick/migrators/license.py
+++ b/conda_forge_tick/migrators/license.py
@@ -8,7 +8,7 @@ import logging
 
 from rever.tools import replace_in_file
 
-from conda_forge_tick.xonsh_utils import indir
+from conda_forge_tick.utils import pushd
 from conda_forge_tick.utils import eval_cmd, _get_source_code
 from conda_forge_tick.recipe_parser import CondaMetaYAML
 from conda_forge_tick.migrators.core import MiniMigrator
@@ -134,7 +134,7 @@ def _scrape_license_string(pkg):
 
     LOGGER.info("LICENSE running cran skeleton for pkg %s" % pkg)
 
-    with tempfile.TemporaryDirectory() as tmpdir, indir(tmpdir):
+    with tempfile.TemporaryDirectory() as tmpdir, pushd(tmpdir):
 
         subprocess.run(
             [
@@ -267,7 +267,7 @@ class LicenseMigrator(MiniMigrator):
             return
         if cb_work_dir is None:
             return
-        with indir(cb_work_dir):
+        with pushd(cb_work_dir):
             # look for a license file
             license_files = [
                 s
@@ -279,7 +279,7 @@ class LicenseMigrator(MiniMigrator):
         eval_cmd(f"rm -r {cb_work_dir}")
         # if there is a license file in tarball update things
         if license_files:
-            with indir(recipe_dir):
+            with pushd(recipe_dir):
                 """BSD 3-Clause License
                 Copyright (c) 2017, Anthony Scopatz
                 Copyright (c) 2018, The Regro Developers

--- a/conda_forge_tick/migrators/mpi_pin_run_as_build.py
+++ b/conda_forge_tick/migrators/mpi_pin_run_as_build.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 
-from conda_forge_tick.xonsh_utils import indir
+from conda_forge_tick.utils import pushd
 from conda_forge_tick.migrators.core import MiniMigrator
 
 MPIS = ["mpich", "openmpi"]
@@ -94,6 +94,6 @@ class MPIPinRunAsBuildCleanup(MiniMigrator):
                 with open(fname, "w") as fp:
                     fp.write("\n".join(new_lines))
             else:
-                with indir(recipe_dir):
+                with pushd(recipe_dir):
                     subprocess.run("git rm -f conda_build_config.yaml", shell=True)
                     subprocess.run("rm -f conda_build_config.yaml", shell=True)

--- a/conda_forge_tick/migrators/pip_check.py
+++ b/conda_forge_tick/migrators/pip_check.py
@@ -5,7 +5,7 @@ from ruamel.yaml import YAML
 import ruamel.yaml
 import io
 
-from conda_forge_tick.xonsh_utils import indir
+from conda_forge_tick.utils import pushd
 from conda_forge_tick.migrators.core import MiniMigrator
 
 if typing.TYPE_CHECKING:
@@ -155,7 +155,7 @@ class PipCheckMigrator(MiniMigrator):
         return "python" not in build_host
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             mapping = {}
             groups = {}
             with open("meta.yaml") as fp:

--- a/conda_forge_tick/migrators/use_pip.py
+++ b/conda_forge_tick/migrators/use_pip.py
@@ -1,7 +1,7 @@
 from typing import Any
 import typing
 
-from conda_forge_tick.xonsh_utils import indir
+from conda_forge_tick.utils import pushd
 from .core import MiniMigrator
 from conda_forge_tick.utils import as_iterable
 
@@ -22,7 +22,7 @@ class PipMigrator(MiniMigrator):
         return not bool(set(self.bad_install) & set(scripts))
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
-        with indir(recipe_dir):
+        with pushd(recipe_dir):
             with open("meta.yaml") as fp:
                 lines = fp.readlines()
 

--- a/conda_forge_tick/migrators/version.py
+++ b/conda_forge_tick/migrators/version.py
@@ -24,7 +24,7 @@ from conda.models.version import VersionOrder
 
 from conda_forge_tick.migrators.core import Migrator
 from conda_forge_tick.contexts import FeedstockContext
-from conda_forge_tick.xonsh_utils import indir
+from conda_forge_tick.utils import pushd
 from conda_forge_tick.recipe_parser import CONDA_SELECTOR, CondaMetaYAML
 from conda_forge_tick.url_transforms import gen_transformed_urls
 from conda_forge_tick.hashing import hash_url
@@ -613,7 +613,7 @@ class Version(Migrator):
                 )
 
         if did_update:
-            with indir(recipe_dir):
+            with pushd(recipe_dir):
                 with open("meta.yaml", "w") as fp:
                     cmeta.dump(fp)
                 self.set_build_number("meta.yaml")

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -71,6 +71,17 @@ CB_CONFIG_PINNING = dict(
 )
 
 
+# https://stackoverflow.com/questions/6194499/pushd-through-os-system
+@contextlib.contextmanager
+def pushd(new_dir):
+    previous_dir = os.getcwd()
+    os.chdir(new_dir)
+    try:
+        yield
+    finally:
+        os.chdir(previous_dir)
+
+
 def yaml_safe_load(stream):
     """Load a yaml doc safely"""
     return ruamel.yaml.YAML(typ="safe", pure=True).load(stream)

--- a/conda_forge_tick/xonsh_utils.py
+++ b/conda_forge_tick/xonsh_utils.py
@@ -3,7 +3,6 @@ import builtins
 
 from xonsh.execer import Execer
 from xonsh.environ import Env
-from xonsh.lib.os import indir
 from xonsh.proc import CommandPipeline
 
 env: Env = builtins.__xonsh__.env  # type: ignore

--- a/conda_forge_tick/xonsh_utils.pyi
+++ b/conda_forge_tick/xonsh_utils.pyi
@@ -8,6 +8,3 @@ env: Env
 execer: Execer
 
 def eval_xonsh(inp: str) -> str: ...
-@contextmanager
-def indir(path: str) -> Iterator[None]:
-    pass

--- a/tests/test_migration_yaml_migration.py
+++ b/tests/test_migration_yaml_migration.py
@@ -2,7 +2,6 @@ import os
 import re
 import builtins
 import logging
-import datetime
 from unittest import mock
 
 import pytest
@@ -15,7 +14,8 @@ from conda_forge_tick.utils import (
 )
 from conda_forge_tick.feedstock_parser import populate_feedstock_attributes
 from conda_forge_tick.migrators import MigrationYamlCreator, merge_migrator_cbc
-from conda_forge_tick.xonsh_utils import eval_xonsh, indir
+from conda_forge_tick.xonsh_utils import eval_xonsh
+from conda_forge_tick.utils import pushd
 
 G = nx.DiGraph()
 G.add_node("conda", reqs=["python"], payload={})
@@ -142,7 +142,7 @@ def test_migration_yaml_migration(tmock, in_out_yaml, caplog, tmpdir):
 
     MYM = MigrationYamlCreator(pname, pin_ver, curr_pin, pin_spec, "hi", G, G)
 
-    with indir(tmpdir):
+    with pushd(tmpdir):
         eval_xonsh("git init .")
 
     os.makedirs(os.path.join(tmpdir, "migrations"), exist_ok=True)

--- a/tests/test_migrators.py
+++ b/tests/test_migrators.py
@@ -35,7 +35,7 @@ from conda_forge_tick.utils import (
 )
 from conda_forge_tick.feedstock_parser import populate_feedstock_attributes
 from xonsh.lib import subprocess
-from xonsh.lib.os import indir
+from conda_forge_tick.utils import pushd
 
 
 sample_yaml_rebuild = """
@@ -291,7 +291,7 @@ def run_test_yaml_migration(
     with open(os.path.join(tmpdir, "recipe", "meta.yaml"), "w") as f:
         f.write(inp)
 
-    with indir(tmpdir):
+    with pushd(tmpdir):
         subprocess.run(["git", "init"])
     # Load the meta.yaml (this is done in the graph)
     try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -3,7 +3,7 @@ import subprocess
 
 
 def test_env_is_protected_against_malicious_recipes(tmpdir, caplog, env_setup):
-    from conda_forge_tick.xonsh_utils import indir
+    from conda_forge_tick.utils import pushd
     import logging
 
     from conda_forge_tick.feedstock_parser import populate_feedstock_attributes
@@ -60,7 +60,7 @@ def test_env_is_protected_against_malicious_recipes(tmpdir, caplog, env_setup):
     os.makedirs(os.path.join(tmpdir, "recipe"), exist_ok=True)
     with open(os.path.join(tmpdir, "recipe", "meta.yaml"), "w") as f:
         f.write(in_yaml)
-    with indir(tmpdir):
+    with pushd(tmpdir):
         subprocess.run(["git", "init"])
 
     pmy = populate_feedstock_attributes("blah", {}, in_yaml, "{}")


### PR DESCRIPTION
I keep seeing odd failures in the bot where it looks like it is not in the right path when changing working directories. I cannot tell how this is happening. See this issue + log: https://github.com/regro/autotick-bot/issues/479

I am trying swapping out the xonsh dir change for a pure python, mostly as a stab in the dark. 