### PR TITLE
BUG make sure to keep PR labels for bot-rerun

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -1418,6 +1418,9 @@ def _remove_closed_pr_json():
                     pri["PRed"][pr_ind]["PR"] = {
                         "state": "closed",
                         "number": lzj.get("number", None),
+                        "labels": [
+                            {"name": lb["name"]} for lb in lzj.get("labels", [])
+                        ],
                     }
                     write = True
                     do_commit = True


### PR DESCRIPTION
closes #1677 

This won't fix older PRs but should prevent new bot-rerun labels from being missed.