### PR TITLE
Update `base_branch` docstring default

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -180,7 +180,7 @@ def run(
     fork : bool
         If true create a fork, defaults to true
     base_branch : str, optional
-        The base branch to which the PR will be targeted. Defaults to "master".
+        The base branch to which the PR will be targeted. Defaults to "main".
     kwargs: dict
         The key word arguments to pass to the migrator
 


### PR DESCRIPTION
Since this is now `main`, update the docstring accordingly.

https://github.com/regro/cf-scripts/blob/c30554fcb230f3f0a92c925dd118b2c9a6ff0bda/conda_forge_tick/auto_tick.py#L163