### PR TITLE
Use commit message's 1st line in migrator PR title

### DIFF
--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -333,7 +333,9 @@ class MigrationYaml(GraphMigrator):
         else:
             add_slug = ""
 
-        return add_slug + self.commit_message(feedstock_ctx)
+        title = self.commit_message(feedstock_ctx).splitlines()[0]
+
+        return add_slug + title
 
     def remote_branch(self, feedstock_ctx: FeedstockContext) -> str:
         s_obj = str(self.obj_version) if self.obj_version else ""


### PR DESCRIPTION
For multiline commit messages (with more filled out bodies), split the commit message into multiple lines and only keep the 1st line of the commit message for use in the PR title.