### PR TITLE
Add ruamel.yaml to static mapping

### DIFF
--- a/conda_forge_tick/pypi_name_mapping_static.yaml
+++ b/conda_forge_tick/pypi_name_mapping_static.yaml
@@ -75,3 +75,7 @@
 - pypi_name: seaborn
   import_name: seaborn
   conda_name: seaborn-base
+
+- pypi_name: ruamel.yaml
+  import_name: ruamel.yaml
+  conda_name: ruamel.yaml


### PR DESCRIPTION
Currently the Grayskull mapping favors ruamel_yaml over ruamel.yaml.

This requires #1642 in order to take effect.