### PR TITLE
Add __win to faked virtual packages

### DIFF
--- a/conda_forge_tick/mamba_solver.py
+++ b/conda_forge_tick/mamba_solver.py
@@ -559,6 +559,7 @@ def virtual_package_repodata():
             FakePackage("__osx", osx_ver),
             subdirs=["osx-64", "osx-arm64"],
         )
+    repodata.add_package(FakePackage("__win", "0"), subdirs=["win-64"])
     repodata.write()
 
     return repodata.channel_url


### PR DESCRIPTION
This fixes the
```
Error: not solvable [...] Encountered problems while solving:\n - nothing provides __win needed by [...]
```
seen in the Py 3.11 migration.