### PR TITLE
Prefer statically defined matches in PyPI import mapping

### DIFF
--- a/conda_forge_tick/pypi_name_mapping.py
+++ b/conda_forge_tick/pypi_name_mapping.py
@@ -335,7 +335,11 @@ def determine_best_matches_for_pypi_import(
                 f"needs {import_name} <- provided_by: {ranked_conda_names} : "
                 f"chosen {winning_name}",
             )
-        final_map[import_name] = map_by_conda_name[winning_name]
+        # Due to concatenating the graph mapping and the static mapping, there might
+        # be multiple candidates with the same conda_name but different PyPI names.
+        winning_candidates = [c for c in candidates if c["conda_name"] == winning_name]
+        winner = resolve_collisions(winning_candidates)
+        final_map[import_name] = winner
         ordered_import_names.append(
             {
                 "import_name": import_name,


### PR DESCRIPTION
This PR consists of a single commit 2406b43 on top of #1640.

Due to concatenating the graph mapping and the static mapping, there might be two candidates with the same `conda_name` but different PyPI names. Currently we pick an arbitrary one (whichever one appears last in the list). This PR changes this behavior to favor matches defined in the static mapping, and to otherwise emit a warning.