### PR TITLE
Piggyback migrator for boost unification

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -108,6 +108,7 @@ from conda_forge_tick.migrators import (
     DependencyUpdateMigrator,
     QtQtMainMigrator,
     JpegTurboMigrator,
+    LibboostMigrator,
 )
 
 from conda_forge_feedstock_check_solvable import is_recipe_solvable
@@ -677,6 +678,8 @@ def add_rebuild_migration_yaml(
         piggy_back_migrations.append(QtQtMainMigrator())
     if migration_name == "jpeg_to_libjpeg_turbo":
         piggy_back_migrations.append(JpegTurboMigrator())
+    if migration_name == "boost_cpp_to_libboost":
+        piggy_back_migrations.append(LibboostMigrator())
     cycles = list(nx.simple_cycles(total_graph))
     migrator = MigrationYaml(
         migration_yaml,

--- a/conda_forge_tick/migrators/__init__.py
+++ b/conda_forge_tick/migrators/__init__.py
@@ -9,6 +9,7 @@ from .conda_forge_yaml_cleanup import CondaForgeYAMLCleanup
 from .mpi_pin_run_as_build import MPIPinRunAsBuildCleanup
 from .qt_to_qt_main import QtQtMainMigrator
 from .jpegturbo import JpegTurboMigrator
+from .libboost import LibboostMigrator
 from .migration_yaml import MigrationYaml, MigrationYamlCreator, merge_migrator_cbc
 from .arch import ArchRebuild, OSXArm
 from .pip_check import PipCheckMigrator

--- a/conda_forge_tick/migrators/libboost.py
+++ b/conda_forge_tick/migrators/libboost.py
@@ -1,0 +1,163 @@
+from conda_forge_tick.migrators.core import MiniMigrator
+import os
+import re
+
+
+def _slice_into_output_sections(meta_yaml_lines, attrs):
+    """
+    Turn a recipe into slices corresponding to the outputs.
+
+    To correctly process requirement sections from either
+    single or multi-output recipes, we need to be able to
+    restrict which lines we're operating on.
+
+    Takes a list of lines and returns a dict from each output name to
+    the list of lines where this output is described in the meta.yaml.
+    The result will always contain a "global" section (== everything
+    if there are no other outputs).
+    """
+    outputs = attrs["meta_yaml"].get("outputs", [])
+    output_names = [o["name"] for o in outputs]
+    # if there are no outputs, there's only one section
+    if not output_names:
+        return {"global": meta_yaml_lines}
+    # output_names may contain duplicates; remove them but keep order
+    names = []
+    [names := names + [x] for x in output_names if x not in names]
+    num_outputs = len(names)
+    # add dummy for later use & reverse list for easier pop()ing
+    names += ["dummy"]
+    names.reverse()
+    # initialize
+    pos, prev, seek = 0, "global", names.pop()
+    sections = {}
+    for i, line in enumerate(meta_yaml_lines):
+        # assumes order of names matches their appearance in meta_yaml,
+        # and that they appear literally (i.e. no {{...}}) and without quotes
+        if f"- name: {seek}" in line:
+            # found the beginning of the next output;
+            # everything until here belongs to the previous one
+            sections[prev] = meta_yaml_lines[pos:i]
+            # update
+            pos, prev, seek = i, seek, names.pop()
+            if seek == "dummy":
+                # reached the last output; it goes until the end of the file
+                sections[prev] = meta_yaml_lines[pos:]
+    if len(sections) != num_outputs + 1:
+        raise RuntimeError("Could not find all output sections in meta.yaml!")
+    return sections
+
+
+def _process_section(name, attrs, lines):
+    """
+    Migrate requirements per section.
+
+    We want to migrate as follows:
+    - rename boost to libboost-python
+    - if boost-cpp is only a host-dep, rename to libboost-headers
+    - if boost-cpp is _also_ a run-dep, rename it to libboost in host
+      and remove it in run.
+    """
+    outputs = attrs["meta_yaml"].get("outputs", [])
+    if name == "global":
+        reqs = attrs["meta_yaml"].get("requirements", {})
+    else:
+        filtered = [o for o in outputs if o["name"] == name]
+        if len(filtered) == 0:
+            raise RuntimeError(f"Could not find output {name}!")
+        reqs = filtered[0].get("requirements", {})
+
+    build_req = reqs.get("build", set()) or set()
+    host_req = reqs.get("host", set()) or set()
+    run_req = reqs.get("run", set()) or set()
+
+    is_boost_in_build = "boost-cpp" in build_req
+    is_boost_in_host = "boost-cpp" in host_req
+    is_boost_in_run = "boost-cpp" in run_req
+
+    # anything behind a comment needs to get replaced first, so it
+    # doesn't mess up the counts below
+    lines = _replacer(
+        lines,
+        r"^(?P<before>\s*\#.*)\b(boost-cpp)\b(?P<after>.*)$",
+        r"\g<before>libboost-devel\g<after>",
+    )
+
+    # boost-cpp, followed optionally by e.g. " =1.72.0" or " {{ boost_cpp }}"
+    p_base = r"boost-cpp(\s*[<>=]?=?[\d\.]+)?(\s+\{\{.*\}\})?"
+    p_selector = r"(\s+\#\s\[.*\])?"
+    if is_boost_in_build:
+        # if boost also occurs in build (assuming only once), replace it once
+        # but keep selectors (e.g. `# [build_platform != target_platform]`)
+        lines = _replacer(lines, p_base, "libboost-devel", max_times=1)
+
+    if is_boost_in_host and is_boost_in_run:
+        # presence in both means we want to replace with libboost, but only in host;
+        # because libboost-devel only exists from newest 1.82, we remove version pins;
+        # generally we assume there's one occurrence in host and on in run, but due
+        # to selectors, this may not be the case; to keep the logic tractable, we
+        # remove all occurrences but the first (and thus need to remove selectors too)
+        lines = _replacer(lines, p_base + p_selector, "libboost-devel", max_times=1)
+        # delete all other occurrences
+        lines = _replacer(lines, "boost-cpp", "")
+    elif is_boost_in_host and name == "global" and outputs:
+        # global build section for multi-output with no run-requirements;
+        # safer to use the full library here
+        lines = _replacer(lines, p_base + p_selector, "libboost-devel", max_times=1)
+        # delete all other occurrences
+        lines = _replacer(lines, "boost-cpp", "")
+    elif is_boost_in_host:
+        # here we know we can replace all with libboost-headers
+        lines = _replacer(lines, p_base, "libboost-headers")
+    elif is_boost_in_run and outputs:
+        # case of multi-output but with the host deps being only in
+        # global section; remove run-deps of boost-cpp nevertheless
+        lines = _replacer(lines, "boost-cpp", "")
+    # in any case, replace occurrences of "- boost"
+    lines = _replacer(lines, "- boost", "- libboost-python-devel")
+    lines = _replacer(lines, r"pin_compatible\([\"\']boost", "")
+    return lines
+
+
+def _replacer(lines, from_this, to_that, max_times=None):
+    """
+    Replaces one pattern with a string in a set of lines, up to max_times
+    """
+    i = 0
+    new_lines = []
+    pat = re.compile(from_this)
+    for line in lines:
+        if pat.search(line) and (max_times is None or i < max_times):
+            i += 1
+            # if to_that is empty, discard line
+            if not to_that:
+                continue
+            line = pat.sub(to_that, line)
+        new_lines.append(line)
+    return new_lines
+
+
+class LibboostMigrator(MiniMigrator):
+    def filter(self, attrs, not_bad_str_start=""):
+        host_req = (attrs.get("requirements", {}) or {}).get("host", set()) or set()
+        run_req = (attrs.get("requirements", {}) or {}).get("run", set()) or set()
+        all_req = set(host_req) | set(run_req)
+        # filter() returns True if we _don't_ want to migrate
+        return not bool({"boost", "boost-cpp"} & all_req)
+
+    def migrate(self, recipe_dir, attrs, **kwargs):
+        outputs = attrs["meta_yaml"].get("outputs", [])
+
+        fname = os.path.join(recipe_dir, "meta.yaml")
+        if os.path.exists(fname):
+            with open(fname) as fp:
+                lines = fp.readlines()
+
+            new_lines = []
+            sections = _slice_into_output_sections(lines, attrs)
+            for name, section in sections.items():
+                # _process_section returns list of lines already
+                new_lines += _process_section(name, attrs, section)
+
+            with open(fname, "w") as fp:
+                fp.write("".join(new_lines))

--- a/tests/test_libboost.py
+++ b/tests/test_libboost.py
@@ -27,6 +27,8 @@ VERSION_WITH_LIBBOOST = Version(
         ("fenics", "1.10.0"),
         # multiple outputs, jinja-style pinning
         ("poppler", "1.10.0"),
+        # multiple outputs, complicated selector & pinning combinations
+        ("scipopt", "1.10.0"),
     ],
 )
 def test_boost(feedstock, new_ver, tmpdir):

--- a/tests/test_libboost.py
+++ b/tests/test_libboost.py
@@ -1,0 +1,47 @@
+import os
+import pytest
+from flaky import flaky
+
+from conda_forge_tick.migrators import LibboostMigrator, Version
+from test_migrators import run_test_migration
+
+
+TEST_YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")
+
+
+LIBBOOST = LibboostMigrator()
+VERSION_WITH_LIBBOOST = Version(
+    set(),
+    piggy_back_migrations=[LIBBOOST],
+)
+
+
+@pytest.mark.parametrize(
+    "feedstock,new_ver",
+    [
+        # this space intentionally left blank
+    ],
+)
+def test_boost(feedstock, new_ver, tmpdir):
+    before = f"libboost_{feedstock}_before_meta.yaml"
+    with open(os.path.join(TEST_YAML_PATH, before)) as fp:
+        in_yaml = fp.read()
+
+    after = f"libboost_{feedstock}_after_meta.yaml"
+    with open(os.path.join(TEST_YAML_PATH, after)) as fp:
+        out_yaml = fp.read()
+
+    run_test_migration(
+        m=VERSION_WITH_LIBBOOST,
+        inp=in_yaml,
+        output=out_yaml,
+        kwargs={"new_version": new_ver},
+        prb="Dependencies have been updated if changed",
+        mr_out={
+            "migrator_name": "Version",
+            "migrator_version": VERSION_WITH_LIBBOOST.migrator_version,
+            "version": new_ver,
+        },
+        tmpdir=tmpdir,
+        should_filter=False,
+    )

--- a/tests/test_libboost.py
+++ b/tests/test_libboost.py
@@ -23,6 +23,8 @@ VERSION_WITH_LIBBOOST = Version(
         ("gudhi", "1.10.0"),
         # single output; with run-dep
         ("carve", "1.10.0"),
+        # multiple outputs, many don't depend on boost; comment trickiness
+        ("fenics", "1.10.0"),
     ],
 )
 def test_boost(feedstock, new_ver, tmpdir):

--- a/tests/test_libboost.py
+++ b/tests/test_libboost.py
@@ -29,6 +29,11 @@ VERSION_WITH_LIBBOOST = Version(
         ("poppler", "1.10.0"),
         # multiple outputs, complicated selector & pinning combinations
         ("scipopt", "1.10.0"),
+        # testing boost -> libboost-python
+        ("rdkit", "1.10.0"),
+        # interaction between boost & boost-cpp;
+        # multiple outputs but no host deps
+        ("cctx", "1.10.0"),
     ],
 )
 def test_boost(feedstock, new_ver, tmpdir):

--- a/tests/test_libboost.py
+++ b/tests/test_libboost.py
@@ -25,6 +25,8 @@ VERSION_WITH_LIBBOOST = Version(
         ("carve", "1.10.0"),
         # multiple outputs, many don't depend on boost; comment trickiness
         ("fenics", "1.10.0"),
+        # multiple outputs, jinja-style pinning
+        ("poppler", "1.10.0"),
     ],
 )
 def test_boost(feedstock, new_ver, tmpdir):

--- a/tests/test_libboost.py
+++ b/tests/test_libboost.py
@@ -19,7 +19,10 @@ VERSION_WITH_LIBBOOST = Version(
 @pytest.mark.parametrize(
     "feedstock,new_ver",
     [
-        # this space intentionally left blank
+        # single output; no run-dep
+        ("gudhi", "1.10.0"),
+        # single output; with run-dep
+        ("carve", "1.10.0"),
     ],
 )
 def test_boost(feedstock, new_ver, tmpdir):

--- a/tests/test_yaml/libboost_carve_after_meta.yaml
+++ b/tests/test_yaml/libboost_carve_after_meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "carve" %}
+{% set version = "1.10.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 3f9e587a96844a9b4ee7f998cfe4dc3964dc95c4ca94d7de6a77bffb99f873da
+  # url: https://github.com/ngodber/carve/archive/v{{ version }}.tar.gz
+  # sha256: 20481918af488fc92694bf1d5bdd6351ad73a0b64fbe4373e1f829a7b0eeff63
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("carve", max_pin="x.x") }}
+
+requirements:
+  build:
+    - cmake
+    - make  # [unix]
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - libboost-devel
+  run:
+
+test:
+  commands:
+    - test -f ${PREFIX}/bin/slice  # [unix]
+    - test -f ${PREFIX}/bin/intersect  # [unix]
+    - test -f ${PREFIX}/bin/triangulate  # [unix]
+    - test -f ${PREFIX}/bin/convert  # [unix]
+    - test -f ${PREFIX}/lib/libcarve${SHLIB_EXT}  # [unix]
+    - if not exist %LIBRARY_PREFIX%\bin\carve.dll exit 1  # [win]
+    - if not exist %LIBRARY_PREFIX%\bin\slice.exe exit 1  # [win]
+    - if not exist %LIBRARY_PREFIX%\bin\intersect.exe exit 1  # [win]
+    - if not exist %LIBRARY_PREFIX%\bin\triangulate.exe exit 1  # [win]
+    - if not exist %LIBRARY_PREFIX%\bin\convert.exe exit 1  # [win]
+
+about:
+  home: https://github.com/PyMesh/carve
+  license: GPL-2.0-or-later
+  license_family: GPL
+  license_file: LICENSE
+  summary: Carve computes boolean operations between sets of arbitrary closed and open surfaces
+  description: |
+    Carve computes boolean operations between sets of arbitrary closed and open surfaces faster, more robustly and with fewer restrictions than comparable software.
+  dev_url: https://github.com/PyMesh/carve
+
+extra:
+  recipe-maintainers:
+    - ngodber

