### PR TITLE
Canonicalize pypi names

### DIFF
--- a/conda_forge_tick/pypi_name_mapping_static.yaml
+++ b/conda_forge_tick/pypi_name_mapping_static.yaml
@@ -72,6 +72,6 @@
   import_name: seaborn
   conda_name: seaborn-base
 
-- pypi_name: ruamel.yaml
+- pypi_name: ruamel-yaml
   import_name: ruamel.yaml
   conda_name: ruamel.yaml

--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,7 @@ dependencies:
  - mamba>=0.23
  - msgpack-python
  - networkx!=2.8.1
+ - packaging
  - psutil
  - pygithub
  - pynamodb

--- a/tests/test_pypi_name_mapper.py
+++ b/tests/test_pypi_name_mapper.py
@@ -28,7 +28,7 @@ def test_directory():
     # zope.interface  is a namespaced package so we check that we don't parse the
     # import_name as zope
     assert {
-        "pypi_name": "zope.interface",
+        "pypi_name": "zope-interface",
         "conda_name": "zope.interface",
         "import_name": "zope.interface",
         "mapping_source": "regro-bot",


### PR DESCRIPTION
This is a single commit e481b53 on top of #1640.

This makes sure that we deal with only canonicalized PyPI names, as defined by PyPA's `packaging` package.

[Diff](https://gist.github.com/maresb/ec2ba446305650052ff59836fad76f3e)