### PR TITLE
Add static mapping for ipopt/cyipopt

### DIFF
--- a/conda_forge_tick/pypi_name_mapping_static.yaml
+++ b/conda_forge_tick/pypi_name_mapping_static.yaml
@@ -40,10 +40,6 @@
   import_name: xxhash
   conda_name: python-xxhash
 
-- pypi_name: docker
-  import_name: docker
-  conda_name: docker-py
-
 - pypi_name: redis
   import_name: redis
   conda_name: redis-py
@@ -79,3 +75,19 @@
 - pypi_name: seaborn
   import_name: seaborn
   conda_name: seaborn-base
+
+- pypi_name: ipopt
+  import_name: ipopt
+  conda_name: cyipopt
+
+- pypi_name: ipopt
+  import_name: cyipopt
+  conda_name: cyipopt
+
+- pypi_name: cyipopt
+  import_name: ipopt
+  conda_name: cyipopt
+
+- pypi_name: cyipopt
+  import_name: cyipopt
+  conda_name: cyipopt


### PR DESCRIPTION
The cyipopt package on conda is published under two names on PyPI: ipopt and cyipopt. It also exports
both 'cyipopt' (preferred) and 'ipopt' (now deprecated) packages. I am not sure whether all these combinations
need to be listed or if some are redundant. I'm also not sure if having duplicates like this works.