--- a/tests/test_yaml/libboost_carve_before_meta.yaml
+++ b/tests/test_yaml/libboost_carve_before_meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "carve" %}
+{% set version = "1.9.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: b6d893dc7dcd4138b9e9df59a13c59695e50e80dc5c2cacee0674670693951a1
+  # url: https://github.com/ngodber/carve/archive/v{{ version }}.tar.gz
+  # sha256: 20481918af488fc92694bf1d5bdd6351ad73a0b64fbe4373e1f829a7b0eeff63
+
+build:
+  number: 1
+  run_exports:
+    - {{ pin_subpackage("carve", max_pin="x.x") }}
+
+requirements:
+  build:
+    - cmake
+    - make  # [unix]
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - boost-cpp
+  run:
+    - boost-cpp
+
+test:
+  commands:
+    - test -f ${PREFIX}/bin/slice  # [unix]
+    - test -f ${PREFIX}/bin/intersect  # [unix]
+    - test -f ${PREFIX}/bin/triangulate  # [unix]
+    - test -f ${PREFIX}/bin/convert  # [unix]
+    - test -f ${PREFIX}/lib/libcarve${SHLIB_EXT}  # [unix]
+    - if not exist %LIBRARY_PREFIX%\bin\carve.dll exit 1  # [win]
+    - if not exist %LIBRARY_PREFIX%\bin\slice.exe exit 1  # [win]
+    - if not exist %LIBRARY_PREFIX%\bin\intersect.exe exit 1  # [win]
+    - if not exist %LIBRARY_PREFIX%\bin\triangulate.exe exit 1  # [win]
+    - if not exist %LIBRARY_PREFIX%\bin\convert.exe exit 1  # [win]
+
+about:
+  home: https://github.com/PyMesh/carve
+  license: GPL-2.0-or-later
+  license_family: GPL
+  license_file: LICENSE
+  summary: Carve computes boolean operations between sets of arbitrary closed and open surfaces
+  description: |
+    Carve computes boolean operations between sets of arbitrary closed and open surfaces faster, more robustly and with fewer restrictions than comparable software.
+  dev_url: https://github.com/PyMesh/carve
+
+extra:
+  recipe-maintainers:
+    - ngodber

--- a/tests/test_yaml/libboost_cctx_after_meta.yaml
+++ b/tests/test_yaml/libboost_cctx_after_meta.yaml
@@ -1,0 +1,137 @@
+{% set version = "1.10.0" %}
+
+package:
+  name: cctbx-base
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 3f9e587a96844a9b4ee7f998cfe4dc3964dc95c4ca94d7de6a77bffb99f873da
+  # url: https://github.com/cctbx/cctbx_project/releases/download/v{{ version }}/cctbx-{{ version }}.tar.gz
+  # sha256: ad46f373875e1893f5fa87267b5445b97d660d0d05887e41d38d1fdd0e46724b
+  patches:
+    - cbf.patch
+    - dxtbx.patch
+    - libann.patch
+    - libtbx_osx-arm64.patch  # [build_platform != target_platform]
+    - libtbx_SConscript.patch
+
+build:
+  number: 0
+  preserve_egg_dir: true
+
+requirements:
+  build:
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - numpy                                  # [build_platform != target_platform]
+    - gnuconfig  # [unix]
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ cdt('mesa-libgl-devel') }}  # [linux]
+    - {{ cdt('mesa-dri-drivers') }}  # [linux]
+    - {{ cdt('libselinux') }}  # [linux]
+    - {{ cdt('libxdamage') }}  # [linux]
+    - {{ cdt('libxxf86vm') }}  # [linux]
+    - {{ cdt('libxext') }}     # [linux]
+  host:
+    - libboost-python-devel
+    - libboost-devel
+    - eigen
+    - future
+    - libglu  # [linux]
+    - numpy
+    - pip
+    - python
+    - python.app  # [osx]
+    - scons
+    - setuptools
+    - six
+    - xorg-libxfixes  # [linux]
+
+outputs:
+  - name: cctbx-base
+    requirements:
+      run:
+        - biopython
+        - future
+        - {{ pin_compatible('libglu') }}  # [linux]
+        - libsvm
+        - matplotlib-base
+        - mrcfile
+        - {{ pin_compatible('numpy') }}
+        - pillow
+        - psutil
+        - python
+        - python.app  # [osx]
+        - reportlab
+        - requests
+        - scipy
+        - six
+    test:
+      imports:
+        - scitbx.array_family.flex
+        - gltbx.gl  # [not (win and py>=38)]
+        - gltbx.glu  # [not (win and py>=38)]
+      commands:
+        - libtbx.show_commands
+        - pip check
+      requires:
+        - pip
+
+  - name: cctbx
+    requirements:
+      host:
+        - python
+      run:
+        - {{ pin_subpackage('cctbx-base', max_pin="x.x.x") }}
+        - ipython
+        - pyside2  # [x86_64 or arm64]
+        - python
+        - pyzmq
+        - websockets
+        - wxpython  # [x86_64 or arm64]
+    test:
+      imports:
+        - scitbx.array_family.flex
+        - gltbx.gl  # [not (win and py>=38)]
+        - gltbx.glu  # [not (win and py>=38)]
+      commands:
+        - libtbx.show_commands
+        - pip check
+        - libtbx.python -c "import wx; wx.App()"  # [not linux]
+      requires:
+        - pip
+
+about:
+  home: https://github.com/cctbx/cctbx_project
+  license: BSD-3-Clause-LBNL AND BSD-3-Clause AND BSL-1.0 AND LGPL-2.0-only AND LGPL-2.1-only AND LGPL-3.0-only AND MIT AND LGPL-2.0-or-later WITH WxWindows-exception-3.1
+  license_family: Other
+  license_file:
+    - ./licenses/LICENSE.txt
+    - ./licenses/Boost_LICENSE_1_0.txt
+    - ./licenses/bsd_3_clause.txt
+    - ./licenses/gpl-3.0.txt
+    - ./licenses/lgpl-2.0.txt
+    - ./licenses/lgpl-2.1.txt
+    - ./licenses/lgpl-3.0.txt
+    - ./licenses/mit.txt
+    - ./licenses/wxWindows_3.1.txt
+
+  summary: The Computational Crystallography Toolbox
+  description: |
+    The Computational Crystallography Toolbox (cctbx) is being developed
+    as the open source component of the Phenix system. The goal of the
+    Phenix project is to advance automation of macromolecular structure
+    determination. Phenix depends on the cctbx, but not vice versa. This
+    hierarchical approach enforces a clean design as a reusable library.
+    The cctbx is therefore also useful for small-molecule crystallography
+    and even general scientific applications.
+  doc_url: https://cctbx.github.io/
+  dev_url: https://github.com/cctbx/cctbx_project
+
+extra:
+  recipe-maintainers:
+    - bkpoon
+    - phyy-nx

--- a/tests/test_yaml/libboost_cctx_before_meta.yaml
+++ b/tests/test_yaml/libboost_cctx_before_meta.yaml
@@ -1,0 +1,139 @@
+{% set version = "1.9.0" %}
+
+package:
+  name: cctbx-base
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: b6d893dc7dcd4138b9e9df59a13c59695e50e80dc5c2cacee0674670693951a1
+  # url: https://github.com/cctbx/cctbx_project/releases/download/v{{ version }}/cctbx-{{ version }}.tar.gz
+  # sha256: ad46f373875e1893f5fa87267b5445b97d660d0d05887e41d38d1fdd0e46724b
+  patches:
+    - cbf.patch
+    - dxtbx.patch
+    - libann.patch
+    - libtbx_osx-arm64.patch  # [build_platform != target_platform]
+    - libtbx_SConscript.patch
+
+build:
+  number: 0
+  preserve_egg_dir: true
+
+requirements:
+  build:
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - numpy                                  # [build_platform != target_platform]
+    - gnuconfig  # [unix]
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ cdt('mesa-libgl-devel') }}  # [linux]
+    - {{ cdt('mesa-dri-drivers') }}  # [linux]
+    - {{ cdt('libselinux') }}  # [linux]
+    - {{ cdt('libxdamage') }}  # [linux]
+    - {{ cdt('libxxf86vm') }}  # [linux]
+    - {{ cdt('libxext') }}     # [linux]
+  host:
+    - boost
+    - boost-cpp
+    - eigen
+    - future
+    - libglu  # [linux]
+    - numpy
+    - pip
+    - python
+    - python.app  # [osx]
+    - scons
+    - setuptools
+    - six
+    - xorg-libxfixes  # [linux]
+
+outputs:
+  - name: cctbx-base
+    requirements:
+      run:
+        - biopython
+        - {{ pin_compatible('boost') }}
+        - boost-cpp
+        - future
+        - {{ pin_compatible('libglu') }}  # [linux]
+        - libsvm
+        - matplotlib-base
+        - mrcfile
+        - {{ pin_compatible('numpy') }}
+        - pillow
+        - psutil
+        - python
+        - python.app  # [osx]
+        - reportlab
+        - requests
+        - scipy
+        - six
+    test:
+      imports:
+        - scitbx.array_family.flex
+        - gltbx.gl  # [not (win and py>=38)]
+        - gltbx.glu  # [not (win and py>=38)]
+      commands:
+        - libtbx.show_commands
+        - pip check
+      requires:
+        - pip
+
+  - name: cctbx
+    requirements:
+      host:
+        - python
+      run:
+        - {{ pin_subpackage('cctbx-base', max_pin="x.x.x") }}
+        - ipython
+        - pyside2  # [x86_64 or arm64]
+        - python
+        - pyzmq
+        - websockets
+        - wxpython  # [x86_64 or arm64]
+    test:
+      imports:
+        - scitbx.array_family.flex
+        - gltbx.gl  # [not (win and py>=38)]
+        - gltbx.glu  # [not (win and py>=38)]
+      commands:
+        - libtbx.show_commands
+        - pip check
+        - libtbx.python -c "import wx; wx.App()"  # [not linux]
+      requires:
+        - pip
+
+about:
+  home: https://github.com/cctbx/cctbx_project
+  license: BSD-3-Clause-LBNL AND BSD-3-Clause AND BSL-1.0 AND LGPL-2.0-only AND LGPL-2.1-only AND LGPL-3.0-only AND MIT AND LGPL-2.0-or-later WITH WxWindows-exception-3.1
+  license_family: Other
+  license_file:
+    - ./licenses/LICENSE.txt
+    - ./licenses/Boost_LICENSE_1_0.txt
+    - ./licenses/bsd_3_clause.txt
+    - ./licenses/gpl-3.0.txt
+    - ./licenses/lgpl-2.0.txt
+    - ./licenses/lgpl-2.1.txt
+    - ./licenses/lgpl-3.0.txt
+    - ./licenses/mit.txt
+    - ./licenses/wxWindows_3.1.txt
+
+  summary: The Computational Crystallography Toolbox
+  description: |
+    The Computational Crystallography Toolbox (cctbx) is being developed
+    as the open source component of the Phenix system. The goal of the
+    Phenix project is to advance automation of macromolecular structure
+    determination. Phenix depends on the cctbx, but not vice versa. This
+    hierarchical approach enforces a clean design as a reusable library.
+    The cctbx is therefore also useful for small-molecule crystallography
+    and even general scientific applications.
+  doc_url: https://cctbx.github.io/
+  dev_url: https://github.com/cctbx/cctbx_project
+
+extra:
+  recipe-maintainers:
+    - bkpoon
+    - phyy-nx

