### PR TITLE
Log the traceback of an exception during dependency update

### DIFF
--- a/conda_forge_tick/migrators/dep_updates.py
+++ b/conda_forge_tick/migrators/dep_updates.py
@@ -40,7 +40,7 @@ class DependencyUpdateMigrator(MiniMigrator):
                 "new_version",
             )
         except (BaseException, Exception) as e:
-            logger.warning("Dep update failed! %s", repr(e))
+            logger.warning("Dep update failed!", exc_info=True)
         else:
             logger.info("applying deps: %s", update_deps)
             apply_dep_update(


### PR DESCRIPTION
The grayskull update of `harlequin` fails since some versions, but the log message `Dep update failed! KeyError('version')` doesn't help me find the issue. Thus I would like to have some more information in the log.