### PR TITLE
Slight formatting tweaks to YAML migrator's PR body text

### DIFF
--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -281,6 +281,7 @@ class MigrationYaml(GraphMigrator):
                 "the feedstock has been rebuilt, so if you are going to "
                 "perform the rebuild yourself don't close this PR until "
                 "the your rebuild has been merged.**\n\n"
+                "<hr>"
                 "".format(
                     name=self.name,
                 )
@@ -296,6 +297,7 @@ class MigrationYaml(GraphMigrator):
                 "the feedstock has been rebuilt, so if you are going to "
                 "perform the rebuild yourself don't close this PR until "
                 "the your rebuild has been merged.**\n\n"
+                "<hr>"
                 "".format(
                     name=self.name,
                 )
@@ -306,9 +308,10 @@ class MigrationYaml(GraphMigrator):
         )
         if commit_body:
             additional_body += (
-                "<hr>\n\n"
+                "\n\n"
                 "Here are some more details about this specific migrator:\n\n"
                 "{commit_body}\n\n"
+                "<hr>"
             ).format(commit_body=commit_body)
 
         children = "\n".join(
@@ -316,10 +319,11 @@ class MigrationYaml(GraphMigrator):
         )
         if len(children) > 0:
             additional_body += (
-                "<hr>\n\n"
+                "\n\n"
                 "This package has the following downstream children:\n"
                 "{children}\n"
-                "and potentially more."
+                "and potentially more.\n\n"
+                "<hr>"
             ).format(children=children)
 
         return body.format(additional_body)

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -310,7 +310,7 @@ class MigrationYaml(GraphMigrator):
             additional_body += (
                 "\n\n"
                 "Here are some more details about this specific migrator:\n\n"
-                "{commit_body}\n\n"
+                "> {commit_body}\n\n"
                 "<hr>"
             ).format(commit_body=commit_body)
 


### PR DESCRIPTION
As `super().pr_body(...)` adds its own text after the `additional_body` constructed by this migrator, make sure to have an `<hr>` right before that text so that the sections are not blended together.

Also quotes the `commit_body` text to make sure it stands out as separate from other text.