--- a/tests/test_yaml/libboost_fenics_after_meta.yaml
+++ b/tests/test_yaml/libboost_fenics_after_meta.yaml
@@ -1,0 +1,292 @@
+{% set version = "1.10.0" %}
+
+package:
+  name: fenics-pkgs
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  - url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: 3f9e587a96844a9b4ee7f998cfe4dc3964dc95c4ca94d7de6a77bffb99f873da
+  # - url: https://bitbucket.org/fenics-project/dijitso/downloads/dijitso-{{ version }}.tar.gz
+  #   sha256: eaa45eec4457f3f865d72a926b7cba86df089410e78de04cd89b15bb405e8fd9
+  #   folder: dijitso
+  # - url: https://bitbucket.org/fenics-project/ffc/downloads/ffc-{{ version }}.tar.gz
+  #   sha256: 4ff821a234869d8b9aaf8c5d7f617d42f9c134a2529e76c9519b681dff35affd
+  #   folder: ffc
+  #   patches:
+  #     - ufc-include-path.patch
+  # - url: https://bitbucket.org/fenics-project/fiat/downloads/fiat-{{ version }}.tar.gz
+  #   sha256: 341a1046cbe0f5f2eb26630c2f71f378b0dca51daf9892a54a2ff193970371e9
+  #   folder: fiat
+  # - url: https://bitbucket.org/fenics-project/ufl/downloads/ufl-{{ version }}.tar.gz
+  #   sha256: 213a56bfa2edb0365909fa6f110f970e582b10a3f5f1fd9a0e85254f1eefaa11
+  #   folder: ufl
+  # - url: https://bitbucket.org/fenics-project/dolfin/downloads/dolfin-{{ version }}.post0.tar.gz
+  #   sha256: 61abdcdb13684ba2a3ba4afb7ea6c7907aa0896a46439d3af7e8848483d4392f
+  #   folder: dolfin
+  #   patches:
+  #     - libboost-python-devel.patch
+  #     - linuxboost.patch  # [linux]
+  #     - find-petsc-slepc.patch
+  #     - hdf5-1.12.patch
+  #     - fix-xdmf.patch
+
+build:
+  number: 0
+  skip: true  # [win]
+
+# NOTE: Top-level environment with libboost-devel is only to separate the build for
+#       multiple boost versions into different CI jobs.
+# TODO: Needs investigation why "separate the two boost builds more strictly"
+#       would be necessary. Ref:
+#       https://github.com/conda-forge/mshr-feedstock/pull/23#issuecomment-749520383
+requirements:
+  host:
+    - libboost-devel
+    # need to split the build matrix on mpi provider
+    - {{ mpi }}
+
+outputs:
+  - name: fenics-dijitso
+    build:
+      script: $PYTHON -m pip install --no-deps ./dijitso
+    requirements:
+      host:
+        - python
+        - pip
+      run:
+        - python
+        - numpy
+        - setuptools
+    test:
+      imports:
+        - dijitso
+
+  - name: fenics-fiat
+    build:
+      script: $PYTHON -m pip install --no-deps ./fiat
+    requirements:
+      host:
+        - python
+        - pip
+      run:
+        - python
+        - setuptools
+        - numpy
+        - sympy >=1
+    test:
+      imports:
+        - FIAT
+
+  - name: fenics-ufl
+    build:
+      script: $PYTHON -m pip install --no-deps ./ufl
+    requirements:
+      host:
+        - python
+        - pip
+      run:
+        - python
+        - setuptools
+        - numpy
+    test:
+      imports:
+        - ufl
+        - ufl.utils
+        - ufl.finiteelement
+        - ufl.core
+        - ufl.corealg
+        - ufl.algorithms
+
+  - name: fenics-ffc
+    build:
+      script:
+        - $PYTHON -m pip install --no-deps ./ffc
+        - mkdir -p $PREFIX/include
+        - cp ffc/ffc/backends/ufc/*.h $PREFIX/include/
+    requirements:
+      host:
+        - python
+        - pip
+      run:
+        - python
+        - numpy
+        - {{ pin_subpackage("fenics-dijitso", exact=True) }}
+        - {{ pin_subpackage("fenics-fiat", exact=True) }}
+        - {{ pin_subpackage("fenics-ufl", exact=True) }}
+    test:
+      imports:
+        - ffc
+        - ffc.backends
+        - ffc.backends.dolfin
+        - ffc.backends.ufc
+        - ffc.errorcontrol
+        - ffc.quadrature
+      commands:
+        - ffc --help
+        - test -f $PREFIX/include/ufc.h
+        - test -f $PREFIX/include/ufc_geometry.h
+
+  - name: fenics-libdolfin
+    build:
+      script: ${RECIPE_DIR}/build-libdolfin.sh
+      skip: true  # [win]
+      script_env:
+        - OMPI_MCA_plm=isolated
+        - OMPI_MCA_rmaps_base_oversubscribe=yes
+        - OMPI_MCA_btl_vader_single_copy_mechanism=none
+      # [[not jinja]] set mpi_prefix = "mpi_" + mpi [[anymore]]
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+      host:
+        - libblas
+        - libcblas
+        - libboost-devel
+        - cmake >=3.9
+        - make
+        - eigen
+        - parmetis
+        - pkg-config
+        - ptscotch
+        - suitesparse
+        - zlib
+        - {{ mpi }}
+        - petsc
+        - slepc
+        - fenics-ffc =={{ version }}
+        # need to list libnetcdf and netcdf-fortran twice to get version
+        # pinning from conda_build_config and build pinning from {{ mpi_prefix }}
+        - hdf5
+        - hdf5 * {{ mpi_prefix }}_*
+      run:
+        - {{ compiler('cxx') }}  # [linux]
+        - cmake >=3.9
+        - eigen
+        - {{ mpi }}
+        - parmetis
+        - petsc
+        - slepc
+        - pkg-config
+        - ptscotch
+        - suitesparse
+        - zlib
+        - fenics-ffc =={{ version }}
+    test:
+      commands:
+        - test -f ${PREFIX}/lib/libdolfin${SHLIB_EXT}
+        - test -f ${PREFIX}/lib/libdolfin.{{ version }}${SHLIB_EXT}  # [osx]
+        - test -f ${PREFIX}/lib/libdolfin${SHLIB_EXT}.{{ version }}  # [linux]
+
+  - name: fenics-dolfin
+    build:
+      script: ${RECIPE_DIR}/build-dolfin.sh
+      script_env:
+        - OMPI_MCA_plm=isolated
+        - OMPI_MCA_rmaps_base_oversubscribe=yes
+        - OMPI_MCA_btl_vader_single_copy_mechanism=none
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+      host:
+        - libblas
+        - libcblas
+        - libboost-devel
+        - python
+        - pip
+        - cmake >=3.9
+        - make
+        - pkgconfig
+        - {{ mpi }}
+        - mpi4py
+        - petsc4py
+        - slepc4py
+        - numpy
+        - pybind11
+        - six
+        - sympy >=1
+        - {{ pin_subpackage("fenics-libdolfin", exact=True) }}
+        - fenics-dijitso =={{ version }}
+        - fenics-fiat =={{ version }}
+        - fenics-ufl =={{ version }}
+        - fenics-ffc =={{ version }}
+        # need to list libnetcdf and netcdf-fortran twice to get version
+        # pinning from conda_build_config and build pinning from {{ mpi_prefix }}
+        - hdf5
+        - hdf5 * {{ mpi_prefix }}_*
+      run:
+        - {{ compiler('cxx') }}  # [linux]
+        - python
+        - setuptools
+        - {{ mpi }}
+        - mpi4py
+        - petsc
+        - petsc4py
+        - slepc
+        - slepc4py
+        - pkgconfig  # Python pkgconfig package
+        - pybind11
+        - {{ pin_compatible('numpy', max_pin=None) }}
+        - six
+        - sympy >=1
+        - {{ pin_subpackage("fenics-libdolfin", exact=True) }}
+        - fenics-dijitso =={{ version }}
+        - fenics-fiat =={{ version }}
+        - fenics-ufl =={{ version }}
+        - fenics-ffc =={{ version }}
+
+    test:
+      commands:
+        - bash ${RECIPE_DIR}/parent/test-dolfin.sh
+      source_files:
+        - dolfin/python/test
+
+      requires:
+        - nose
+        - pytest
+        - git
+        - decorator
+
+  - name: fenics
+    build:
+      skip: true  # [win or py2k]
+      script: echo 1
+    requirements:
+      host:
+        - python
+        - {{ mpi }}  # ensure mpi is in hash inputs
+      run:
+        - python
+        - {{ pin_subpackage("fenics-dijitso", exact=True) }}
+        - {{ pin_subpackage("fenics-fiat", exact=True) }}
+        - {{ pin_subpackage("fenics-ufl", exact=True) }}
+        - {{ pin_subpackage("fenics-ffc", exact=True) }}
+        - {{ pin_subpackage('fenics-dolfin', exact=True) }}
+    test:
+      commands:
+        - bash ${RECIPE_DIR}/parent/test-fenics.sh
+
+about:
+  home: http://www.fenicsproject.org
+  license: LGPL-3.0-or-later
+  license_file: dolfin/COPYING.LESSER
+  summary: FEniCS is a collection of free software for automated, efficient solution of differential equations
+
+  description: |
+    FEniCS is a collection of free software for automated, efficient solution of differential equations
+    (<http://fenicsproject.org>). It provides C++ and Python interfaces, and creates efficient solvers via
+    expression of finite variational statements in a domain-specific language that are transformed and
+    just-in-time compiled into efficient implementations.
+  doc_url: http://fenics.readthedocs.io/
+  dev_url: https://bitbucket.org/fenics-project/
+
+extra:
+  recipe-maintainers:
+    - garth-wells
+    - johannesring
+    - mikaem
+    - minrk
+    - jan-janssen

--- a/tests/test_yaml/libboost_fenics_before_meta.yaml
+++ b/tests/test_yaml/libboost_fenics_before_meta.yaml
@@ -1,0 +1,294 @@
+{% set version = "1.9.0" %}
+
+package:
+  name: fenics-pkgs
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  - url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: b6d893dc7dcd4138b9e9df59a13c59695e50e80dc5c2cacee0674670693951a1
+  # - url: https://bitbucket.org/fenics-project/dijitso/downloads/dijitso-{{ version }}.tar.gz
+  #   sha256: eaa45eec4457f3f865d72a926b7cba86df089410e78de04cd89b15bb405e8fd9
+  #   folder: dijitso
+  # - url: https://bitbucket.org/fenics-project/ffc/downloads/ffc-{{ version }}.tar.gz
+  #   sha256: 4ff821a234869d8b9aaf8c5d7f617d42f9c134a2529e76c9519b681dff35affd
+  #   folder: ffc
+  #   patches:
+  #     - ufc-include-path.patch
+  # - url: https://bitbucket.org/fenics-project/fiat/downloads/fiat-{{ version }}.tar.gz
+  #   sha256: 341a1046cbe0f5f2eb26630c2f71f378b0dca51daf9892a54a2ff193970371e9
+  #   folder: fiat
+  # - url: https://bitbucket.org/fenics-project/ufl/downloads/ufl-{{ version }}.tar.gz
+  #   sha256: 213a56bfa2edb0365909fa6f110f970e582b10a3f5f1fd9a0e85254f1eefaa11
+  #   folder: ufl
+  # - url: https://bitbucket.org/fenics-project/dolfin/downloads/dolfin-{{ version }}.post0.tar.gz
+  #   sha256: 61abdcdb13684ba2a3ba4afb7ea6c7907aa0896a46439d3af7e8848483d4392f
+  #   folder: dolfin
+  #   patches:
+  #     - boost.patch
+  #     - linuxboost.patch  # [linux]
+  #     - find-petsc-slepc.patch
+  #     - hdf5-1.12.patch
+  #     - fix-xdmf.patch
+
+build:
+  number: 35
+  skip: true  # [win]
+
+# NOTE: Top-level environment with boost-cpp is only to separate the build for
+#       multiple boost versions into different CI jobs.
+# TODO: Needs investigation why "separate the two boost builds more strictly"
+#       would be necessary. Ref:
+#       https://github.com/conda-forge/mshr-feedstock/pull/23#issuecomment-749520383
+requirements:
+  host:
+    - boost-cpp
+    # need to split the build matrix on mpi provider
+    - {{ mpi }}
+
+outputs:
+  - name: fenics-dijitso
+    build:
+      script: $PYTHON -m pip install --no-deps ./dijitso
+    requirements:
+      host:
+        - python
+        - pip
+      run:
+        - python
+        - numpy
+        - setuptools
+    test:
+      imports:
+        - dijitso
+
+  - name: fenics-fiat
+    build:
+      script: $PYTHON -m pip install --no-deps ./fiat
+    requirements:
+      host:
+        - python
+        - pip
+      run:
+        - python
+        - setuptools
+        - numpy
+        - sympy >=1
+    test:
+      imports:
+        - FIAT
+
+  - name: fenics-ufl
+    build:
+      script: $PYTHON -m pip install --no-deps ./ufl
+    requirements:
+      host:
+        - python
+        - pip
+      run:
+        - python
+        - setuptools
+        - numpy
+    test:
+      imports:
+        - ufl
+        - ufl.utils
+        - ufl.finiteelement
+        - ufl.core
+        - ufl.corealg
+        - ufl.algorithms
+
+  - name: fenics-ffc
+    build:
+      script:
+        - $PYTHON -m pip install --no-deps ./ffc
+        - mkdir -p $PREFIX/include
+        - cp ffc/ffc/backends/ufc/*.h $PREFIX/include/
+    requirements:
+      host:
+        - python
+        - pip
+      run:
+        - python
+        - numpy
+        - {{ pin_subpackage("fenics-dijitso", exact=True) }}
+        - {{ pin_subpackage("fenics-fiat", exact=True) }}
+        - {{ pin_subpackage("fenics-ufl", exact=True) }}
+    test:
+      imports:
+        - ffc
+        - ffc.backends
+        - ffc.backends.dolfin
+        - ffc.backends.ufc
+        - ffc.errorcontrol
+        - ffc.quadrature
+      commands:
+        - ffc --help
+        - test -f $PREFIX/include/ufc.h
+        - test -f $PREFIX/include/ufc_geometry.h
+
+  - name: fenics-libdolfin
+    build:
+      script: ${RECIPE_DIR}/build-libdolfin.sh
+      skip: true  # [win]
+      script_env:
+        - OMPI_MCA_plm=isolated
+        - OMPI_MCA_rmaps_base_oversubscribe=yes
+        - OMPI_MCA_btl_vader_single_copy_mechanism=none
+      # [[not jinja]] set mpi_prefix = "mpi_" + mpi [[anymore]]
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+      host:
+        - libblas
+        - libcblas
+        - boost-cpp
+        - cmake >=3.9
+        - make
+        - eigen
+        - parmetis
+        - pkg-config
+        - ptscotch
+        - suitesparse
+        - zlib
+        - {{ mpi }}
+        - petsc
+        - slepc
+        - fenics-ffc =={{ version }}
+        # need to list libnetcdf and netcdf-fortran twice to get version
+        # pinning from conda_build_config and build pinning from {{ mpi_prefix }}
+        - hdf5
+        - hdf5 * {{ mpi_prefix }}_*
+      run:
+        - {{ compiler('cxx') }}  # [linux]
+        - cmake >=3.9
+        - eigen
+        - {{ mpi }}
+        - parmetis
+        - petsc
+        - slepc
+        - pkg-config
+        - ptscotch
+        - suitesparse
+        - zlib
+        - fenics-ffc =={{ version }}
+        - boost-cpp
+    test:
+      commands:
+        - test -f ${PREFIX}/lib/libdolfin${SHLIB_EXT}
+        - test -f ${PREFIX}/lib/libdolfin.{{ version }}${SHLIB_EXT}  # [osx]
+        - test -f ${PREFIX}/lib/libdolfin${SHLIB_EXT}.{{ version }}  # [linux]
+
+  - name: fenics-dolfin
+    build:
+      script: ${RECIPE_DIR}/build-dolfin.sh
+      script_env:
+        - OMPI_MCA_plm=isolated
+        - OMPI_MCA_rmaps_base_oversubscribe=yes
+        - OMPI_MCA_btl_vader_single_copy_mechanism=none
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+      host:
+        - libblas
+        - libcblas
+        - boost-cpp
+        - python
+        - pip
+        - cmake >=3.9
+        - make
+        - pkgconfig
+        - {{ mpi }}
+        - mpi4py
+        - petsc4py
+        - slepc4py
+        - numpy
+        - pybind11
+        - six
+        - sympy >=1
+        - {{ pin_subpackage("fenics-libdolfin", exact=True) }}
+        - fenics-dijitso =={{ version }}
+        - fenics-fiat =={{ version }}
+        - fenics-ufl =={{ version }}
+        - fenics-ffc =={{ version }}
+        # need to list libnetcdf and netcdf-fortran twice to get version
+        # pinning from conda_build_config and build pinning from {{ mpi_prefix }}
+        - hdf5
+        - hdf5 * {{ mpi_prefix }}_*
+      run:
+        - {{ compiler('cxx') }}  # [linux]
+        - python
+        - boost-cpp
+        - setuptools
+        - {{ mpi }}
+        - mpi4py
+        - petsc
+        - petsc4py
+        - slepc
+        - slepc4py
+        - pkgconfig  # Python pkgconfig package
+        - pybind11
+        - {{ pin_compatible('numpy', max_pin=None) }}
+        - six
+        - sympy >=1
+        - {{ pin_subpackage("fenics-libdolfin", exact=True) }}
+        - fenics-dijitso =={{ version }}
+        - fenics-fiat =={{ version }}
+        - fenics-ufl =={{ version }}
+        - fenics-ffc =={{ version }}
+
+    test:
+      commands:
+        - bash ${RECIPE_DIR}/parent/test-dolfin.sh
+      source_files:
+        - dolfin/python/test
+
+      requires:
+        - nose
+        - pytest
+        - git
+        - decorator
+
+  - name: fenics
+    build:
+      skip: true  # [win or py2k]
+      script: echo 1
+    requirements:
+      host:
+        - python
+        - {{ mpi }}  # ensure mpi is in hash inputs
+      run:
+        - python
+        - {{ pin_subpackage("fenics-dijitso", exact=True) }}
+        - {{ pin_subpackage("fenics-fiat", exact=True) }}
+        - {{ pin_subpackage("fenics-ufl", exact=True) }}
+        - {{ pin_subpackage("fenics-ffc", exact=True) }}
+        - {{ pin_subpackage('fenics-dolfin', exact=True) }}
+    test:
+      commands:
+        - bash ${RECIPE_DIR}/parent/test-fenics.sh
+
+about:
+  home: http://www.fenicsproject.org
+  license: LGPL-3.0-or-later
+  license_file: dolfin/COPYING.LESSER
+  summary: FEniCS is a collection of free software for automated, efficient solution of differential equations
+
+  description: |
+    FEniCS is a collection of free software for automated, efficient solution of differential equations
+    (<http://fenicsproject.org>). It provides C++ and Python interfaces, and creates efficient solvers via
+    expression of finite variational statements in a domain-specific language that are transformed and
+    just-in-time compiled into efficient implementations.
+  doc_url: http://fenics.readthedocs.io/
+  dev_url: https://bitbucket.org/fenics-project/
+
+extra:
+  recipe-maintainers:
+    - garth-wells
+    - johannesring
+    - mikaem
+    - minrk
+    - jan-janssen

--- a/tests/test_yaml/libboost_gudhi_after_meta.yaml
+++ b/tests/test_yaml/libboost_gudhi_after_meta.yaml
@@ -1,0 +1,79 @@
+{% set version = "1.10.0" %}
+
+package:
+  name: gudhi
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 3f9e587a96844a9b4ee7f998cfe4dc3964dc95c4ca94d7de6a77bffb99f873da
+  # git_url: https://github.com/GUDHI/gudhi-devel.git
+  # git_rev: tags/gudhi-release-{{ version }}
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake
+    - make  # [not win]
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - cython                                 # [build_platform != target_platform]
+    - pybind11                               # [build_platform != target_platform]
+    - numpy                                  # [build_platform != target_platform]
+    - git                                    # [build_platform != target_platform]
+  host:
+    - python
+    - pip
+    - setuptools
+    - cython
+    - pybind11
+    - numpy
+    - libboost-headers
+    - eigen
+    - cgal-cpp >=5.5
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+    - cgal-cpp >=5.5
+
+test:
+  requires:
+    - pytest
+    - python
+  source_files:
+    - src/python/test
+  commands:
+    - test -f ${PREFIX}/include/gudhi/Simplex_tree.h  # [unix]
+    - if not exist %LIBRARY_INC%\gudhi\Simplex_tree.h exit 1  # [win]
+    - pytest src/python/test/test_alpha_complex.py
+    - pytest src/python/test/test_bottleneck_distance.py
+    - pytest src/python/test/test_cubical_complex.py
+    - pytest src/python/test/test_euclidean_witness_complex.py
+    - pytest src/python/test/test_reader_utils.py
+    - pytest src/python/test/test_rips_complex.py
+    - pytest src/python/test/test_simplex_generators.py
+    - pytest src/python/test/test_simplex_tree.py
+    - pytest src/python/test/test_subsampling.py
+    - pytest src/python/test/test_tangential_complex.py
+    - pytest src/python/test/test_time_delay.py
+    - pytest src/python/test/test_witness_complex.py
+about:
+  home: https://gudhi.inria.fr/
+  license: MIT AND BSD-3-Clause AND MPL-2.0 AND LGPL-3.0-or-later AND GPL-3.0-or-later
+  license_file: LICENSE
+  summary: Geometry Understanding in Higher Dimensions
+  description: |
+    The GUDHI library is a generic open source C++ library, with a Python
+    interface, for Topological Data Analysis (TDA) and Higher Dimensional
+    Geometry Understanding. The library offers state-of-the-art data structures
+    and algorithms to construct simplicial complexes and compute persistent
+    homology.
+  doc_url: https://gudhi.inria.fr/python/{{ version }}/
+extra:
+  recipe-maintainers:
+    - VincentRouvreau

--- a/tests/test_yaml/libboost_gudhi_before_meta.yaml
+++ b/tests/test_yaml/libboost_gudhi_before_meta.yaml
@@ -1,0 +1,79 @@
+{% set version = "1.9.0" %}
+
+package:
+  name: gudhi
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: b6d893dc7dcd4138b9e9df59a13c59695e50e80dc5c2cacee0674670693951a1
+  # git_url: https://github.com/GUDHI/gudhi-devel.git
+  # git_rev: tags/gudhi-release-{{ version }}
+
+build:
+  number: 5
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake
+    - make  # [not win]
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - cython                                 # [build_platform != target_platform]
+    - pybind11                               # [build_platform != target_platform]
+    - numpy                                  # [build_platform != target_platform]
+    - git                                    # [build_platform != target_platform]
+  host:
+    - python
+    - pip
+    - setuptools
+    - cython
+    - pybind11
+    - numpy
+    - boost-cpp
+    - eigen
+    - cgal-cpp >=5.5
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+    - cgal-cpp >=5.5
+
+test:
+  requires:
+    - pytest
+    - python
+  source_files:
+    - src/python/test
+  commands:
+    - test -f ${PREFIX}/include/gudhi/Simplex_tree.h  # [unix]
+    - if not exist %LIBRARY_INC%\gudhi\Simplex_tree.h exit 1  # [win]
+    - pytest src/python/test/test_alpha_complex.py
+    - pytest src/python/test/test_bottleneck_distance.py
+    - pytest src/python/test/test_cubical_complex.py
+    - pytest src/python/test/test_euclidean_witness_complex.py
+    - pytest src/python/test/test_reader_utils.py
+    - pytest src/python/test/test_rips_complex.py
+    - pytest src/python/test/test_simplex_generators.py
+    - pytest src/python/test/test_simplex_tree.py
+    - pytest src/python/test/test_subsampling.py
+    - pytest src/python/test/test_tangential_complex.py
+    - pytest src/python/test/test_time_delay.py
+    - pytest src/python/test/test_witness_complex.py
+about:
+  home: https://gudhi.inria.fr/
+  license: MIT AND BSD-3-Clause AND MPL-2.0 AND LGPL-3.0-or-later AND GPL-3.0-or-later
+  license_file: LICENSE
+  summary: Geometry Understanding in Higher Dimensions
+  description: |
+    The GUDHI library is a generic open source C++ library, with a Python
+    interface, for Topological Data Analysis (TDA) and Higher Dimensional
+    Geometry Understanding. The library offers state-of-the-art data structures
+    and algorithms to construct simplicial complexes and compute persistent
+    homology.
+  doc_url: https://gudhi.inria.fr/python/{{ version }}/
+extra:
+  recipe-maintainers:
+    - VincentRouvreau

--- a/tests/test_yaml/libboost_poppler_after_meta.yaml
+++ b/tests/test_yaml/libboost_poppler_after_meta.yaml
@@ -1,0 +1,230 @@
+{% set version = "1.10.0" %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+{% set prefix = 'Library/' if win else '' %}
+
+package:
+  name: poppler-split
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  # url: https://poppler.freedesktop.org/poppler-{{ version }}.tar.xz
+  sha256: 3f9e587a96844a9b4ee7f998cfe4dc3964dc95c4ca94d7de6a77bffb99f873da
+  patches:
+    - exportsymbols.patch  # [win]
+    - windows-data.patch  # [win]
+    # libtiff uses Unix I/O even on Windows
+    # https://github.com/conda-forge/libtiff-feedstock/pull/51
+    - disable-libtiff-win32-io.patch  # [win]
+    - includesystembeforejpeg.patch  # [win]
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    # Need these CDTs for Qt on Linux. Please keep them alphabetized!
+    - {{ cdt('libselinux-devel') }}     # [linux]
+    - {{ cdt('libxdamage') }}           # [linux]
+    - {{ cdt('libxfixes') }}            # [linux]
+    - {{ cdt('libxscrnsaver-devel') }}  # [linux]
+    - {{ cdt('libxtst-devel') }}        # [linux]
+    - {{ cdt('libxxf86vm') }}           # [linux]
+    - {{ cdt('mesa-libgl-devel') }}     # [linux]
+    - {{ cdt('mesa-libegl-devel') }}    # [linux]
+    - m2-msys2-runtime  # [win]
+    - {{ native }}pkg-config
+    - cmake
+    - make
+    - ninja
+    - {{ posix }}patch
+    - perl 5
+    - gobject-introspection 1.*  # [not win]
+    - libboost-devel  # [build_platform != target_platform]
+    - cairo       # [build_platform != target_platform]
+    - curl        # [build_platform != target_platform]
+    - fontconfig  # [build_platform != target_platform]
+    - freetype    # [build_platform != target_platform]
+    - gettext     # [build_platform != target_platform]
+    - glib        # [build_platform != target_platform]
+    - libjpeg-turbo         # [build_platform != target_platform]
+    - lcms2       # [build_platform != target_platform]
+    - libcurl     # [build_platform != target_platform]
+    - libiconv    # [build_platform != target_platform]
+    - libpng      # [build_platform != target_platform]
+    - libtiff     # [build_platform != target_platform]
+    - nss         # [not win and build_platform != target_platform]
+    - openjpeg    # [build_platform != target_platform]
+    - zlib        # [build_platform != target_platform]
+  host:
+    - libboost-devel
+    - cairo
+    - curl
+    - fontconfig
+    - freetype
+    - gettext
+    - glib
+    - libjpeg-turbo
+    - lcms2
+    - libcurl
+    - libiconv
+    - libpng
+    - libtiff
+    - nss  # [not win]
+    - openjpeg
+    - qt-main  # [not (ppc64le or arm64)]
+    - zlib
+
+outputs:
+  - name: poppler
+    script: install.sh  # [unix]
+    script: install.bat  # [not unix]
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        # Need these CDTs for Qt on Linux. Please keep them alphabetized!
+        - {{ cdt('libselinux-devel') }}     # [linux]
+        - {{ cdt('libxdamage') }}           # [linux]
+        - {{ cdt('libxfixes') }}            # [linux]
+        - {{ cdt('libxscrnsaver-devel') }}  # [linux]
+        - {{ cdt('libxtst-devel') }}        # [linux]
+        - {{ cdt('libxxf86vm') }}           # [linux]
+        - {{ cdt('mesa-libgl-devel') }}     # [linux]
+        - {{ cdt('mesa-libegl-devel') }}    # [linux]
+        - m2-msys2-runtime  # [win]
+        - {{ native }}pkg-config
+        - cmake
+        - make
+        - ninja
+        - {{ posix }}patch
+        - perl 5
+        - gobject-introspection 1.*  # [not win]
+        - libboost-devel  # [build_platform != target_platform]
+        - cairo       # [build_platform != target_platform]
+        - curl        # [build_platform != target_platform]
+        - fontconfig  # [build_platform != target_platform]
+        - freetype    # [build_platform != target_platform]
+        - gettext     # [build_platform != target_platform]
+        - glib        # [build_platform != target_platform]
+        - libjpeg-turbo         # [build_platform != target_platform]
+        - lcms2       # [build_platform != target_platform]
+        - libcurl     # [build_platform != target_platform]
+        - libiconv    # [build_platform != target_platform]
+        - libpng      # [build_platform != target_platform]
+        - libtiff     # [build_platform != target_platform]
+        - nss         # [not win and build_platform != target_platform]
+        - openjpeg    # [build_platform != target_platform]
+        - zlib        # [build_platform != target_platform]
+      host:
+        - libboost-devel
+        - cairo
+        - curl
+        - fontconfig
+        - freetype
+        - gettext
+        - glib
+        - libjpeg-turbo
+        - lcms2
+        - libcurl
+        - libiconv
+        - libpng
+        - libtiff
+        - nss  # [not win]
+        - openjpeg
+        - zlib
+      run:
+        - poppler-data
+    test:
+      commands:
+        - pdfinfo -listenc
+        - pdfunite --help
+        - pdftocairo --help
+
+  - name: poppler-qt
+    build:
+      skip: true  # [ppc64le or arm64]
+    script: install.sh  # [unix]
+    script: install.bat  # [not unix]
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        # Need these CDTs for Qt on Linux. Please keep them alphabetized!
+        - {{ cdt('libselinux-devel') }}     # [linux]
+        - {{ cdt('libxdamage') }}           # [linux]
+        - {{ cdt('libxfixes') }}            # [linux]
+        - {{ cdt('libxscrnsaver-devel') }}  # [linux]
+        - {{ cdt('libxtst-devel') }}        # [linux]
+        - {{ cdt('libxxf86vm') }}           # [linux]
+        - {{ cdt('mesa-libgl-devel') }}     # [linux]
+        - {{ cdt('mesa-libegl-devel') }}    # [linux]
+        - m2-msys2-runtime  # [win]
+        - {{ native }}pkg-config
+        - cmake
+        - make
+        - ninja
+        - {{ posix }}patch
+        - perl 5
+        - gobject-introspection 1.*  # [not win]
+        - libboost-devel  # [build_platform != target_platform]
+        - cairo       # [build_platform != target_platform]
+        - curl        # [build_platform != target_platform]
+        - fontconfig  # [build_platform != target_platform]
+        - freetype    # [build_platform != target_platform]
+        - gettext     # [build_platform != target_platform]
+        - glib        # [build_platform != target_platform]
+        - libjpeg-turbo         # [build_platform != target_platform]
+        - lcms2       # [build_platform != target_platform]
+        - libcurl     # [build_platform != target_platform]
+        - libiconv    # [build_platform != target_platform]
+        - libpng      # [build_platform != target_platform]
+        - libtiff     # [build_platform != target_platform]
+        - nss         # [not win and build_platform != target_platform]
+        - openjpeg    # [build_platform != target_platform]
+        - zlib        # [build_platform != target_platform]
+      host:
+        - libboost-headers
+        - cairo
+        - curl
+        - fontconfig
+        - freetype
+        - gettext
+        - glib
+        - libjpeg-turbo
+        - lcms2
+        - libcurl
+        - libiconv
+        - libpng
+        - libtiff
+        - nss  # [not win]
+        - openjpeg
+        - qt-main
+        - zlib
+        - {{ pin_subpackage('poppler', exact=True) }}
+      run:
+        - {{ pin_subpackage('poppler', exact=True) }}
+    test:
+      commands:
+        - test -f ${PREFIX}/lib/pkgconfig/poppler-qt5.pc  # [not win]
+        - if not exist %LIBRARY_BIN%\\poppler.dll exit 1  # [win]
+
+about:
+  home: https://poppler.freedesktop.org/
+  license: GPL-2.0-only
+  license_family: GPL
+  license_file: COPYING
+  summary: The Poppler PDF manipulation library.
+
+extra:
+  feedstock-name: poppler
+  recipe-maintainers:
+    - pkgw
+    - ocefpaf
+    - xhochy
+    - xylar

--- a/tests/test_yaml/libboost_poppler_before_meta.yaml
+++ b/tests/test_yaml/libboost_poppler_before_meta.yaml
@@ -1,0 +1,231 @@
+{% set version = "1.9.0" %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+{% set prefix = 'Library/' if win else '' %}
+
+package:
+  name: poppler-split
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  # url: https://poppler.freedesktop.org/poppler-{{ version }}.tar.xz
+  sha256: b6d893dc7dcd4138b9e9df59a13c59695e50e80dc5c2cacee0674670693951a1
+  patches:
+    - exportsymbols.patch  # [win]
+    - windows-data.patch  # [win]
+    # libtiff uses Unix I/O even on Windows
+    # https://github.com/conda-forge/libtiff-feedstock/pull/51
+    - disable-libtiff-win32-io.patch  # [win]
+    - includesystembeforejpeg.patch  # [win]
+
+build:
+  number: 1
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    # Need these CDTs for Qt on Linux. Please keep them alphabetized!
+    - {{ cdt('libselinux-devel') }}     # [linux]
+    - {{ cdt('libxdamage') }}           # [linux]
+    - {{ cdt('libxfixes') }}            # [linux]
+    - {{ cdt('libxscrnsaver-devel') }}  # [linux]
+    - {{ cdt('libxtst-devel') }}        # [linux]
+    - {{ cdt('libxxf86vm') }}           # [linux]
+    - {{ cdt('mesa-libgl-devel') }}     # [linux]
+    - {{ cdt('mesa-libegl-devel') }}    # [linux]
+    - m2-msys2-runtime  # [win]
+    - {{ native }}pkg-config
+    - cmake
+    - make
+    - ninja
+    - {{ posix }}patch
+    - perl 5
+    - gobject-introspection 1.*  # [not win]
+    - boost-cpp {{ boost_cpp }}  # [build_platform != target_platform]
+    - cairo       # [build_platform != target_platform]
+    - curl        # [build_platform != target_platform]
+    - fontconfig  # [build_platform != target_platform]
+    - freetype    # [build_platform != target_platform]
+    - gettext     # [build_platform != target_platform]
+    - glib        # [build_platform != target_platform]
+    - libjpeg-turbo         # [build_platform != target_platform]
+    - lcms2       # [build_platform != target_platform]
+    - libcurl     # [build_platform != target_platform]
+    - libiconv    # [build_platform != target_platform]
+    - libpng      # [build_platform != target_platform]
+    - libtiff     # [build_platform != target_platform]
+    - nss         # [not win and build_platform != target_platform]
+    - openjpeg    # [build_platform != target_platform]
+    - zlib        # [build_platform != target_platform]
+  host:
+    - boost-cpp
+    - cairo
+    - curl
+    - fontconfig
+    - freetype
+    - gettext
+    - glib
+    - libjpeg-turbo
+    - lcms2
+    - libcurl
+    - libiconv
+    - libpng
+    - libtiff
+    - nss  # [not win]
+    - openjpeg
+    - qt-main  # [not (ppc64le or arm64)]
+    - zlib
+
+outputs:
+  - name: poppler
+    script: install.sh  # [unix]
+    script: install.bat  # [not unix]
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        # Need these CDTs for Qt on Linux. Please keep them alphabetized!
+        - {{ cdt('libselinux-devel') }}     # [linux]
+        - {{ cdt('libxdamage') }}           # [linux]
+        - {{ cdt('libxfixes') }}            # [linux]
+        - {{ cdt('libxscrnsaver-devel') }}  # [linux]
+        - {{ cdt('libxtst-devel') }}        # [linux]
+        - {{ cdt('libxxf86vm') }}           # [linux]
+        - {{ cdt('mesa-libgl-devel') }}     # [linux]
+        - {{ cdt('mesa-libegl-devel') }}    # [linux]
+        - m2-msys2-runtime  # [win]
+        - {{ native }}pkg-config
+        - cmake
+        - make
+        - ninja
+        - {{ posix }}patch
+        - perl 5
+        - gobject-introspection 1.*  # [not win]
+        - boost-cpp {{ boost_cpp }}  # [build_platform != target_platform]
+        - cairo       # [build_platform != target_platform]
+        - curl        # [build_platform != target_platform]
+        - fontconfig  # [build_platform != target_platform]
+        - freetype    # [build_platform != target_platform]
+        - gettext     # [build_platform != target_platform]
+        - glib        # [build_platform != target_platform]
+        - libjpeg-turbo         # [build_platform != target_platform]
+        - lcms2       # [build_platform != target_platform]
+        - libcurl     # [build_platform != target_platform]
+        - libiconv    # [build_platform != target_platform]
+        - libpng      # [build_platform != target_platform]
+        - libtiff     # [build_platform != target_platform]
+        - nss         # [not win and build_platform != target_platform]
+        - openjpeg    # [build_platform != target_platform]
+        - zlib        # [build_platform != target_platform]
+      host:
+        - boost-cpp {{ boost_cpp }}
+        - cairo
+        - curl
+        - fontconfig
+        - freetype
+        - gettext
+        - glib
+        - libjpeg-turbo
+        - lcms2
+        - libcurl
+        - libiconv
+        - libpng
+        - libtiff
+        - nss  # [not win]
+        - openjpeg
+        - zlib
+      run:
+        - {{ pin_compatible('boost-cpp') }}
+        - poppler-data
+    test:
+      commands:
+        - pdfinfo -listenc
+        - pdfunite --help
+        - pdftocairo --help
+
+  - name: poppler-qt
+    build:
+      skip: true  # [ppc64le or arm64]
+    script: install.sh  # [unix]
+    script: install.bat  # [not unix]
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        # Need these CDTs for Qt on Linux. Please keep them alphabetized!
+        - {{ cdt('libselinux-devel') }}     # [linux]
+        - {{ cdt('libxdamage') }}           # [linux]
+        - {{ cdt('libxfixes') }}            # [linux]
+        - {{ cdt('libxscrnsaver-devel') }}  # [linux]
+        - {{ cdt('libxtst-devel') }}        # [linux]
+        - {{ cdt('libxxf86vm') }}           # [linux]
+        - {{ cdt('mesa-libgl-devel') }}     # [linux]
+        - {{ cdt('mesa-libegl-devel') }}    # [linux]
+        - m2-msys2-runtime  # [win]
+        - {{ native }}pkg-config
+        - cmake
+        - make
+        - ninja
+        - {{ posix }}patch
+        - perl 5
+        - gobject-introspection 1.*  # [not win]
+        - boost-cpp {{ boost_cpp }}  # [build_platform != target_platform]
+        - cairo       # [build_platform != target_platform]
+        - curl        # [build_platform != target_platform]
+        - fontconfig  # [build_platform != target_platform]
+        - freetype    # [build_platform != target_platform]
+        - gettext     # [build_platform != target_platform]
+        - glib        # [build_platform != target_platform]
+        - libjpeg-turbo         # [build_platform != target_platform]
+        - lcms2       # [build_platform != target_platform]
+        - libcurl     # [build_platform != target_platform]
+        - libiconv    # [build_platform != target_platform]
+        - libpng      # [build_platform != target_platform]
+        - libtiff     # [build_platform != target_platform]
+        - nss         # [not win and build_platform != target_platform]
+        - openjpeg    # [build_platform != target_platform]
+        - zlib        # [build_platform != target_platform]
+      host:
+        - boost-cpp {{ boost_cpp }}
+        - cairo
+        - curl
+        - fontconfig
+        - freetype
+        - gettext
+        - glib
+        - libjpeg-turbo
+        - lcms2
+        - libcurl
+        - libiconv
+        - libpng
+        - libtiff
+        - nss  # [not win]
+        - openjpeg
+        - qt-main
+        - zlib
+        - {{ pin_subpackage('poppler', exact=True) }}
+      run:
+        - {{ pin_subpackage('poppler', exact=True) }}
+    test:
+      commands:
+        - test -f ${PREFIX}/lib/pkgconfig/poppler-qt5.pc  # [not win]
+        - if not exist %LIBRARY_BIN%\\poppler.dll exit 1  # [win]
+
+about:
+  home: https://poppler.freedesktop.org/
+  license: GPL-2.0-only
+  license_family: GPL
+  license_file: COPYING
+  summary: The Poppler PDF manipulation library.
+
+extra:
+  feedstock-name: poppler
+  recipe-maintainers:
+    - pkgw
+    - ocefpaf
+    - xhochy
+    - xylar

--- a/tests/test_yaml/libboost_rdkit_after_meta.yaml
+++ b/tests/test_yaml/libboost_rdkit_after_meta.yaml
@@ -1,0 +1,102 @@
+{% set name = "rdkit" %}
+{% set version = "1.10.0" %}
+{% set filename = "Release_%s.tar.gz" % version.replace(".", "_") %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 3f9e587a96844a9b4ee7f998cfe4dc3964dc95c4ca94d7de6a77bffb99f873da
+  # fn: {{ filename }}
+  # url: https://github.com/rdkit/rdkit/archive/{{ filename }}
+  # sha256: db346afbd0ba52c843926a2a62f8a38c7b774ffab37eaf382d789a824f21996c
+
+build:
+  number: 0
+  skip: true  # [aarch64]
+  missing_dso_whitelist:
+    - '*/RDKit*dll'  # [win]
+
+requirements:
+  build:
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - numpy                                  # [build_platform != target_platform]
+    - {{ compiler('cxx') }}
+    - cmake
+    - jom  # [win]
+    - make  # [unix]
+    - pkg-config
+  host:
+    - libboost-python-devel
+    - cairo
+    - eigen
+    - freetype
+    - python
+    - numpy
+    - pillow
+    - pandas
+  run:
+    - libboost-python-devel
+    - cairo
+    - python
+    - pillow
+    - pandas
+    - {{ pin_compatible('numpy') }}
+    - pycairo
+    - matplotlib-base
+    - sqlalchemy
+    - reportlab
+
+test:
+  commands:
+    - python -c "import rdkit; assert rdkit.__version__ == '{{ version }}'"
+  imports:
+    - rdkit
+    - rdkit.Avalon
+    - rdkit.Chem
+    - rdkit.Chem.AllChem
+    - rdkit.Chem.rdFreeSASA
+    - rdkit.DataManip
+    - rdkit.Dbase
+    - rdkit.DistanceGeometry
+    - rdkit.ForceField
+    - rdkit.Geometry
+    - rdkit.ML
+    - rdkit.Numerics
+    - rdkit.SimDivFilters
+    - rdkit.VLib
+    - rdkit.VLib.NodeLib
+
+outputs:
+  - name: rdkit
+  - name: rdkit-dev
+    script: install_rdkit_dev.bat  # [win]
+    requirements:
+      run:
+        - rdkit
+    test:
+      commands:
+        - if not exist %LIBRARY_INC%\\rdkit\\Catalogs\\Catalog.h exit 1   # [win]
+    about:
+      summary: RDKit headers and library used in rdkit package
+      license: BSD-3-Clause
+      license_file: license.txt
+
+about:
+  home: http://rdkit.org
+  license: BSD-3-Clause
+  license_file: license.txt
+  summary: RDKit is a collection of cheminformatics and machine-learning software written in C++ and Python.
+  doc_url: http://www.rdkit.org/docs/index.html
+  dev_url: https://github.com/rdkit/rdkit
+
+extra:
+  recipe-maintainers:
+    - greglandrum
+    - pstjohn
+    - mcs07
+    - jaimergp

