### PR TITLE
Refactor Logging, Add GitHub Graph Backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,27 @@ in the `autotick-bot` subdirectory.
 If you want to stop the worker, rename the file to `please.stop` and it will not restart
 itself on the next round.
 
+
+## Debugging Locally
+You can use the CLI of the bot to debug it locally. To do so, install the bot with the following command:
+```bash
+pip install -e .
+```
+
+Then you can use the CLI like this:
+```bash
+conda-forge-tick --help
+```
+
+For debugging, use the `--debug` flag. This enables debug logging and disables multiprocessing.
+
+Note that the bot expects the [conda-forge dependency graph](https://github.com/regro/cf-graph-countyfair) to be
+present in the current working directory by default. Use `--online` to download missing files on demand from GitHub.
+
+The local debugging functionality is still work in progress and might not work for all commands.
+Currently, the following commands are supported and tested:
+- `update-upstream-versions`
+
 ## What has the bot done recently?
 
 Check out its [PRs](https://github.com/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+author%3Aregro-cf-autotick-bot+archived%3Afalse+), its currently [running jobs](https://github.com/regro/cf-scripts/actions?query=is%3Ain_progress++), and the [status page](https://conda-forge.org/status/#current_migrations)!

--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ conda-forge-tick --help
 For debugging, use the `--debug` flag. This enables debug logging and disables multiprocessing.
 
 Note that the bot expects the [conda-forge dependency graph](https://github.com/regro/cf-graph-countyfair) to be
-present in the current working directory by default. Use `--online` to download missing files on demand from GitHub.
+present in the current working directory by default, unless the `--online` flag is used.
+
+> [!TIP]
+> Use the `--online` flag when debugging the bot locally to avoid having to clone the whole
+> dependency graph.
 
 The local debugging functionality is still work in progress and might not work for all commands.
 Currently, the following commands are supported and tested:

--- a/conda_forge_tick/all_feedstocks.py
+++ b/conda_forge_tick/all_feedstocks.py
@@ -1,16 +1,14 @@
 import logging
-from typing import Any, List
+from typing import List
 
 import github
 import tqdm
 
 from conda_forge_tick import sensitive_env
 
-from .cli_context import CliContext
 from .lazy_json_backends import dump, load
-from .utils import setup_logger
 
-logger = logging.getLogger("conda_forge_tick.all_feedstocks")
+logger = logging.getLogger(__name__)
 
 
 def get_all_feedstocks_from_github():
@@ -67,11 +65,7 @@ def get_archived_feedstocks(cached: bool = False) -> List[str]:
     return names
 
 
-def main(ctx: CliContext) -> None:
-    if ctx.debug:
-        setup_logger(logger, level="debug")
-    else:
-        setup_logger(logger)
+def main() -> None:
     logger.info("fetching active feedstocks from github")
     data = get_all_feedstocks_from_github()
     with open("all_feedstocks.json", "w") as fp:

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -27,6 +27,12 @@ from typing import (
 import tqdm
 
 from .cli_context import CliContext
+from .lazy_json_backends import (
+    LazyJson,
+    get_all_keys_for_hashmap,
+    lazy_json_transaction,
+    remove_key_for_hashmap,
+)
 
 if typing.TYPE_CHECKING:
     from .migrators_types import MetaYamlTypedDict, MigrationUidTypedDict, PackageName
@@ -53,12 +59,6 @@ from conda_forge_tick.git_utils import (
     get_repo,
     is_github_api_limit_reached,
     push_repo,
-)
-from conda_forge_tick.lazy_json_backends import (
-    LazyJson,
-    get_all_keys_for_hashmap,
-    lazy_json_transaction,
-    remove_key_for_hashmap,
 )
 from conda_forge_tick.migrators import (
     ArchRebuild,
@@ -105,14 +105,13 @@ from conda_forge_tick.utils import (
     parse_munged_run_export,
     pluck,
     sanitize_string,
-    setup_logger,
     yaml_safe_load,
 )
 
 # not using this right now
 # from conda_forge_tick.deploy import deploy
 
-logger = logging.getLogger("conda_forge_tick.auto_tick")
+logger = logging.getLogger(__name__)
 
 PR_LIMIT = 5
 MAX_PR_LIMIT = 50
@@ -1565,12 +1564,6 @@ def main(ctx: CliContext) -> None:
 
     global BOT_HOME_DIR
     BOT_HOME_DIR = os.getcwd()
-
-    # logging
-    if ctx.debug:
-        setup_logger(logging.getLogger("conda_forge_tick"), level="debug")
-    else:
-        setup_logger(logging.getLogger("conda_forge_tick"))
 
     with fold_log_lines("updating graph with PR info"):
         _update_graph_with_pr_info()

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -100,6 +100,7 @@ from conda_forge_tick.utils import (
     fold_log_lines,
     frozen_to_json_friendly,
     get_keys_default,
+    load_existing_graph,
     load_graph,
     parse_meta_yaml,
     parse_munged_run_export,
@@ -982,7 +983,7 @@ def initialize_migrators(
     dry_run: bool = False,
 ) -> Tuple[MigratorSessionContext, list, MutableSequence[Migrator]]:
     temp = glob.glob("/tmp/*")
-    gx = load_graph()
+    gx = load_existing_graph()
     smithy_version = eval_cmd("conda smithy --version").strip()
     pinning_version = json.loads(eval_cmd("conda list conda-forge-pinning --json"))[0][
         "version"
@@ -1409,7 +1410,7 @@ def _setup_limits():
         resource.setrlimit(resource.RLIMIT_AS, (limit_int, limit_int))
 
 
-def _update_nodes_with_bot_rerun(gx):
+def _update_nodes_with_bot_rerun(gx: nx.DiGraph):
     """Go through all the open PRs and check if they are rerun"""
 
     print("processing bot-rerun labels", flush=True)
@@ -1552,7 +1553,7 @@ def _remove_closed_pr_json():
 
 def _update_graph_with_pr_info():
     _remove_closed_pr_json()
-    gx = load_graph()
+    gx = load_existing_graph()
     _update_nodes_with_bot_rerun(gx)
     _update_nodes_with_new_versions(gx)
     dump_graph(gx)

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -101,7 +101,6 @@ from conda_forge_tick.utils import (
     frozen_to_json_friendly,
     get_keys_default,
     load_existing_graph,
-    load_graph,
     parse_meta_yaml,
     parse_munged_run_export,
     pluck,

--- a/conda_forge_tick/backend_settings.py
+++ b/conda_forge_tick/backend_settings.py
@@ -1,0 +1,3 @@
+GITHUB_GRAPH_BACKEND_BASE_URL = (
+    "https://github.com/regro/cf-graph-countyfair/raw/master"
+)

--- a/conda_forge_tick/cli.py
+++ b/conda_forge_tick/cli.py
@@ -4,7 +4,7 @@ import time
 from typing import Optional
 
 import click
-from click import IntRange
+from click import IntRange, Context
 
 from conda_forge_tick import lazy_json_backends
 
@@ -59,7 +59,14 @@ click.Group.command_class = TimedCommand
     "used to cache JSON files. Local files will be used if they exist.",
 )
 @pass_context
-def main(ctx: CliContext, debug: bool, dry_run: bool, online: bool) -> None:
+@click.pass_context
+def main(
+    click_context: Context,
+    ctx: CliContext,
+    debug: bool,
+    dry_run: bool,
+    online: bool,
+) -> None:
     log_level = "debug" if debug else "info"
     setup_logging(log_level)
 
@@ -71,8 +78,9 @@ def main(ctx: CliContext, debug: bool, dry_run: bool, online: bool) -> None:
 
     if online:
         logger.info("Running in online mode")
-        lazy_json_backends.CF_TICK_GRAPH_DATA_BACKENDS = ("github",)
-        lazy_json_backends.CF_TICK_GRAPH_DATA_PRIMARY_BACKEND = "github"
+        click_context.with_resource(
+            lazy_json_backends.lazy_json_override_backends(["github"]),
+        )
 
 
 @main.command(name="gather-all-feedstocks")

--- a/conda_forge_tick/cli.py
+++ b/conda_forge_tick/cli.py
@@ -54,7 +54,7 @@ click.Group.command_class = TimedCommand
 @click.option(
     "--online/--offline",
     default=False,
-    help="online: Use the GitHub API for accessing the dependency graph. This is useful for local testing. Note "
+    help="online: Make requests to GitHub for accessing the dependency graph. This is useful for local testing. Note "
     "however that any write operations will not be performed. Important: The current working directory will be "
     "used to cache JSON files. Local files will be used if they exist.",
 )

--- a/conda_forge_tick/cli.py
+++ b/conda_forge_tick/cli.py
@@ -7,6 +7,7 @@ import click
 from click import Context, IntRange
 
 from conda_forge_tick import lazy_json_backends
+from conda_forge_tick.utils import setup_logging
 
 from .cli_context import CliContext
 

--- a/conda_forge_tick/cli.py
+++ b/conda_forge_tick/cli.py
@@ -7,7 +7,6 @@ import click
 from click import IntRange
 
 from conda_forge_tick import lazy_json_backends
-from conda_forge_tick.utils import setup_logger
 
 from .cli_context import CliContext
 
@@ -61,7 +60,7 @@ click.Group.command_class = TimedCommand
 @pass_context
 def main(ctx: CliContext, debug: bool, dry_run: bool, online: bool) -> None:
     log_level = "debug" if debug else "info"
-    setup_logger(logger, log_level)
+    setup_logging(log_level)
 
     ctx.debug = debug
     ctx.dry_run = dry_run
@@ -80,7 +79,7 @@ def main(ctx: CliContext, debug: bool, dry_run: bool, online: bool) -> None:
 def gather_all_feedstocks(ctx: CliContext) -> None:
     from . import all_feedstocks
 
-    all_feedstocks.main(ctx)
+    all_feedstocks.main()
 
 
 @main.command(name="make-graph")

--- a/conda_forge_tick/cli.py
+++ b/conda_forge_tick/cli.py
@@ -54,7 +54,7 @@ click.Group.command_class = TimedCommand
 @click.option(
     "--online/--offline",
     default=False,
-    help="Online: Use the GitHub API for accessing the dependency graph. This is useful for local testing. Note "
+    help="online: Use the GitHub API for accessing the dependency graph. This is useful for local testing. Note "
     "however that any write operations will not be performed. Important: The current working directory will be "
     "used to cache JSON files. Local files will be used if they exist.",
 )

--- a/conda_forge_tick/cli.py
+++ b/conda_forge_tick/cli.py
@@ -55,7 +55,8 @@ click.Group.command_class = TimedCommand
     "--online/--offline",
     default=False,
     help="Online: Use the GitHub API for accessing the dependency graph. This is useful for local testing. Note "
-    "however that any write operations will not be performed.",
+    "however that any write operations will not be performed. Important: The current working directory will be "
+    "used to cache JSON files. Local files will be used if they exist.",
 )
 @pass_context
 def main(ctx: CliContext, debug: bool, dry_run: bool, online: bool) -> None:
@@ -76,7 +77,7 @@ def main(ctx: CliContext, debug: bool, dry_run: bool, online: bool) -> None:
 
 @main.command(name="gather-all-feedstocks")
 @pass_context
-def gather_all_feedstocks(ctx: CliContext) -> None:
+def gather_all_feedstocks() -> None:
     from . import all_feedstocks
 
     all_feedstocks.main()

--- a/conda_forge_tick/cli.py
+++ b/conda_forge_tick/cli.py
@@ -4,7 +4,7 @@ import time
 from typing import Optional
 
 import click
-from click import IntRange, Context
+from click import Context, IntRange
 
 from conda_forge_tick import lazy_json_backends
 

--- a/conda_forge_tick/cli.py
+++ b/conda_forge_tick/cli.py
@@ -85,7 +85,6 @@ def main(
 
 
 @main.command(name="gather-all-feedstocks")
-@pass_context
 def gather_all_feedstocks() -> None:
     from . import all_feedstocks
 

--- a/conda_forge_tick/depfinder_api.py
+++ b/conda_forge_tick/depfinder_api.py
@@ -40,7 +40,7 @@ from depfinder.inspection import iterate_over_library
 from depfinder.stdliblist import builtin_modules as _builtin_modules
 from depfinder.utils import SKETCHY_TYPES_TABLE
 
-logger = logging.getLogger("conda_forge_tick.depfinder_api")
+logger = logging.getLogger(__name__)
 
 
 def extract_pkg_from_import(name):

--- a/conda_forge_tick/deploy.py
+++ b/conda_forge_tick/deploy.py
@@ -6,7 +6,7 @@ from doctr.travis import run_command_hiding_token as doctr_run
 from . import sensitive_env
 from .cli_context import CliContext
 from .lazy_json_backends import CF_TICK_GRAPH_DATA_HASHMAPS, get_lazy_json_backends
-from .utils import load_graph
+from .utils import load_existing_graph
 
 BUILD_URL_KEY = "CIRCLE_BUILD_URL"
 
@@ -93,7 +93,7 @@ def deploy(ctx: CliContext):
 
         # make sure the graph can load, if not we will error
         try:
-            gx = load_graph()
+            gx = load_existing_graph()
             # TODO: be more selective about which json to check
             for node, attrs in gx.nodes.items():
                 attrs["payload"]._load()

--- a/conda_forge_tick/executors.py
+++ b/conda_forge_tick/executors.py
@@ -19,7 +19,7 @@ PRLOCK = DummyLock()
 DLOCK = DummyLock()
 
 
-logger = logging.getLogger("conda_forge_tick.executor")
+logger = logging.getLogger(__name__)
 
 
 def _init_process(lock):

--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 from .utils import as_iterable, parse_meta_yaml
 
-logger = logging.getLogger("conda_forge_tick.feedstock_parser")
+logger = logging.getLogger(__name__)
 
 PIN_SEP_PAT = re.compile(r" |>|<|=|\[")
 

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -232,8 +232,11 @@ class GithubLazyJsonBackend(LazyJsonBackend):
 
     def hexists(self, name: str, key: str) -> bool:
         self._inform_web_request()
-        url = urllib.parse.urljoin(self.base_url, f"{name}/{key}.json")
-        status = requests.head(url).status_code
+        url = urllib.parse.urljoin(
+            self.base_url,
+            get_sharded_path(f"{name}/{key}.json"),
+        )
+        status = requests.head(url, allow_redirects=True).status_code
 
         if status == 200:
             return True

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -203,20 +203,21 @@ class GithubLazyJsonBackend(LazyJsonBackend):
             value += "/"
         self._base_url = value
 
-    def _ignore_write(self) -> None:
-        if self._write_warned:
+    @classmethod
+    def _ignore_write(cls) -> None:
+        if cls._write_warned:
             return
         logger.info(f"Note: Write operations to the GitHub online backend are ignored.")
-        self._write_warned = True
+        cls._write_warned = True
 
     @classmethod
     def _inform_web_request(cls):
         cls._n_requests += 1
-        if cls._n_requests % 10 == 0:
+        if cls._n_requests % 20 == 0:
             logger.info(
                 f"Made {cls._n_requests} requests to the GitHub online backend.",
             )
-        if cls._n_requests == 10:
+        if cls._n_requests == 20:
             logger.warning(
                 f"Using the GitHub online backend for making a lot of requests is not recommended.",
             )
@@ -855,26 +856,12 @@ def load(
 
 
 def main_sync(ctx: CliContext):
-    from conda_forge_tick.utils import setup_logger
-
-    if ctx.debug:
-        setup_logger(logging.getLogger("conda_forge_tick"), level="debug")
-    else:
-        setup_logger(logging.getLogger("conda_forge_tick"))
-
     if not ctx.dry_run:
         sync_lazy_json_across_backends()
 
 
 def main_cache(ctx: CliContext):
-    from conda_forge_tick.utils import setup_logger
-
     global CF_TICK_GRAPH_DATA_BACKENDS
-
-    if ctx.debug:
-        setup_logger(logging.getLogger("conda_forge_tick"), level="debug")
-    else:
-        setup_logger(logging.getLogger("conda_forge_tick"))
 
     if not ctx.dry_run and len(CF_TICK_GRAPH_DATA_BACKENDS) > 1:
         OLD_CF_TICK_GRAPH_DATA_BACKENDS = CF_TICK_GRAPH_DATA_BACKENDS

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -269,6 +269,8 @@ class GithubLazyJsonBackend(LazyJsonBackend):
         sharded_path = get_sharded_path(f"{name}/{key}.json")
         url = urllib.parse.urljoin(self.base_url, sharded_path)
         r = requests.get(url)
+        if r.status_code == 404:
+            raise KeyError(f"Key {key} not found in hashmap {name}")
         r.raise_for_status()
         return r.text
 

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -58,12 +58,12 @@ def get_sharded_path(file_path, n_dirs=5):
 class LazyJsonBackend(ABC):
     @contextlib.contextmanager
     @abstractmethod
-    def transaction_context(self) -> "LazyJsonBackend":
+    def transaction_context(self) -> "Iterator[LazyJsonBackend]":
         pass
 
     @contextlib.contextmanager
     @abstractmethod
-    def snapshot_context(self) -> "LazyJsonBackend":
+    def snapshot_context(self) -> "Iterator[LazyJsonBackend]":
         pass
 
     @abstractmethod
@@ -108,12 +108,12 @@ class LazyJsonBackend(ABC):
 
 class FileLazyJsonBackend(LazyJsonBackend):
     @contextlib.contextmanager
-    def transaction_context(self) -> "FileLazyJsonBackend":
+    def transaction_context(self) -> "Iterator[FileLazyJsonBackend]":
         # context not required
         yield self
 
     @contextlib.contextmanager
-    def snapshot_context(self) -> "FileLazyJsonBackend":
+    def snapshot_context(self) -> "Iterator[FileLazyJsonBackend]":
         # context not required
         yield self
 
@@ -131,7 +131,7 @@ class FileLazyJsonBackend(LazyJsonBackend):
         for key, value in mapping.items():
             self.hset(name, key, value)
 
-    def hmget(self, name: str, keys: str) -> List[str]:
+    def hmget(self, name: str, keys: Iterable[str]) -> List[str]:
         return [self.hget(name, key) for key in keys]
 
     def hgetall(self, name: str, hashval: bool = False) -> Dict[str, str]:
@@ -222,11 +222,11 @@ class GithubLazyJsonBackend(LazyJsonBackend):
                 f"Using the GitHub online backend for making a lot of requests is not recommended.",
             )
 
-    def transaction_context(self) -> "GithubLazyJsonBackend":
+    def transaction_context(self) -> "Iterator[GithubLazyJsonBackend]":
         # context not required
         yield self
 
-    def snapshot_context(self) -> "GithubLazyJsonBackend":
+    def snapshot_context(self) -> "Iterator[GithubLazyJsonBackend]":
         # context not required
         yield self
 
@@ -318,7 +318,7 @@ class MongoDBLazyJsonBackend(LazyJsonBackend):
     _snapshot_session = None
 
     @contextlib.contextmanager
-    def transaction_context(self):
+    def transaction_context(self) -> "Iterator[MongoDBLazyJsonBackend]":
         try:
             if self.__class__._session is None:
                 client = get_graph_data_mongodb_client()
@@ -333,7 +333,7 @@ class MongoDBLazyJsonBackend(LazyJsonBackend):
             self.__class__._session = None
 
     @contextlib.contextmanager
-    def snapshot_context(self):
+    def snapshot_context(self) -> "Iterator[MongoDBLazyJsonBackend]":
         try:
             if self.__class__._snapshot_session is None:
                 client = get_graph_data_mongodb_client()

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -260,12 +260,12 @@ class GithubLazyJsonBackend(LazyJsonBackend):
     def hkeys(self, name: str) -> List[str]:
         """
         Not implemented for GithubLazyJsonBackend.
-        Logs a warning and returns an empty list.
+        Raises an error.
         """
-        logger.warning(
-            "hkeys not implemented for GithubLazyJsonBackend. Returning empty list.",
+        raise NotImplementedError(
+            "hkeys not implemented for GitHub JSON backend."
+            "You cannot use the GitHub backend with operations that require listing all hashmap keys."
         )
-        return []
 
     def hget(self, name: str, key: str) -> str:
         self._inform_web_request()
@@ -280,12 +280,13 @@ class GithubLazyJsonBackend(LazyJsonBackend):
     def hgetall(self, name: str, hashval: bool = False) -> Dict[str, str]:
         """
         Not implemented for GithubLazyJsonBackend.
-        Logs a warning and returns an empty dict.
+        Raises an error.
         """
-        logger.warning(
-            "hgetall not implemented for GithubLazyJsonBackend. Returning empty dict.",
+        raise NotImplementedError(
+            "hgetall not implemented for GitHub JSON backend."
+            "You cannot use the GitHub backend as source or target for hashmap synchronization or other"
+            "commands that require listing all hashmap keys.",
         )
-        return {}
 
 
 @functools.lru_cache(maxsize=128)

--- a/conda_forge_tick/lazy_json_backups.py
+++ b/conda_forge_tick/lazy_json_backups.py
@@ -14,7 +14,7 @@ from conda_forge_tick.lazy_json_backends import (
 
 from .cli_context import CliContext
 
-logger = logging.getLogger("conda_forge_tick.lazy_json_backends")
+logger = logging.getLogger(__name__)
 
 CF_TICK_GRAPH_DATA_BACKUP_BACKEND = os.environ.get(
     "CF_TICK_GRAPH_DATA_BACKUP_BACKEND",
@@ -164,13 +164,6 @@ def save_backup(fname):
 
 
 def main_backup(ctx: CliContext):
-    from conda_forge_tick.utils import setup_logger
-
-    if ctx.debug:
-        setup_logger(logging.getLogger("conda_forge_tick"), level="debug")
-    else:
-        setup_logger(logging.getLogger("conda_forge_tick"))
-
     def _name_to_ts(b):
         return int(b.split(".")[0].split("_")[-1])
 

--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -26,12 +26,13 @@ from .all_feedstocks import get_all_feedstocks, get_archived_feedstocks
 from .cli_context import CliContext
 from .contexts import GithubContext
 from .executors import executor
-from .utils import as_iterable, dump_graph, load_graph, setup_logger
+from .utils import as_iterable, dump_graph, load_graph
 
 # from conda_forge_tick.profiler import profiling
 
 
-logger = logging.getLogger("conda_forge_tick.make_graph")
+logger = logging.getLogger(__name__)
+
 pin_sep_pat = re.compile(r" |>|<|=|\[")
 random.seed(os.urandom(64))
 
@@ -312,11 +313,6 @@ def _migrate_schemas():
 
 # @profiling
 def main(ctx: CliContext) -> None:
-    if ctx.debug:
-        setup_logger(logging.getLogger("conda_forge_tick"), level="debug")
-    else:
-        setup_logger(logging.getLogger("conda_forge_tick"))
-
     names = get_all_feedstocks(cached=True)
     gx = load_graph()
 

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -24,7 +24,7 @@ if typing.TYPE_CHECKING:
     from ..migrators_types import AttrsTypedDict, MigrationUidTypedDict, PackageName
 
 
-logger = logging.getLogger("conda_forge_tick.migrators.core")
+logger = logging.getLogger(__name__)
 
 
 def _sanitized_muids(pred: List[dict]) -> List["JsonFriendly"]:

--- a/conda_forge_tick/migrators/cross_compile.py
+++ b/conda_forge_tick/migrators/cross_compile.py
@@ -10,7 +10,7 @@ from conda_forge_tick.utils import _get_source_code, yaml_safe_dump, yaml_safe_l
 if typing.TYPE_CHECKING:
     from ..migrators_types import AttrsTypedDict
 
-logger = logging.getLogger("conda_forge_tick.migrators.cross_compile")
+logger = logging.getLogger(__name__)
 
 
 class CrossCompilationMigratorBase(MiniMigrator):

--- a/conda_forge_tick/migrators/dep_updates.py
+++ b/conda_forge_tick/migrators/dep_updates.py
@@ -9,7 +9,7 @@ from conda_forge_tick.utils import get_keys_default
 if typing.TYPE_CHECKING:
     from ..migrators_types import AttrsTypedDict
 
-logger = logging.getLogger("conda_forge_tick.migrators.dep_updates")
+logger = logging.getLogger(__name__)
 
 
 class DependencyUpdateMigrator(MiniMigrator):

--- a/conda_forge_tick/migrators/license.py
+++ b/conda_forge_tick/migrators/license.py
@@ -23,7 +23,7 @@ if typing.TYPE_CHECKING:
 
 LICENSE_SPLIT = re.compile(r"\||\+")
 
-logger = logging.getLogger("conda_forge_tick.migrators.license")
+logger = logging.getLogger(__name__)
 
 
 def _to_spdx(lic):

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -26,7 +26,7 @@ from conda_forge_tick.utils import (
 if typing.TYPE_CHECKING:
     from ..migrators_types import AttrsTypedDict, MigrationUidTypedDict, PackageName
 
-logger = logging.getLogger("conda_forge_tick.migrators.migration_yaml")
+logger = logging.getLogger(__name__)
 
 
 def _patch_dict(cfg, patches):
@@ -403,9 +403,11 @@ class MigrationYaml(GraphMigrator):
             graph,
             key=lambda x: (
                 _not_has_error(x),
-                random.uniform(0, 1)
-                if not _not_has_error(x)
-                else len(nx.descendants(total_graph, x)),
+                (
+                    random.uniform(0, 1)
+                    if not _not_has_error(x)
+                    else len(nx.descendants(total_graph, x))
+                ),
                 x,
             ),
             reverse=True,

--- a/conda_forge_tick/migrators/version.py
+++ b/conda_forge_tick/migrators/version.py
@@ -28,7 +28,7 @@ SKIP_DEPS_NODES = [
     "ansible",
 ]
 
-logger = logging.getLogger("conda_forge_tick.migrators.version")
+logger = logging.getLogger(__name__)
 
 
 def _fmt_error_message(errors, version):

--- a/conda_forge_tick/pypi_name_mapping.py
+++ b/conda_forge_tick/pypi_name_mapping.py
@@ -20,7 +20,7 @@ from packaging.utils import NormalizedName as PypiName
 from packaging.utils import canonicalize_name as canonicalize_pypi_name
 
 from .lazy_json_backends import LazyJson, dump, get_all_keys_for_hashmap, loads
-from .utils import as_iterable, load_graph
+from .utils import as_iterable, load_existing_graph, load_graph
 
 
 class Mapping(TypedDict):
@@ -298,7 +298,7 @@ def determine_best_matches_for_pypi_import(
         map_by_conda_name[conda_name] = m
 
     graph_file = str(pathlib.Path(".") / "graph.json")
-    gx = load_graph(graph_file)
+    gx = load_existing_graph(graph_file)
     # TODO: filter out archived feedstocks?
 
     try:

--- a/conda_forge_tick/pypi_name_mapping.py
+++ b/conda_forge_tick/pypi_name_mapping.py
@@ -20,7 +20,7 @@ from packaging.utils import NormalizedName as PypiName
 from packaging.utils import canonicalize_name as canonicalize_pypi_name
 
 from .lazy_json_backends import LazyJson, dump, get_all_keys_for_hashmap, loads
-from .utils import as_iterable, load_existing_graph, load_graph
+from .utils import as_iterable, load_existing_graph
 
 
 class Mapping(TypedDict):

--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -17,7 +17,6 @@ from conda.models.version import VersionOrder
 from graphviz import Source
 
 from conda_forge_tick.auto_tick import _filter_ignored_versions, initialize_migrators
-from conda_forge_tick.cli_context import CliContext
 from conda_forge_tick.contexts import FeedstockContext
 from conda_forge_tick.lazy_json_backends import LazyJson, get_all_keys_for_hashmap
 from conda_forge_tick.migrators import (

--- a/conda_forge_tick/update_deps.py
+++ b/conda_forge_tick/update_deps.py
@@ -22,7 +22,7 @@ try:
 except ImportError:
     from grayskull.__main__ import create_python_recipe
 
-logger = logging.getLogger("conda_forge_tick.update_deps")
+logger = logging.getLogger(__name__)
 
 
 SECTIONS_TO_PARSE = ["host", "run"]

--- a/conda_forge_tick/update_prs.py
+++ b/conda_forge_tick/update_prs.py
@@ -2,7 +2,6 @@ import copy
 import hashlib
 import logging
 import random
-import typing
 from concurrent.futures._base import as_completed
 
 import github3

--- a/conda_forge_tick/update_prs.py
+++ b/conda_forge_tick/update_prs.py
@@ -18,7 +18,7 @@ from conda_forge_tick.git_utils import (
 
 from .executors import executor
 from .make_graph import ghctx
-from .utils import github_client, load_graph
+from .utils import github_client, load_existing_graph
 
 # from conda_forge_tick.profiler import profiling
 
@@ -164,7 +164,7 @@ def close_dirty_prs(
 
 # @profiling
 def main(ctx: CliContext, job: int = 1, n_jobs: int = 1) -> None:
-    gx = load_graph()
+    gx = load_existing_graph()
 
     gx = close_labels(gx, ctx.dry_run, job=job, n_jobs=n_jobs)
     gx = update_graph_pr_status(gx, ctx.dry_run, job=job, n_jobs=n_jobs)

--- a/conda_forge_tick/update_prs.py
+++ b/conda_forge_tick/update_prs.py
@@ -19,11 +19,11 @@ from conda_forge_tick.git_utils import (
 
 from .executors import executor
 from .make_graph import ghctx
-from .utils import github_client, load_graph, setup_logger
+from .utils import github_client, load_graph
 
 # from conda_forge_tick.profiler import profiling
 
-logger = logging.getLogger("conda_forge_tick.update_prs")
+logger = logging.getLogger(__name__)
 
 NUM_GITHUB_THREADS = 2
 KEEP_PR_FRACTION = 1.5
@@ -165,11 +165,6 @@ def close_dirty_prs(
 
 # @profiling
 def main(ctx: CliContext, job: int = 1, n_jobs: int = 1) -> None:
-    if ctx.debug:
-        setup_logger(logger, level="debug")
-    else:
-        setup_logger(logger)
-
     gx = load_graph()
 
     gx = close_labels(gx, ctx.dry_run, job=job, n_jobs=n_jobs)

--- a/conda_forge_tick/update_recipe/version.py
+++ b/conda_forge_tick/update_recipe/version.py
@@ -25,7 +25,7 @@ CHECKSUM_NAMES = [
 # matches valid jinja2 vars
 JINJA2_VAR_RE = re.compile("{{ ((?:[a-zA-Z]|(?:_[a-zA-Z0-9]))[a-zA-Z0-9_]*) }}")
 
-logger = logging.getLogger("conda_forge_tick.update_recipe.version")
+logger = logging.getLogger(__name__)
 
 
 def _gen_key_selector(dct: MutableMapping, key: str):

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -27,7 +27,7 @@ if typing.TYPE_CHECKING:
 
 CRAN_INDEX: Optional[dict] = None
 
-logger = logging.getLogger("conda_forge_tick._update_version.update_sources")
+logger = logging.getLogger(__name__)
 
 CURL_ONLY_URL_SLUGS = [
     "https://eups.lsst.codes/",

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -139,7 +139,7 @@ class AbstractSource(abc.ABC):
         pass
 
 
-class VersionFromFeed(AbstractSource):
+class VersionFromFeed(AbstractSource, abc.ABC):
     name = "VersionFromFeed"
     ver_prefix_remove = ["release-", "releases%2F", "v_", "v.", "v"]
     dev_vers = [

--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -36,7 +36,7 @@ from .update_sources import (
     RawURL,
     ROSDistro,
 )
-from .utils import get_keys_default, load_graph
+from .utils import get_keys_default, load_existing_graph
 
 T = TypeVar("T")
 
@@ -405,7 +405,7 @@ def main(
     """
     logger.info("Reading graph")
     # Graph enabled for inspection
-    gx = load_graph()
+    gx = load_existing_graph()
 
     # Check if 'versions' folder exists or create a new one;
     os.makedirs("versions", exist_ok=True)

--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -36,7 +36,7 @@ from .update_sources import (
     RawURL,
     ROSDistro,
 )
-from .utils import get_keys_default, load_graph, setup_logger
+from .utils import get_keys_default, load_graph
 
 T = TypeVar("T")
 
@@ -403,11 +403,6 @@ def main(
     :param n_jobs: The total number of jobs.
     :param package: The package to update. If None, update all packages.
     """
-    if ctx.debug:
-        setup_logger(logger, level="debug")
-    else:
-        setup_logger(logger)
-
     logger.info("Reading graph")
     # Graph enabled for inspection
     gx = load_graph()

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -27,7 +27,7 @@ if typing.TYPE_CHECKING:
 
     from conda_forge_tick.migrators_types import MetaYamlTypedDict
 
-logger = logging.getLogger("conda_forge_tick.utils")
+logger = logging.getLogger(__name__)
 
 T = typing.TypeVar("T")
 TD = typing.TypeVar("TD", bound=dict, covariant=True)
@@ -394,17 +394,12 @@ class NullUndefined(jinja2.Undefined):
         return f'{self}["{name}"]'
 
 
-def setup_logger(logger: logging.Logger, level: str = "INFO") -> None:
-    """Basic configuration for logging"""
-    logger.setLevel(level.upper())
-    ch = logging.StreamHandler()
-    ch.setLevel(level.upper())
-    ch.setFormatter(
-        logging.Formatter("%(asctime)-15s %(levelname)-8s %(name)s || %(message)s"),
+def setup_logging(level: str = "INFO") -> None:
+    logging.basicConfig(
+        format="%(asctime)-15s %(levelname)-8s %(name)s || %(message)s",
+        level=level.upper(),
     )
-    logger.addHandler(ch)
-    # this prevents duplicate logging messages
-    logger.propagate = False
+    logging.getLogger("urllib3").setLevel(logging.INFO)
 
 
 # TODO: upstream this into networkx?

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -454,7 +454,7 @@ def load_graph(filename: str = "graph.json") -> nx.DiGraph:
     if dta:
         return nx.node_link_graph(dta)
     else:
-        return None
+        raise FileNotFoundError("Graph file not found.")
 
 
 # TODO: This type does not support generics yet sadly

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -451,23 +451,27 @@ def dump_graph(
 def load_existing_graph(filename: str = DEFAULT_GRAPH_FILENAME) -> nx.DiGraph:
     """
     Load the graph from a file using the lazy json backend.
-    If a non-existing or empty file is encountered, a FileNotFoundError is raised.
-    If you expect the graph to possibly not exist, use load_graph.
+    If the file does not exist, it is initialized with empty JSON before performing any reads.
+    If empty JSON is encountered, a ValueError is raised.
+    If you expect the graph to be possibly empty JSON (i.e. not initialized), use load_graph.
 
     :return: the graph
+    :raises ValueError if the file contains empty JSON (or did not exist before)
     """
     gx = load_graph(filename)
     if gx is None:
-        raise FileNotFoundError(f"Graph file {filename} does not exist or is empty")
+        raise ValueError(f"Graph file {filename} contains empty JSON")
     return gx
 
 
 def load_graph(filename: str = DEFAULT_GRAPH_FILENAME) -> Optional[nx.DiGraph]:
     """
     Load the graph from a file using the lazy json backend.
-    If you expect the graph to exist, use load_existing_graph.
+    If the file does not exist, it is initialized with empty JSON.
+    If you expect the graph to be non-empty JSON, use load_existing_graph.
 
-    :return: the graph, or None if the file does not exist or is empty JSON
+    :return: the graph, or None if the file is empty JSON (or
+    :raises FileNotFoundError if the file does not exist
     """
     dta = copy.deepcopy(LazyJson(filename).data)
     if dta:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,7 +71,6 @@ def test_invalid_job(command: str, job: int, n_jobs: int):
 
 
 takes_context_commands = (
-    "gather-all-feedstocks",
     "make-graph",
     "update-upstream-versions",
     "auto-tick",

--- a/tests/test_lazy_json_backends.py
+++ b/tests/test_lazy_json_backends.py
@@ -550,3 +550,35 @@ class TestGithubLazyJsonBackend:
         mock_head.assert_called_once_with(
             f"{TestGithubLazyJsonBackend.base_url}/name/key.json",
         )
+
+    def test_hkeys(self, backend: GithubLazyJsonBackend) -> None:
+        assert backend.hkeys("name") == []
+
+    def test_hgetall(self, backend: GithubLazyJsonBackend) -> None:
+        assert backend.hgetall("name") == {}
+
+    @mock.patch("requests.get")
+    def test_hget_success(
+        self,
+        mock_get: MagicMock,
+        backend: GithubLazyJsonBackend,
+    ) -> None:
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.text = "{'key': 'value'}"
+        assert backend.hget("name", "key") == "{'key': 'value'}"
+        mock_get.assert_called_once_with(
+            f"{TestGithubLazyJsonBackend.base_url}/name/4/4/0/9/d/key.json",
+        )
+
+    @mock.patch("requests.get")
+    def test_hget_not_found(
+        self,
+        mock_get: MagicMock,
+        backend: GithubLazyJsonBackend,
+    ) -> None:
+        mock_get.return_value.status_code = 404
+        with pytest.raises(KeyError):
+            backend.hget("name", "key")
+        mock_get.assert_called_once_with(
+            f"{TestGithubLazyJsonBackend.base_url}/name/4/4/0/9/d/key.json",
+        )

--- a/tests/test_lazy_json_backends.py
+++ b/tests/test_lazy_json_backends.py
@@ -590,8 +590,8 @@ def test_github_hmset(caplog) -> None:
 
 
 def test_github_hset(caplog) -> None:
-    caplog.set_level(logging.DEBUG)
     backend = GithubLazyJsonBackend()
+    caplog.set_level(logging.DEBUG)
     backend.hset("name", "key", "value")
 
     assert "Write operations to the GitHub online backend are ignored." in caplog.text

--- a/tests/test_lazy_json_backends.py
+++ b/tests/test_lazy_json_backends.py
@@ -549,11 +549,13 @@ def test_github_online_hexists_failure(name: str, key: str) -> None:
 
 
 def test_github_hkeys() -> None:
-    assert GithubLazyJsonBackend().hkeys("name") == []
+    with pytest.raises(NotImplementedError):
+        assert GithubLazyJsonBackend().hkeys("name") == []
 
 
 def test_github_hgetall() -> None:
-    assert GithubLazyJsonBackend().hgetall("name") == {}
+    with pytest.raises(NotImplementedError):
+        GithubLazyJsonBackend().hgetall("name")
 
 
 @mock.patch("requests.get")

--- a/tests/test_lazy_json_backends.py
+++ b/tests/test_lazy_json_backends.py
@@ -590,8 +590,8 @@ def test_github_hmset(caplog) -> None:
 
 
 def test_github_hset(caplog) -> None:
-    backend = GithubLazyJsonBackend()
     caplog.set_level(logging.DEBUG)
+    backend = GithubLazyJsonBackend()
     backend.hset("name", "key", "value")
 
     assert "Write operations to the GitHub online backend are ignored." in caplog.text

--- a/tests/test_lazy_json_backends.py
+++ b/tests/test_lazy_json_backends.py
@@ -557,7 +557,16 @@ def test_github_hexists_unexpected_status_code(request_mock: MagicMock) -> None:
         GithubLazyJsonBackend().hexists("name", "key")
 
 
-def test_github_hdel(caplog) -> None:
+@pytest.fixture
+def reset_github_backend():
+    # In the future, the program architecture should be changed such that backend instances are shared, instead of
+    # instantiating each backend multiple times (whenever it is needed). Then, this can be moved into instance
+    # variables that don't need to be reset.
+    GithubLazyJsonBackend._write_warned = False
+    GithubLazyJsonBackend._n_requests = 0
+
+
+def test_github_hdel(caplog, reset_github_backend) -> None:
     caplog.set_level(logging.DEBUG)
     backend = GithubLazyJsonBackend()
     backend.hdel("name", ["key1", "key2"])
@@ -573,7 +582,7 @@ def test_github_hdel(caplog) -> None:
     )
 
 
-def test_github_hmset(caplog) -> None:
+def test_github_hmset(caplog, reset_github_backend) -> None:
     caplog.set_level(logging.DEBUG)
     backend = GithubLazyJsonBackend()
     backend.hmset("name", {"a": "b"})
@@ -589,7 +598,7 @@ def test_github_hmset(caplog) -> None:
     )
 
 
-def test_github_hset(caplog) -> None:
+def test_github_hset(caplog, reset_github_backend) -> None:
     caplog.set_level(logging.DEBUG)
     backend = GithubLazyJsonBackend()
     backend.hset("name", "key", "value")
@@ -605,7 +614,7 @@ def test_github_hset(caplog) -> None:
     )
 
 
-def test_github_write_mix(caplog) -> None:
+def test_github_write_mix(caplog, reset_github_backend) -> None:
     caplog.set_level(logging.DEBUG)
     backend = GithubLazyJsonBackend()
 

--- a/tests/test_upstream_versions.py
+++ b/tests/test_upstream_versions.py
@@ -1590,7 +1590,7 @@ def test_update_upstream_versions_process_pool_exception_repr_exception(
 
 @pytest.mark.parametrize("debug", [True, False])
 @mock.patch("os.makedirs")
-@mock.patch("conda_forge_tick.update_upstream_versions.load_graph")
+@mock.patch("conda_forge_tick.update_upstream_versions.load_existing_graph")
 @mock.patch("conda_forge_tick.update_upstream_versions.update_upstream_versions")
 def test_main(
     update_upstream_versions_mock: MagicMock,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,52 @@
-from conda_forge_tick.utils import get_keys_default
+from unittest import mock
+from unittest.mock import MagicMock, mock_open
+
+import pytest
+
+from conda_forge_tick.utils import (
+    DEFAULT_GRAPH_FILENAME,
+    get_keys_default,
+    load_existing_graph,
+    load_graph,
+)
+
+EMPTY_JSON = "{}"
+DEMO_GRAPH = """
+{
+    "directed": true,
+    "graph": {
+        "outputs_lut": {
+            "package1": {
+                "__set__": true,
+                "elements": [
+                    "package1"
+                ]
+            },
+            "package2": {
+                "__set__": true,
+                "elements": [
+                    "package2"
+                ]
+            }
+        }
+    },
+    "links": [
+        {
+            "source": "package1",
+            "target": "package2"
+        }
+    ],
+    "multigraph": false,
+    "nodes": [
+        {
+            "id": "package1",
+            "payload": {
+                "__lazy_json__": "node_attrs/package1.json"
+            }
+        }
+    ]
+}
+"""
 
 
 def test_get_keys_default():
@@ -25,9 +73,76 @@ def test_get_keys_default_none():
             "bot": None,
         },
     }
-    get_keys_default(
-        attrs,
-        ["conda-forge.yml", "bot", "check_solvable"],
-        {},
-        False,
-    ) is False
+    assert (
+        get_keys_default(
+            attrs,
+            ["conda-forge.yml", "bot", "check_solvable"],
+            {},
+            False,
+        )
+        is False
+    )
+
+
+def test_load_graph():
+    with mock.patch("builtins.open", mock_open(read_data=DEMO_GRAPH)) as mock_file:
+        gx = load_graph()
+
+        assert gx is not None
+
+        assert gx.nodes.keys() == {"package1", "package2"}
+
+    mock_file: MagicMock
+    mock_file.assert_has_calls([mock.call(DEFAULT_GRAPH_FILENAME)])
+
+
+def test_load_graph_empty_graph():
+    with mock.patch("builtins.open", mock_open(read_data=EMPTY_JSON)) as mock_file:
+        gx = load_graph()
+
+        assert gx is None
+
+    mock_file: MagicMock
+    mock_file.assert_has_calls([mock.call(DEFAULT_GRAPH_FILENAME)])
+
+
+@mock.patch("os.path.exists")
+def test_load_graph_file_does_not_exist(exists_mock: MagicMock):
+    exists_mock.return_value = False
+
+    with mock.patch("builtins.open", mock_open(read_data=EMPTY_JSON)) as mock_file:
+        load_graph()
+
+    mock_file: MagicMock
+    mock_file.assert_has_calls([mock.call(DEFAULT_GRAPH_FILENAME, "w")])
+
+
+def test_load_existing_graph():
+    with mock.patch("builtins.open", mock_open(read_data=DEMO_GRAPH)) as mock_file:
+        gx = load_existing_graph()
+
+        assert gx.nodes.keys() == {"package1", "package2"}
+
+    mock_file: MagicMock
+    mock_file.assert_has_calls([mock.call(DEFAULT_GRAPH_FILENAME)])
+
+
+def test_load_existing_graph_empty_graph():
+    with mock.patch("builtins.open", mock_open(read_data=EMPTY_JSON)) as mock_file:
+        with pytest.raises(ValueError, match="empty JSON"):
+            load_existing_graph()
+
+    mock_file: MagicMock
+    mock_file.assert_has_calls([mock.call(DEFAULT_GRAPH_FILENAME)])
+
+
+@mock.patch("os.path.exists")
+def test_load_existing_graph_file_does_not_exist(exists_mock: MagicMock):
+    exists_mock.return_value = False
+
+    with mock.patch("builtins.open", mock_open(read_data=EMPTY_JSON)) as mock_file:
+        with pytest.raises(ValueError, match="empty JSON"):
+            load_existing_graph()
+
+    mock_file: MagicMock
+    mock_file.assert_has_calls([mock.call(DEFAULT_GRAPH_FILENAME, "w")])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -92,7 +92,6 @@ def test_load_graph():
 
         assert gx.nodes.keys() == {"package1", "package2"}
 
-    mock_file: MagicMock
     mock_file.assert_has_calls([mock.call(DEFAULT_GRAPH_FILENAME)])
 
 
@@ -102,7 +101,6 @@ def test_load_graph_empty_graph():
 
         assert gx is None
 
-    mock_file: MagicMock
     mock_file.assert_has_calls([mock.call(DEFAULT_GRAPH_FILENAME)])
 
 
@@ -113,7 +111,6 @@ def test_load_graph_file_does_not_exist(exists_mock: MagicMock):
     with mock.patch("builtins.open", mock_open(read_data=EMPTY_JSON)) as mock_file:
         load_graph()
 
-    mock_file: MagicMock
     mock_file.assert_has_calls([mock.call(DEFAULT_GRAPH_FILENAME, "w")])
 
 
@@ -123,7 +120,6 @@ def test_load_existing_graph():
 
         assert gx.nodes.keys() == {"package1", "package2"}
 
-    mock_file: MagicMock
     mock_file.assert_has_calls([mock.call(DEFAULT_GRAPH_FILENAME)])
 
 
@@ -132,7 +128,6 @@ def test_load_existing_graph_empty_graph():
         with pytest.raises(ValueError, match="empty JSON"):
             load_existing_graph()
 
-    mock_file: MagicMock
     mock_file.assert_has_calls([mock.call(DEFAULT_GRAPH_FILENAME)])
 
 
@@ -144,5 +139,4 @@ def test_load_existing_graph_file_does_not_exist(exists_mock: MagicMock):
         with pytest.raises(ValueError, match="empty JSON"):
             load_existing_graph()
 
-    mock_file: MagicMock
     mock_file.assert_has_calls([mock.call(DEFAULT_GRAPH_FILENAME, "w")])


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is an extension of #2139. #2139 should be reviewed and merged first.

As part of my work on #2123, this PR adds the following changes:
- The logger config is now handled centrally in `setup_logging` instead of configuring each module-level logger individually
- Add an `--online` CLI option that downloads missing dependency graph files from GitHub on demand (uses the new GithubLazyJsonBackend)
- Added tests