### PR TITLE
Include `commit_message` body in `pr_body`

### DIFF
--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -301,6 +301,14 @@ class MigrationYaml(GraphMigrator):
                 )
             )
 
+        commit_body = " ".join([e for e in self.commit_message(feedstock_ctx).splitlines()[1:] if e])
+        if commit_body:
+            additional_body += (
+                "<hr>"
+                "Here are some more details about this specific migrator:\n\n"
+                "{commit_body}\n\n"
+            ).format(commit_body=commit_body)
+
         children = "\n".join(
             [" - %s" % ch for ch in self.downstream_children(feedstock_ctx)],
         )

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -306,6 +306,7 @@ class MigrationYaml(GraphMigrator):
         )
         if len(children) > 0:
             additional_body += (
+                "<hr>"
                 "This package has the following downstream children:\n"
                 "{children}\n"
                 "and potentially more."

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -301,7 +301,9 @@ class MigrationYaml(GraphMigrator):
                 )
             )
 
-        commit_body = " ".join([e for e in self.commit_message(feedstock_ctx).splitlines()[1:] if e])
+        commit_body = " ".join(
+            [e for e in self.commit_message(feedstock_ctx).splitlines()[1:] if e],
+        )
         if commit_body:
             additional_body += (
                 "<hr>"


### PR DESCRIPTION
Improve visibility of additional details from the `commit_message` by including in the migrator PR's body message.