--- a/tests/test_yaml/libboost_rdkit_before_meta.yaml
+++ b/tests/test_yaml/libboost_rdkit_before_meta.yaml
@@ -1,0 +1,102 @@
+{% set name = "rdkit" %}
+{% set version = "1.9.0" %}
+{% set filename = "Release_%s.tar.gz" % version.replace(".", "_") %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: b6d893dc7dcd4138b9e9df59a13c59695e50e80dc5c2cacee0674670693951a1
+  # fn: {{ filename }}
+  # url: https://github.com/rdkit/rdkit/archive/{{ filename }}
+  # sha256: db346afbd0ba52c843926a2a62f8a38c7b774ffab37eaf382d789a824f21996c
+
+build:
+  number: 0
+  skip: true  # [aarch64]
+  missing_dso_whitelist:
+    - '*/RDKit*dll'  # [win]
+
+requirements:
+  build:
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - numpy                                  # [build_platform != target_platform]
+    - {{ compiler('cxx') }}
+    - cmake
+    - jom  # [win]
+    - make  # [unix]
+    - pkg-config
+  host:
+    - boost
+    - cairo
+    - eigen
+    - freetype
+    - python
+    - numpy
+    - pillow
+    - pandas
+  run:
+    - boost
+    - cairo
+    - python
+    - pillow
+    - pandas
+    - {{ pin_compatible('numpy') }}
+    - pycairo
+    - matplotlib-base
+    - sqlalchemy
+    - reportlab
+
+test:
+  commands:
+    - python -c "import rdkit; assert rdkit.__version__ == '{{ version }}'"
+  imports:
+    - rdkit
+    - rdkit.Avalon
+    - rdkit.Chem
+    - rdkit.Chem.AllChem
+    - rdkit.Chem.rdFreeSASA
+    - rdkit.DataManip
+    - rdkit.Dbase
+    - rdkit.DistanceGeometry
+    - rdkit.ForceField
+    - rdkit.Geometry
+    - rdkit.ML
+    - rdkit.Numerics
+    - rdkit.SimDivFilters
+    - rdkit.VLib
+    - rdkit.VLib.NodeLib
+
+outputs:
+  - name: rdkit
+  - name: rdkit-dev
+    script: install_rdkit_dev.bat  # [win]
+    requirements:
+      run:
+        - rdkit
+    test:
+      commands:
+        - if not exist %LIBRARY_INC%\\rdkit\\Catalogs\\Catalog.h exit 1   # [win]
+    about:
+      summary: RDKit headers and library used in rdkit package
+      license: BSD-3-Clause
+      license_file: license.txt
+
+about:
+  home: http://rdkit.org
+  license: BSD-3-Clause
+  license_file: license.txt
+  summary: RDKit is a collection of cheminformatics and machine-learning software written in C++ and Python.
+  doc_url: http://www.rdkit.org/docs/index.html
+  dev_url: https://github.com/rdkit/rdkit
+
+extra:
+  recipe-maintainers:
+    - greglandrum
+    - pstjohn
+    - mcs07
+    - jaimergp

--- a/tests/test_yaml/libboost_scipopt_after_meta.yaml
+++ b/tests/test_yaml/libboost_scipopt_after_meta.yaml
@@ -1,0 +1,236 @@
+# TODO check these versions have not changed
+{% set version = "1.10.0" %}
+{% set papilo_version = "2.1.2" %}
+{% set soplex_version = "6.0.3" %}
+{% set gcg_version = "3.5.3" %}
+{% set zimpl_version = "3.5.3" %}
+# For dispatching between Unix and Windows
+{% set install_prefix = "." %}  # [unix]
+{% set install_prefix = "Library" %}  # [win]
+
+
+package:
+  name: scipoptsuite
+  version: {{ version }}
+#   version: {{ scip_version }}
+
+source:
+  # fake source url to get version migrator to pass
+  - url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: 3f9e587a96844a9b4ee7f998cfe4dc3964dc95c4ca94d7de6a77bffb99f873da
+#   - url: https://scipopt.org/download/release/scipoptsuite-{{ scip_version }}.tgz
+#     sha256: 5ad50eb42254c825d96f5747d8f3568dcbff0284dfbd1a727910c5a7c2899091
+#     folder: scipoptsuite
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('fortran') }}
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake >=3.15
+    - make            # [unix]
+  host:
+    - tbb-devel
+    - libblas
+    - zlib
+    - ipopt
+    - cppad
+    - libboost-devel
+    - gmp             # [unix]
+    - cliquer         # [unix]
+    - bison           # [unix]
+    - flex            # [unix]
+
+outputs:
+
+  - name: papilo
+    version: {{ papilo_version }}
+    requirements:
+      build:
+        - {{ compiler('fortran') }}
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+      host:
+        - zlib
+        - gmp             # [unix]
+        - libboost-headers  # [win]
+        - libboost-headers       # [unix]
+        - libblas
+      run:
+        - tbb-devel
+    files:
+      - {{ install_prefix }}/lib/cmake/papilo/
+      # Executable is not installed by Papilo's CMake
+      # - {{ install_prefix }}/bin/papilo*
+      # Vendored libraries
+      - {{ install_prefix }}/lib/libclusol*
+      - {{ install_prefix }}/lib/libpapilo-core*
+      - {{ install_prefix }}/include/papilo/
+
+  - name: scip
+    version: {{ scip_version }}
+    build:
+      run_exports:
+        - {{ pin_subpackage('scip') }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        # Soplex statically linked
+        - {{ compiler('cxx') }}
+        # Papilo statically linked but needs direct dependency from used shared libs.
+        - {{ compiler('fortran') }}
+      host:
+        - zlib
+        - ipopt
+        - cppad
+        - gmp  # [unix]
+        # Papilo statically linked
+        # Papilo statically linked but needs direct dependency from used shared libs.
+        - tbb-devel
+        - libblas
+    files:
+      - {{ install_prefix }}/lib/libscip*
+      - {{ install_prefix }}/lib/cmake/scip/
+      - {{ install_prefix }}/bin/scip*
+      - {{ install_prefix }}/bin/libscip*  # [win]
+      - {{ install_prefix }}/include/blockmemshell/
+      - {{ install_prefix }}/include/dijkstra/
+      - {{ install_prefix }}/include/lpi/
+      - {{ install_prefix }}/include/nlpi/
+      - {{ install_prefix }}/include/objscip/
+      - {{ install_prefix }}/include/scip/
+      - {{ install_prefix }}/include/symmetry/
+      - {{ install_prefix }}/include/tclique/
+      - {{ install_prefix }}/include/tinycthread/
+      - {{ install_prefix }}/include/tpi/
+      - {{ install_prefix }}/include/xml/
+    test:
+      script: run_scip_test.sh  # [unix]
+      script: run_scip_test.bat  # [win]
+      source_files:
+        - scipoptsuite/scip/examples/Queens
+      requires:
+        - {{ compiler('cxx') }}
+        - cmake >=3.15
+        - make                   # [unix]
+
+  - name: soplex
+    version: {{ soplex_version }}
+    requirements:
+      build:
+        - {{ compiler('cxx') }}
+        # Papilo statically linked but needs direct dependency from used shared libs.
+        - {{ compiler('fortran') }}
+      host:
+        - zlib
+        - gmp             # [unix]
+        - libboost-devel
+        # Papilo statically linked but needs direct dependency from used shared libs.
+        - tbb-devel
+        - libblas
+      run:
+        # libboost_program_options.so needed by bin/soplex.
+        # boost does not set run_exports so it is needed in run requirements.
+        - zlib
+        - {{ pin_subpackage('papilo', exact=True) }}
+    files:
+      - {{ install_prefix }}/lib/libsoplex*
+      - {{ install_prefix }}/lib/cmake/soplex/
+      - {{ install_prefix }}/bin/soplex*
+      - {{ install_prefix }}/bin/libsoplex*  # [win]
+      - {{ install_prefix }}/include/soplex*
+      - {{ install_prefix }}/include/soplex/
+    test:
+      script: run_soplex_test.sh  # [unix]
+      script: run_soplex_test.bat  # [win]
+      source_files:
+        - scipoptsuite/soplex/src/example.cpp
+      requires:
+        - {{ compiler('cxx') }}
+        - cmake >=3.15
+        - make                     # [unix]
+        # Papilo statically linked
+        - {{ compiler('fortran') }}
+
+  - name: gcg
+    version: {{ gcg_version }}
+    build:
+      skip: true  # [win]
+      run_exports:
+        - {{ pin_subpackage('gcg') }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+      host:
+        - gmp
+        - cliquer
+        - gnuplot
+        - {{ pin_subpackage('scip', exact=True) }}
+      run:
+        - {{ pin_subpackage('scip') }}
+        # run_exports not set for cliquer
+        - cliquer
+    files:
+      - lib/libgcg*
+      - lib/cmake/gcg
+      - bin/gcg
+      - include/gcg
+    test:
+      commands:
+        - gcg --version
+        - test -d "${PREFIX}/lib/cmake/gcg"
+        - test -d "${PREFIX}/include/gcg"
+
+  - name: zimpl
+    version: {{ zimpl_version }}
+    build:
+      # zimpl is not built in Windows since gmp is not available on
+      # conda-forge so this test is skipped. Details were left for
+      # the path to zimpl if we find a solution in the future.
+      skip: true  # [win or arm64]
+    requirements:
+      build:
+        - {{ compiler('c') }}
+      host:
+        - zlib
+        - gmp    # [unix]
+        - bison  # [unix]
+        - flex   # [unix]
+    files:
+      - {{ install_prefix }}/lib/libzimpl*
+      - {{ install_prefix }}/lib/cmake/zimpl/
+      - {{ install_prefix }}/bin/zimpl*
+      - {{ install_prefix }}/bin/libzimpl*  # [win]
+      - {{ install_prefix }}/include/zimpl
+    test:
+      commands:
+        - zimpl -V
+        - test -d "${PREFIX}/lib/cmake/zimpl"                                   # [unix]
+        - test -d "${PREFIX}/include/zimpl"                                     # [unix]
+        - if exist %PREFIX%\\Library\\lib\\cmake\\zimpl (exit 0) else (exit 1)  # [win]
+        - if exist %PREFIX%\\Library\\include\\zimpl (exit 0) else (exit 1)     # [win]
+
+
+about:
+  home: https://scipopt.org/
+  license: Apache 2.0 AND ZIB-Academic AND LGPL-3.0-or-later
+  license_file:
+    - scipoptsuite/papilo/COPYING
+    - scipoptsuite/papilo/src/papilo/external/lusol/LICENSE.md
+    - scipoptsuite/papilo/src/papilo/external/pdqsort/license.txt
+    - scipoptsuite/papilo/src/papilo/external/ska/LICENSE.txt
+    - scipoptsuite/soplex/LICENSE
+    - scipoptsuite/scip/LICENSE
+    - scipoptsuite/gcg/LICENSE
+    - scipoptsuite/zimpl/LICENSE
+  summary: Mixed Integer Programming (MIP) solver and Branch-and-Cut-and-Price Framework
+
+extra:
+  recipe-maintainers:
+    - AntoinePrv
+    - pokutta
+    - fschloesser

--- a/tests/test_yaml/libboost_scipopt_before_meta.yaml
+++ b/tests/test_yaml/libboost_scipopt_before_meta.yaml
@@ -1,0 +1,240 @@
+# TODO check these versions have not changed
+{% set version = "1.9.0" %}
+{% set papilo_version = "2.1.2" %}
+{% set soplex_version = "6.0.3" %}
+{% set gcg_version = "3.5.3" %}
+{% set zimpl_version = "3.5.3" %}
+# For dispatching between Unix and Windows
+{% set install_prefix = "." %}  # [unix]
+{% set install_prefix = "Library" %}  # [win]
+
+
+package:
+  name: scipoptsuite
+  version: {{ version }}
+#   version: {{ scip_version }}
+
+source:
+  # fake source url to get version migrator to pass
+  - url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: b6d893dc7dcd4138b9e9df59a13c59695e50e80dc5c2cacee0674670693951a1
+#   - url: https://scipopt.org/download/release/scipoptsuite-{{ scip_version }}.tgz
+#     sha256: 5ad50eb42254c825d96f5747d8f3568dcbff0284dfbd1a727910c5a7c2899091
+#     folder: scipoptsuite
+
+build:
+  number: 1
+
+requirements:
+  build:
+    - {{ compiler('fortran') }}
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake >=3.15
+    - make            # [unix]
+  host:
+    - tbb-devel
+    - libblas
+    - zlib
+    - ipopt
+    - cppad
+    - boost-cpp ==1.72.0  # [win]
+    - boost-cpp       # [unix]
+    - gmp             # [unix]
+    - cliquer         # [unix]
+    - bison           # [unix]
+    - flex            # [unix]
+
+outputs:
+
+  - name: papilo
+    version: {{ papilo_version }}
+    requirements:
+      build:
+        - {{ compiler('fortran') }}
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+      host:
+        - zlib
+        - gmp             # [unix]
+        - boost-cpp ==1.72.0  # [win]
+        - boost-cpp       # [unix]
+        - libblas
+      run:
+        - tbb-devel
+    files:
+      - {{ install_prefix }}/lib/cmake/papilo/
+      # Executable is not installed by Papilo's CMake
+      # - {{ install_prefix }}/bin/papilo*
+      # Vendored libraries
+      - {{ install_prefix }}/lib/libclusol*
+      - {{ install_prefix }}/lib/libpapilo-core*
+      - {{ install_prefix }}/include/papilo/
+
+  - name: scip
+    version: {{ scip_version }}
+    build:
+      run_exports:
+        - {{ pin_subpackage('scip') }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        # Soplex statically linked
+        - {{ compiler('cxx') }}
+        # Papilo statically linked but needs direct dependency from used shared libs.
+        - {{ compiler('fortran') }}
+      host:
+        - zlib
+        - ipopt
+        - cppad
+        - gmp  # [unix]
+        # Papilo statically linked
+        # Papilo statically linked but needs direct dependency from used shared libs.
+        - tbb-devel
+        - libblas
+    files:
+      - {{ install_prefix }}/lib/libscip*
+      - {{ install_prefix }}/lib/cmake/scip/
+      - {{ install_prefix }}/bin/scip*
+      - {{ install_prefix }}/bin/libscip*  # [win]
+      - {{ install_prefix }}/include/blockmemshell/
+      - {{ install_prefix }}/include/dijkstra/
+      - {{ install_prefix }}/include/lpi/
+      - {{ install_prefix }}/include/nlpi/
+      - {{ install_prefix }}/include/objscip/
+      - {{ install_prefix }}/include/scip/
+      - {{ install_prefix }}/include/symmetry/
+      - {{ install_prefix }}/include/tclique/
+      - {{ install_prefix }}/include/tinycthread/
+      - {{ install_prefix }}/include/tpi/
+      - {{ install_prefix }}/include/xml/
+    test:
+      script: run_scip_test.sh  # [unix]
+      script: run_scip_test.bat  # [win]
+      source_files:
+        - scipoptsuite/scip/examples/Queens
+      requires:
+        - {{ compiler('cxx') }}
+        - cmake >=3.15
+        - make                   # [unix]
+
+  - name: soplex
+    version: {{ soplex_version }}
+    requirements:
+      build:
+        - {{ compiler('cxx') }}
+        # Papilo statically linked but needs direct dependency from used shared libs.
+        - {{ compiler('fortran') }}
+      host:
+        - zlib
+        - gmp             # [unix]
+        - boost-cpp ==1.72.0  # [win]
+        - boost-cpp       # [unix]
+        # Papilo statically linked but needs direct dependency from used shared libs.
+        - tbb-devel
+        - libblas
+      run:
+        # libboost_program_options.so needed by bin/soplex.
+        # boost does not set run_exports so it is needed in run requirements.
+        - boost-cpp ==1.72.0  # [win]
+        - boost-cpp       # [unix]
+        - zlib
+        - {{ pin_subpackage('papilo', exact=True) }}
+    files:
+      - {{ install_prefix }}/lib/libsoplex*
+      - {{ install_prefix }}/lib/cmake/soplex/
+      - {{ install_prefix }}/bin/soplex*
+      - {{ install_prefix }}/bin/libsoplex*  # [win]
+      - {{ install_prefix }}/include/soplex*
+      - {{ install_prefix }}/include/soplex/
+    test:
+      script: run_soplex_test.sh  # [unix]
+      script: run_soplex_test.bat  # [win]
+      source_files:
+        - scipoptsuite/soplex/src/example.cpp
+      requires:
+        - {{ compiler('cxx') }}
+        - cmake >=3.15
+        - make                     # [unix]
+        # Papilo statically linked
+        - {{ compiler('fortran') }}
+
+  - name: gcg
+    version: {{ gcg_version }}
+    build:
+      skip: true  # [win]
+      run_exports:
+        - {{ pin_subpackage('gcg') }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+      host:
+        - gmp
+        - cliquer
+        - gnuplot
+        - {{ pin_subpackage('scip', exact=True) }}
+      run:
+        - {{ pin_subpackage('scip') }}
+        # run_exports not set for cliquer
+        - cliquer
+    files:
+      - lib/libgcg*
+      - lib/cmake/gcg
+      - bin/gcg
+      - include/gcg
+    test:
+      commands:
+        - gcg --version
+        - test -d "${PREFIX}/lib/cmake/gcg"
+        - test -d "${PREFIX}/include/gcg"
+
+  - name: zimpl
+    version: {{ zimpl_version }}
+    build:
+      # zimpl is not built in Windows since gmp is not available on
+      # conda-forge so this test is skipped. Details were left for
+      # the path to zimpl if we find a solution in the future.
+      skip: true  # [win or arm64]
+    requirements:
+      build:
+        - {{ compiler('c') }}
+      host:
+        - zlib
+        - gmp    # [unix]
+        - bison  # [unix]
+        - flex   # [unix]
+    files:
+      - {{ install_prefix }}/lib/libzimpl*
+      - {{ install_prefix }}/lib/cmake/zimpl/
+      - {{ install_prefix }}/bin/zimpl*
+      - {{ install_prefix }}/bin/libzimpl*  # [win]
+      - {{ install_prefix }}/include/zimpl
+    test:
+      commands:
+        - zimpl -V
+        - test -d "${PREFIX}/lib/cmake/zimpl"                                   # [unix]
+        - test -d "${PREFIX}/include/zimpl"                                     # [unix]
+        - if exist %PREFIX%\\Library\\lib\\cmake\\zimpl (exit 0) else (exit 1)  # [win]
+        - if exist %PREFIX%\\Library\\include\\zimpl (exit 0) else (exit 1)     # [win]
+
+
+about:
+  home: https://scipopt.org/
+  license: Apache 2.0 AND ZIB-Academic AND LGPL-3.0-or-later
+  license_file:
+    - scipoptsuite/papilo/COPYING
+    - scipoptsuite/papilo/src/papilo/external/lusol/LICENSE.md
+    - scipoptsuite/papilo/src/papilo/external/pdqsort/license.txt
+    - scipoptsuite/papilo/src/papilo/external/ska/LICENSE.txt
+    - scipoptsuite/soplex/LICENSE
+    - scipoptsuite/scip/LICENSE
+    - scipoptsuite/gcg/LICENSE
+    - scipoptsuite/zimpl/LICENSE
+  summary: Mixed Integer Programming (MIP) solver and Branch-and-Cut-and-Price Framework
+
+extra:
+  recipe-maintainers:
+    - AntoinePrv
+    - pokutta
+    - fschloesser


### PR DESCRIPTION
This is ~a draft~ the implenentation for https://github.com/conda-forge/boost-feedstock/pull/164

# TL;DR

The main rule is:
* if `boost-cpp` is only a host dep, replace it with `libboost-headers` (that doesn't have nor need a run-export)
* if `boost-cpp` is also a run dep, remove it there and turn the host dep into `libboost-devel` (which has a run-export)

Additionally, `boost` is renamed to `libboost-python-devel`.

## Implementation

I tried to base myself on https://github.com/regro/cf-scripts/pull/1602, but found that I needed some more control, especially for multi-output recipes. Since everything is already parsed and re-parsed many times, I went with a dead-simple solution that avoids having to identify exactly where in the meta.yaml a given requirement comes from, but have a broad section (based on the outputs that we know) in which to do replacements. It's possible that this already exists (or should exist?) in the utils here...?

The implementation is already pretty involved due to the fact that while operating on the unstructured strings, it's hard to tell what's a host or a run dependence, and we have to fall back to _some_ assumptions involving how many times we want to replace or discard something. This gets more complicated by the occurrence of our key strings in build dependencies or comments. Of course, there are always things that are going to break the logic here, but I think it should hopefully handle 90+% of feedstocks correctly, and I think there are diminishing returns for upping the complexity of the implementation further.

## Tests

I added a bunch of tests for feedstocks that showed up when searching for [boost-cpp](https://github.com/search?q=org%3Aconda-forge+%2Fboost-cpp%2F+path%3A*%2Fmeta.yaml&type=code) or [boost](https://github.com/search?q=org%3Aconda-forge+%2F-+boost%2F+path%3A*%2Fmeta.yaml&type=code), and I'm quite happy that even some of the trickier setups (pins, selectors, etc.) are handled correctly. 

These were hard to write (because the machinery in play is very hard to understand IMO), so happy to improve. I ended up replacing the source sections of all sample recipes with scipy, because the version migrator (that's necessary to test the piggybacking, because we cannot test an actual pin migration AFAICT) would otherwise choke for reasons that aren't clear to me. Aside from that (and light editing that the migrator insists on, like removing quotes or changing selector spacing), the recipes are as they are on their current feedstocks.

I kept the tests in separate commits, because they're hard to read in the GH UI.  For the benefit of the reader, here is the diff between the before/after file:

### Single output; only host-dependence on boost-cpp

<details>
<summary><code>git diff HEAD:tests/test_yaml/libboost_gudhi_before_meta.yaml HEAD:tests/test_yaml/libboost_gudhi_after_meta.yaml</code></summary>

```diff
--- a/tests/test_yaml/libboost_gudhi_before_meta.yaml
+++ b/tests/test_yaml/libboost_gudhi_after_meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.9.0" %}
+{% set version = "1.10.0" %}

 package:
   name: gudhi
@@ -7,12 +7,12 @@ package:
 source:
   # fake source url to get version migrator to pass
   url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: b6d893dc7dcd4138b9e9df59a13c59695e50e80dc5c2cacee0674670693951a1
+  sha256: 3f9e587a96844a9b4ee7f998cfe4dc3964dc95c4ca94d7de6a77bffb99f873da
   # git_url: https://github.com/GUDHI/gudhi-devel.git
   # git_rev: tags/gudhi-release-{{ version }}

 build:
-  number: 5
+  number: 0

 requirements:
   build:
@@ -33,7 +33,7 @@ requirements:
     - cython
     - pybind11
     - numpy
-    - boost-cpp
+    - libboost-headers
     - eigen
     - cgal-cpp >=5.5
   run:
```

</details>

### Single output; host- & run-dependence on boost-cpp

<details>
<summary><code>git diff HEAD:tests/test_yaml/libboost_carve_before_meta.yaml HEAD:tests/test_yaml/libboost_carve_after_meta.yaml</code></summary>

```diff
--- a/tests/test_yaml/libboost_carve_before_meta.yaml
+++ b/tests/test_yaml/libboost_carve_after_meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "carve" %}
-{% set version = "1.9.0" %}
+{% set version = "1.10.0" %}

 package:
   name: {{ name|lower }}
@@ -8,12 +8,12 @@ package:
 source:
   # fake source url to get version migrator to pass
   url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: b6d893dc7dcd4138b9e9df59a13c59695e50e80dc5c2cacee0674670693951a1
+  sha256: 3f9e587a96844a9b4ee7f998cfe4dc3964dc95c4ca94d7de6a77bffb99f873da
   # url: https://github.com/ngodber/carve/archive/v{{ version }}.tar.gz
   # sha256: 20481918af488fc92694bf1d5bdd6351ad73a0b64fbe4373e1f829a7b0eeff63

 build:
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage("carve", max_pin="x.x") }}

@@ -24,9 +24,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - boost-cpp
+    - libboost-devel
   run:
-    - boost-cpp

 test:
   commands:
```

</details>

### Multiple outputs; tricky because appearance in comment messes up naïve counting

<details>
<summary><code>git diff HEAD:tests/test_yaml/libboost_fenics_before_meta.yaml HEAD:tests/test_yaml/libboost_fenics_after_meta.yaml</code></summary>

I consider the fact that the patch name gets spuriously renamed to be acceptable.

```diff
--- a/tests/test_yaml/libboost_fenics_before_meta.yaml
+++ b/tests/test_yaml/libboost_fenics_after_meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.9.0" %}
+{% set version = "1.10.0" %}

 package:
   name: fenics-pkgs
@@ -7,7 +7,7 @@ package:
 source:
   # fake source url to get version migrator to pass
   - url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: b6d893dc7dcd4138b9e9df59a13c59695e50e80dc5c2cacee0674670693951a1
+    sha256: 3f9e587a96844a9b4ee7f998cfe4dc3964dc95c4ca94d7de6a77bffb99f873da
   # - url: https://bitbucket.org/fenics-project/dijitso/downloads/dijitso-{{ version }}.tar.gz
   #   sha256: eaa45eec4457f3f865d72a926b7cba86df089410e78de04cd89b15bb405e8fd9
   #   folder: dijitso
@@ -26,24 +26,24 @@ source:
   #   sha256: 61abdcdb13684ba2a3ba4afb7ea6c7907aa0896a46439d3af7e8848483d4392f
   #   folder: dolfin
   #   patches:
-  #     - boost.patch
+  #     - libboost-devel-python.patch
   #     - linuxboost.patch  # [linux]
   #     - find-petsc-slepc.patch
   #     - hdf5-1.12.patch
   #     - fix-xdmf.patch

 build:
-  number: 35
+  number: 0
   skip: true  # [win]

-# NOTE: Top-level environment with boost-cpp is only to separate the build for
+# NOTE: Top-level environment with libboost-devel is only to separate the build for
 #       multiple boost versions into different CI jobs.
 # TODO: Needs investigation why "separate the two boost builds more strictly"
 #       would be necessary. Ref:
 #       https://github.com/conda-forge/mshr-feedstock/pull/23#issuecomment-749520383
 requirements:
   host:
-    - boost-cpp
+    - libboost-devel
     # need to split the build matrix on mpi provider
     - {{ mpi }}

@@ -144,7 +144,7 @@ outputs:
       host:
         - libblas
         - libcblas
-        - boost-cpp
+        - libboost-devel
         - cmake >=3.9
         - make
         - eigen
@@ -174,7 +174,6 @@ outputs:
         - suitesparse
         - zlib
         - fenics-ffc =={{ version }}
-        - boost-cpp
     test:
       commands:
         - test -f ${PREFIX}/lib/libdolfin${SHLIB_EXT}
@@ -195,7 +194,7 @@ outputs:
       host:
         - libblas
         - libcblas
-        - boost-cpp
+        - libboost-devel
         - python
         - pip
         - cmake >=3.9
@@ -221,7 +220,6 @@ outputs:
       run:
         - {{ compiler('cxx') }}  # [linux]
         - python
-        - boost-cpp
         - setuptools
         - {{ mpi }}
         - mpi4py
```

</details>

### Multiple outputs; tricky due to selectors, `{{ }}` pins & pin_compatible

<details>
<summary><code>git diff HEAD:tests/test_yaml/libboost_poppler_before_meta.yaml HEAD:tests/test_yaml/libboost_poppler_after_meta.yaml</code></summary>

```diff
--- a/tests/test_yaml/libboost_poppler_before_meta.yaml
+++ b/tests/test_yaml/libboost_poppler_after_meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.9.0" %}
+{% set version = "1.10.0" %}
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
 {% set prefix = 'Library/' if win else '' %}
@@ -11,7 +11,7 @@ source:
   # fake source url to get version migrator to pass
   url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
   # url: https://poppler.freedesktop.org/poppler-{{ version }}.tar.xz
-  sha256: b6d893dc7dcd4138b9e9df59a13c59695e50e80dc5c2cacee0674670693951a1
+  sha256: 3f9e587a96844a9b4ee7f998cfe4dc3964dc95c4ca94d7de6a77bffb99f873da
   patches:
     - exportsymbols.patch  # [win]
     - windows-data.patch  # [win]
@@ -21,7 +21,7 @@ source:
     - includesystembeforejpeg.patch  # [win]

 build:
-  number: 1
+  number: 0
   detect_binary_files_with_prefix: true

 requirements:
@@ -45,7 +45,7 @@ requirements:
     - {{ posix }}patch
     - perl 5
     - gobject-introspection 1.*  # [not win]
-    - boost-cpp {{ boost_cpp }}  # [build_platform != target_platform]
+    - libboost-devel  # [build_platform != target_platform]
     - cairo       # [build_platform != target_platform]
     - curl        # [build_platform != target_platform]
     - fontconfig  # [build_platform != target_platform]
@@ -62,7 +62,7 @@ requirements:
     - openjpeg    # [build_platform != target_platform]
     - zlib        # [build_platform != target_platform]
   host:
-    - boost-cpp
+    - libboost-devel
     - cairo
     - curl
     - fontconfig
@@ -105,7 +105,7 @@ outputs:
         - {{ posix }}patch
         - perl 5
         - gobject-introspection 1.*  # [not win]
-        - boost-cpp {{ boost_cpp }}  # [build_platform != target_platform]
+        - libboost-devel  # [build_platform != target_platform]
         - cairo       # [build_platform != target_platform]
         - curl        # [build_platform != target_platform]
         - fontconfig  # [build_platform != target_platform]
@@ -122,7 +122,7 @@ outputs:
         - openjpeg    # [build_platform != target_platform]
         - zlib        # [build_platform != target_platform]
       host:
-        - boost-cpp {{ boost_cpp }}
+        - libboost-devel
         - cairo
         - curl
         - fontconfig
@@ -139,7 +139,6 @@ outputs:
         - openjpeg
         - zlib
       run:
-        - {{ pin_compatible('boost-cpp') }}
         - poppler-data
     test:
       commands:
@@ -173,7 +172,7 @@ outputs:
         - {{ posix }}patch
         - perl 5
         - gobject-introspection 1.*  # [not win]
-        - boost-cpp {{ boost_cpp }}  # [build_platform != target_platform]
+        - libboost-devel  # [build_platform != target_platform]
         - cairo       # [build_platform != target_platform]
         - curl        # [build_platform != target_platform]
         - fontconfig  # [build_platform != target_platform]
@@ -190,7 +189,7 @@ outputs:
         - openjpeg    # [build_platform != target_platform]
         - zlib        # [build_platform != target_platform]
       host:
-        - boost-cpp {{ boost_cpp }}
+        - libboost-headers
         - cairo
         - curl
         - fontconfig
```

</details>

### Multiple outputs; tricky due to duplicate host entries & version pins

<details>
<summary><code>git diff HEAD:tests/test_yaml/libboost_scipopt_before_meta.yaml HEAD:tests/test_yaml/libboost_scipopt_after_meta.yaml</code></summary>

```diff
--- a/tests/test_yaml/libboost_scipopt_before_meta.yaml
+++ b/tests/test_yaml/libboost_scipopt_after_meta.yaml
@@ -1,5 +1,5 @@
 # TODO check these versions have not changed
-{% set version = "1.9.0" %}
+{% set version = "1.10.0" %}
 {% set papilo_version = "2.1.2" %}
 {% set soplex_version = "6.0.3" %}
 {% set gcg_version = "3.5.3" %}
@@ -17,13 +17,13 @@ package:
 source:
   # fake source url to get version migrator to pass
   - url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: b6d893dc7dcd4138b9e9df59a13c59695e50e80dc5c2cacee0674670693951a1
+    sha256: 3f9e587a96844a9b4ee7f998cfe4dc3964dc95c4ca94d7de6a77bffb99f873da
 #   - url: https://scipopt.org/download/release/scipoptsuite-{{ scip_version }}.tgz
 #     sha256: 5ad50eb42254c825d96f5747d8f3568dcbff0284dfbd1a727910c5a7c2899091
 #     folder: scipoptsuite

 build:
-  number: 1
+  number: 0

 requirements:
   build:
@@ -38,8 +38,7 @@ requirements:
     - zlib
     - ipopt
     - cppad
-    - boost-cpp ==1.72.0  # [win]
-    - boost-cpp       # [unix]
+    - libboost-devel
     - gmp             # [unix]
     - cliquer         # [unix]
     - bison           # [unix]
@@ -57,8 +56,8 @@ outputs:
       host:
         - zlib
         - gmp             # [unix]
-        - boost-cpp ==1.72.0  # [win]
-        - boost-cpp       # [unix]
+        - libboost-headers  # [win]
+        - libboost-headers       # [unix]
         - libblas
       run:
         - tbb-devel
@@ -128,16 +127,13 @@ outputs:
       host:
         - zlib
         - gmp             # [unix]
-        - boost-cpp ==1.72.0  # [win]
-        - boost-cpp       # [unix]
+        - libboost-devel
         # Papilo statically linked but needs direct dependency from used shared libs.
         - tbb-devel
         - libblas
       run:
         # libboost_program_options.so needed by bin/soplex.
         # boost does not set run_exports so it is needed in run requirements.
-        - boost-cpp ==1.72.0  # [win]
-        - boost-cpp       # [unix]
         - zlib
         - {{ pin_subpackage('papilo', exact=True) }}
     files:
```

</details>

### Python output (`boost -> libboost-python-devel`): simple case

<details>
<summary><code>git diff HEAD:tests/test_yaml/libboost_rdkit_before_meta.yaml HEAD:tests/test_yaml/libboost_rdkit_after_meta.yaml</code></summary>

```diff
--- a/tests/test_yaml/libboost_rdkit_before_meta.yaml
+++ b/tests/test_yaml/libboost_rdkit_after_meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rdkit" %}
-{% set version = "1.9.0" %}
+{% set version = "1.10.0" %}
 {% set filename = "Release_%s.tar.gz" % version.replace(".", "_") %}

 package:
@@ -9,7 +9,7 @@ package:
 source:
   # fake source url to get version migrator to pass
   url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: b6d893dc7dcd4138b9e9df59a13c59695e50e80dc5c2cacee0674670693951a1
+  sha256: 3f9e587a96844a9b4ee7f998cfe4dc3964dc95c4ca94d7de6a77bffb99f873da
   # fn: {{ filename }}
   # url: https://github.com/rdkit/rdkit/archive/{{ filename }}
   # sha256: db346afbd0ba52c843926a2a62f8a38c7b774ffab37eaf382d789a824f21996c
@@ -31,7 +31,7 @@ requirements:
     - make  # [unix]
     - pkg-config
   host:
-    - boost
+    - libboost-python-devel
     - cairo
     - eigen
     - freetype
@@ -40,7 +40,7 @@ requirements:
     - pillow
     - pandas
   run:
-    - boost
+    - libboost-python-devel
     - cairo
     - python
     - pillow
```

</details>

### Python output (`boost -> libboost-python-devel`): interaction with `boost-cpp`

<details>
<summary><code>git diff HEAD:tests/test_yaml/libboost_cctx_before_meta.yaml HEAD:tests/test_yaml/libboost_cctx_after_meta.yaml</code></summary>

```diff
--- a/tests/test_yaml/libboost_cctx_before_meta.yaml
+++ b/tests/test_yaml/libboost_cctx_after_meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.9.0" %}
+{% set version = "1.10.0" %}

 package:
   name: cctbx-base
@@ -7,7 +7,7 @@ package:
 source:
   # fake source url to get version migrator to pass
   url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: b6d893dc7dcd4138b9e9df59a13c59695e50e80dc5c2cacee0674670693951a1
+  sha256: 3f9e587a96844a9b4ee7f998cfe4dc3964dc95c4ca94d7de6a77bffb99f873da
   # url: https://github.com/cctbx/cctbx_project/releases/download/v{{ version }}/cctbx-{{ version }}.tar.gz
   # sha256: ad46f373875e1893f5fa87267b5445b97d660d0d05887e41d38d1fdd0e46724b
   patches:
@@ -36,8 +36,8 @@ requirements:
     - {{ cdt('libxxf86vm') }}  # [linux]
     - {{ cdt('libxext') }}     # [linux]
   host:
-    - boost
-    - boost-cpp
+    - libboost-python-devel
+    - libboost-devel
     - eigen
     - future
     - libglu  # [linux]
@@ -55,8 +55,6 @@ outputs:
     requirements:
       run:
         - biopython
-        - {{ pin_compatible('boost') }}
-        - boost-cpp
         - future
         - {{ pin_compatible('libglu') }}  # [linux]
         - libsvm
```

</details>
