### PR TITLE
Prefer statically defined matches in PyPI Grayskull mapping

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,7 @@ repos:
         args:
           - --ignore-words-list=rever,pring,pullrequest,pullrequests
           - --exclude-file=.codespellignorelines
+          - -L=statics
   # - repo: https://gitlab.com/pycqa/flake8
   #   rev: 3.8.4
   #   hooks:

--- a/conda_forge_tick/pypi_name_mapping.py
+++ b/conda_forge_tick/pypi_name_mapping.py
@@ -182,7 +182,18 @@ def convert_to_grayskull_style_yaml(
     grayskull_fmt: Dict[str, Mapping] = {}
     for mapping in sorted_mappings:
         pypi_name = mapping["pypi_name"]
-        grayskull_fmt[pypi_name] = mapping
+        if pypi_name not in grayskull_fmt:
+            grayskull_fmt[pypi_name] = mapping
+        else:
+            # This is an exceptional case where the same PyPI package name has two
+            # different import names. For example, the PyPI package ruamel.yaml is
+            # provided also by a conda-forge package named ruamel_yaml.
+            collisions = [
+                mapping
+                for mapping in package_mappings
+                if mapping["pypi_name"] == pypi_name
+            ]
+            grayskull_fmt[pypi_name] = resolve_collisions(collisions)
     return grayskull_fmt
 
 

--- a/conda_forge_tick/pypi_name_mapping.py
+++ b/conda_forge_tick/pypi_name_mapping.py
@@ -14,7 +14,7 @@ import pathlib
 import functools
 
 from collections import Counter, defaultdict
-from typing import Dict, List, Optional, Any, Tuple, Set, Iterable
+from typing import Dict, List, Optional, Any, Tuple, Set
 from os.path import commonprefix
 
 
@@ -164,10 +164,11 @@ def extract_pypi_information(cf_graph: str) -> List[Dict[str, str]]:
 
 
 def convert_to_grayskull_style_yaml(
-    package_mappings: Iterable[Dict[str, str]],
+    best_imports: Dict[str, Dict[str, str]],
 ) -> Dict[str, Dict[str, str]]:
     """Convert our list style mapping to the pypi-centric version
-    required by grayskull"""
+    required by grayskull by reindexing on the PyPI name"""
+    package_mappings = best_imports.values()
     grayskull_fmt = {
         x["pypi_name"]: {k: v for k, v in x.items() if x != "pypi_name"}
         for x in sorted(package_mappings, key=lambda x: x["pypi_name"])
@@ -316,7 +317,7 @@ def main(args: "CLIArgs") -> None:
         mapping=pypi_package_mappings + static_packager_mappings,
     )
 
-    grayskull_style = convert_to_grayskull_style_yaml(best_imports.values())
+    grayskull_style = convert_to_grayskull_style_yaml(best_imports)
 
     dirname = pathlib.Path(cf_graph) / "mappings" / "pypi"
     dirname.mkdir(parents=True, exist_ok=True)

--- a/conda_forge_tick/pypi_name_mapping.py
+++ b/conda_forge_tick/pypi_name_mapping.py
@@ -176,10 +176,12 @@ def convert_to_grayskull_style_yaml(
     """Convert our list style mapping to the pypi-centric version
     required by grayskull by reindexing on the PyPI name"""
     package_mappings = best_imports.values()
-    grayskull_fmt = {
-        x["pypi_name"]: x
-        for x in sorted(package_mappings, key=lambda x: x["pypi_name"])
-    }
+    sorted_mappings = sorted(package_mappings, key=lambda mapping: mapping["pypi_name"])
+
+    grayskull_fmt: Dict[str, Mapping] = {}
+    for mapping in sorted_mappings:
+        pypi_name = mapping["pypi_name"]
+        grayskull_fmt[pypi_name] = mapping
     return grayskull_fmt
 
 

--- a/conda_forge_tick/pypi_name_mapping.py
+++ b/conda_forge_tick/pypi_name_mapping.py
@@ -295,27 +295,20 @@ def determine_best_matches_for_pypi_import(
 
     for import_name, candidates in sorted(map_by_import_name.items()):
         conda_names = {c["conda_name"] for c in candidates}
-        if len(candidates) > 1:
-            ranked_conda_names = list(sorted(conda_names, key=score))
-            winning_name = ranked_conda_names[0]
+        ranked_conda_names = list(sorted(conda_names, key=score))
+        winning_name = ranked_conda_names[0]
+        if len(ranked_conda_names) > 1:
             print(
-                f"needs {import_name} <- provided_by: {conda_names} : "
+                f"needs {import_name} <- provided_by: {ranked_conda_names} : "
                 f"chosen {winning_name}",
             )
-            final_map[import_name] = map_by_conda_name[winning_name]
-            ordered_import_names.append(
-                {
-                    "import_name": import_name,
-                    "ranked_conda_names": list(reversed(ranked_conda_names)),
-                },
-            )
-        else:
-            winning_name = conda_names[0]
-            final_map[import_name] = map_by_conda_name[winning_name]
-            ordered_import_names.append(
-                {"import_name": import_name, "ranked_conda_names": [winning_name]},
-            )
-
+        final_map[import_name] = map_by_conda_name[winning_name]
+        ordered_import_names.append(
+            {
+                "import_name": import_name,
+                "ranked_conda_names": list(reversed(ranked_conda_names)),
+            },
+        )
     return final_map, ordered_import_names
 
 

--- a/conda_forge_tick/pypi_name_mapping.py
+++ b/conda_forge_tick/pypi_name_mapping.py
@@ -170,7 +170,7 @@ def convert_to_grayskull_style_yaml(
     required by grayskull by reindexing on the PyPI name"""
     package_mappings = best_imports.values()
     grayskull_fmt = {
-        x["pypi_name"]: {k: v for k, v in x.items() if x != "pypi_name"}
+        x["pypi_name"]: x
         for x in sorted(package_mappings, key=lambda x: x["pypi_name"])
     }
     return grayskull_fmt


### PR DESCRIPTION
This PR consists of a single commit 98e51a2 on top of #1640.

Since the input mappings are indexed by `import_name`, it sometimes happens that there are multiple `Mapping` objects with the same `pypi_name`. Currently we pick an arbitrary one, but this PR makes it explicit that we should favor one from the static mapping if it's defined. Otherwise emit a warning.