### PR TITLE
remove `add-trailing-comma` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,10 +23,6 @@ repos:
       - id: pyupgrade
         args:
           - --py36-plus
-  - repo: https://github.com/asottile/add-trailing-comma
-    rev: v2.2.0
-    hooks:
-      - id: add-trailing-comma
   - repo: https://github.com/codespell-project/codespell
     rev: v2.1.0
     hooks:


### PR DESCRIPTION
Produces false negatives for strings, and should not be necessary, because black already takes care of trailing commas.