### PR TITLE
Remove spurious python-opencv static mapping

### DIFF
--- a/conda_forge_tick/pypi_name_mapping_static.yaml
+++ b/conda_forge_tick/pypi_name_mapping_static.yaml
@@ -28,10 +28,6 @@
   delimiter_min: "5.0.0"
   delimiter_max: "6.0.0"
 
-- pypi_name: python-opencv
-  import_name: cv2
-  conda_name: opencv
-
 - pypi_name: tables
   import_name: pytables
   conda_name: pytables


### PR DESCRIPTION
There is no such PyPI package.

My guess is that this was probably meant to be [opencv-python](https://pypi.org/project/opencv-python/), which is already in the mapping. Or was this deliberate? (ping: @mariusvniekerk)