### PR TITLE
add platform_allowlist for migrator

### DIFF
--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -221,7 +221,7 @@ def populate_feedstock_attributes(
             ci_support_files = glob.glob(
                 os.path.join(feedstock_dir, ".ci_support", "*.yaml"),
             )
-            varient_yamls = []
+            variant_yamls = []
             plat_arch = []
             for cbc_path in ci_support_files:
                 LOGGER.debug("parsing conda-build config: %s", cbc_path)
@@ -242,7 +242,7 @@ def populate_feedstock_attributes(
                         break
                 plat_arch.append((plat, arch))
 
-                varient_yamls.append(
+                variant_yamls.append(
                     parse_meta_yaml(
                         meta_yaml,
                         platform=plat,
@@ -259,23 +259,23 @@ def populate_feedstock_attributes(
                 # sometimes the requirements come out to None or [None]
                 # and this ruins the aggregated meta_yaml / breaks stuff
                 LOGGER.debug("getting reqs for config: %s", cbc_path)
-                if "requirements" in varient_yamls[-1]:
-                    varient_yamls[-1]["requirements"] = _clean_req_nones(
-                        varient_yamls[-1]["requirements"],
+                if "requirements" in variant_yamls[-1]:
+                    variant_yamls[-1]["requirements"] = _clean_req_nones(
+                        variant_yamls[-1]["requirements"],
                     )
-                if "outputs" in varient_yamls[-1]:
-                    for iout in range(len(varient_yamls[-1]["outputs"])):
-                        if "requirements" in varient_yamls[-1]["outputs"][iout]:
-                            varient_yamls[-1]["outputs"][iout][
+                if "outputs" in variant_yamls[-1]:
+                    for iout in range(len(variant_yamls[-1]["outputs"])):
+                        if "requirements" in variant_yamls[-1]["outputs"][iout]:
+                            variant_yamls[-1]["outputs"][iout][
                                 "requirements"
                             ] = _clean_req_nones(
-                                varient_yamls[-1]["outputs"][iout]["requirements"],
+                                variant_yamls[-1]["outputs"][iout]["requirements"],
                             )
 
                 # collapse them down
                 LOGGER.debug("collapsing reqs for config: %s", cbc_path)
                 final_cfgs = {}
-                for plat_arch, varyml in zip(plat_arch, varient_yamls):
+                for plat_arch, varyml in zip(plat_arch, variant_yamls):
                     if plat_arch not in final_cfgs:
                         final_cfgs[plat_arch] = []
                     final_cfgs[plat_arch].append(varyml)
@@ -283,17 +283,17 @@ def populate_feedstock_attributes(
                     ymls = final_cfgs[k]
                     final_cfgs[k] = _convert_to_dict(ChainDB(*ymls))
                 plat_arch = []
-                varient_yamls = []
+                variant_yamls = []
                 for k, v in final_cfgs.items():
                     plat_arch.append(k)
-                    varient_yamls.append(v)
+                    variant_yamls.append(v)
         else:
             LOGGER.debug("doing generic parsing")
             plat_arch = [("win", "64"), ("osx", "64"), ("linux", "64")]
             for k in set(sub_graph["conda-forge.yml"].get("provider", {})):
                 if "_" in k:
                     plat_arch.append(tuple(k.split("_")))
-            varient_yamls = [
+            variant_yamls = [
                 parse_meta_yaml(meta_yaml, platform=plat, arch=arch)
                 for plat, arch in plat_arch
             ]
@@ -307,8 +307,8 @@ def populate_feedstock_attributes(
     LOGGER.debug("platforms: %s", plat_arch)
 
     # this makes certain that we have consistent ordering
-    sorted_varient_yamls = [x for _, x in sorted(zip(plat_arch, varient_yamls))]
-    yaml_dict = ChainDB(*sorted_varient_yamls)
+    sorted_variant_yamls = [x for _, x in sorted(zip(plat_arch, variant_yamls))]
+    yaml_dict = ChainDB(*sorted_variant_yamls)
     if not yaml_dict:
         LOGGER.error(f"Something odd happened when parsing recipe {name}")
         sub_graph["parsing_error"] = "make_graph: Could not parse"
@@ -317,7 +317,7 @@ def populate_feedstock_attributes(
     sub_graph["meta_yaml"] = _convert_to_dict(yaml_dict)
     meta_yaml = sub_graph["meta_yaml"]
 
-    for k, v in zip(plat_arch, varient_yamls):
+    for k, v in zip(plat_arch, variant_yamls):
         plat_arch_name = "_".join(k)
         sub_graph[f"{plat_arch_name}_meta_yaml"] = v
         _, sub_graph[f"{plat_arch_name}_requirements"], _ = _extract_requirements(v)

--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -305,6 +305,7 @@ def populate_feedstock_attributes(
         raise
 
     LOGGER.debug("platforms: %s", plat_arch)
+    sub_graph["platforms"] = ["_".join(k) for k in plat_arch]
 
     # this makes certain that we have consistent ordering
     sorted_variant_yamls = [x for _, x in sorted(zip(plat_arch, variant_yamls))]

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -188,6 +188,10 @@ class MigrationYaml(GraphMigrator):
 
         platform_filtered = False
         if platform_allowlist:
+            # migrator.platform_allowlist allows both styles: "osx-64" & "osx_64";
+            # before comparison, normalize to consistently use underscores (we get
+            # "_" in attrs.platforms from the feedstock_parser)
+            platform_allowlist = [x.replace("-", "_") for x in platform_allowlist]
             # filter out nodes where the intersection between
             # attrs.platforms and platform_allowlist is empty
             intersection = set(attrs.get("platforms", {})) & set(platform_allowlist)

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -183,14 +183,14 @@ class MigrationYaml(GraphMigrator):
         Calls up the MRO until Migrator.filter, see docstring there (./core.py).
         """
         migrator_payload = self.loaded_yaml.get("__migrator", {})
-        platform_restriction = migrator_payload.get("platform_restriction", [])
+        platform_allowlist = migrator_payload.get("platform_allowlist", [])
         wait_for_migrators = migrator_payload.get("wait_for_migrators", [])
 
         platform_filtered = False
-        if platform_restriction:
+        if platform_allowlist:
             # filter out nodes where the intersection between
-            # attrs.platforms and platform_restriction is empty
-            intersection = set(attrs.get("platforms", {})) & set(platform_restriction)
+            # attrs.platforms and platform_allowlist is empty
+            intersection = set(attrs.get("platforms", {})) & set(platform_allowlist)
             platform_filtered = not bool(intersection)
 
         need_to_wait = False

--- a/conda_forge_tick/migrators_types.pyi
+++ b/conda_forge_tick/migrators_types.pyi
@@ -111,6 +111,7 @@ class AttrsTypedDict_(TypedDict, total=False):
     package: PackageTypedDict
     raw_meta_yaml: str
     req: Set[str]
+    platforms: List[str]
     requirements: RequirementsTypedDict
     source: SourceTypedDict
     test: TestTypedDict


### PR DESCRIPTION
Very specifically for https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1359, though hopefully useful in general.

I thought about this a bit, but I'm completely new to this codebase, and it's a bit hard to penetrate TBH. I mainly tried to follow Matthew's [idea](https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1359#issuecomment-1029945907).

The migrator for fortran-only-on-windows would then look like:
```
__migrator:
  kind:
    version
  migration_number: 1
  build_number: 1
  longterm: True
  platform_allowlist:  # new
    - win_64           # new
  override_cbc_keys:
    - fortran_compiler_stub
```

The underscore in `win_64` comes from the same pattern [elsewhere](https://github.com/regro/cf-scripts/blob/36cdec4560688d99aeced594f9d7e5da10e093b2/conda_forge_tick/feedstock_parser.py#L321) in `feedstock_parser.py`, but unsurprisingly I don't care whether it's `-` or `_` (or whatever).

The tricker bit is writing tests for this. I tried to look for tests for the similar `wait_for_migrators`, but this has no tests either (which is probably why it's [broken](https://github.com/regro/cf-scripts/issues/1595))... Advice & help welcome