### PR TITLE
update_sources: ignore preview candidate (pc) versions

### DIFF
--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -159,6 +159,7 @@ class VersionFromFeed(AbstractSource):
         "test",
         "pre",
         "git",
+        "pc",
     ]
 
     def get_version(self, url) -> Optional[str]:


### PR DESCRIPTION
This is a fix for #1550
#1441 would be really great to fix this issue for everybody in long term.

Here is branch naming convention in oneDNN: https://github.com/oneapi-src/oneDNN/issues/1779