### PR TITLE
Add fastjsonschema to pypi_name_mapping_static.yaml

### DIFF
--- a/conda_forge_tick/pypi_name_mapping_static.yaml
+++ b/conda_forge_tick/pypi_name_mapping_static.yaml
@@ -79,3 +79,7 @@
 - pypi_name: ruamel-yaml
   import_name: ruamel.yaml
   conda_name: ruamel.yaml
+
+- pypi_name: fastjsonschema
+  import_name: fastjsonschema
+  conda_name: python-fastjsonschema


### PR DESCRIPTION
PyPI uses "fastjsonschema" while conda uses "python-fastjsonschema"