### PR TITLE
Add json map to mapping output

### DIFF
--- a/conda_forge_tick/pypi_name_mapping.py
+++ b/conda_forge_tick/pypi_name_mapping.py
@@ -306,7 +306,7 @@ def main(args: "CLIArgs") -> None:
 
     yaml_dump = functools.partial(yaml.dump, default_flow_style=False, sort_keys=True)
     # import pdb; pdb.set_trace()
-    for dumper, suffix in ((yaml_dump, 'yaml'), (json.dump, 'json')):
+    for dumper, suffix in ((yaml_dump, "yaml"), (json.dump, "json")):
         with (dirname / f"grayskull_pypi_mapping.{suffix}").open("w") as fp:
             dumper(grayskull_style, fp)
 


### PR DESCRIPTION
i'd like to get this info in json too. it's programmatically used in depfinder in its yaml format which is substantially slower to load than json (~30x). i _think_ this should just transparently work. this will change the output format of `mappings/pypi/import_name_priority_mapping.yaml` because json.dump doesn't know what to do with `list_reverseiterator`
```
TypeError: Object of type list_reverseiterator is not JSON serializable
```

Is updating the output of import_name_priority_mapping.yaml to look like the following snippet instead going to be a problem for anything else?

```diff
-  ranked_conda_names: !!python/object/apply:builtins.reversed
-    args:
-    - - pycryptodome
-      - pycrypto
-    state: 1
+  ranked_conda_names:
+  - pycrypto
+  - pycryptodome
```
