### PR TITLE
Use newer 'test:' syntax when migrating osx_arm64

### DIFF
--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -169,7 +169,7 @@ class OSXArm(GraphMigrator):
 
     additional_keys = {
         "build_platform": {"osx_arm64": "osx_64"},
-        "test_on_native_only": True,
+        "test": "native_and_emulated",
     }
 
     def __init__(


### PR DESCRIPTION
As noted in the [documention](https://conda-forge.org/docs/maintainer/conda_forge_yml.html#test-on-native-only) (added in https://github.com/conda-forge/conda-forge.github.io/commit/2275ee0eec00353157e2e6e4887586ce700aaa3e), the old form of this is now deprecated. The new testing syntax was added (and old deprecated) in https://github.com/conda-forge/conda-smithy/commit/7d0bfffe0c902fbe3b694ac02330027920669ad2.

This PR updates the autotick migrator to use this new syntax.

I.. do not know how to exhaustively test this. The instructions in the README seem a little out-of-date, I can run `pytest` on the `tests/` directory and get roughly the same number of failures as the main branch (+/- apparently flaky tests), but `tests/test_migrators.py` test file only seems to check the recipe yaml, and not any migrations on the conda-forge.yml.

With thanks to @isuruf for pointing me to the relevant parts of the code.