### PR TITLE
Add Seaborn static mapping

### DIFF
--- a/conda_forge_tick/pypi_name_mapping_static.yaml
+++ b/conda_forge_tick/pypi_name_mapping_static.yaml
@@ -78,4 +78,4 @@
 
 - pypi_name: seaborn
   import_name: seaborn
-  conda_name: seaborn
+  conda_name: seaborn-base

--- a/conda_forge_tick/pypi_name_mapping_static.yaml
+++ b/conda_forge_tick/pypi_name_mapping_static.yaml
@@ -75,3 +75,7 @@
 - pypi_name: typing-extensions
   import_name: typing_extensions
   conda_name: typing_extensions
+
+- pypi_name: seaborn
+  import_name: seaborn
+  conda_name: seaborn


### PR DESCRIPTION
The Seaborn package has some oddities going on with its package names (#1513), which this static override fixes.