### PR TITLE
Support Updating Single Package, Refactoring update_upstream_versions

### DIFF
--- a/conda_forge_tick/cli.py
+++ b/conda_forge_tick/cli.py
@@ -1,5 +1,6 @@
 import os
 import time
+from typing import Optional
 
 import click
 from click import IntRange
@@ -73,13 +74,24 @@ def make_graph(ctx: CliContext) -> None:
 @main.command(name="update-upstream-versions")
 @job_option
 @n_jobs_option
+@click.argument(
+    "package",
+    required=False,
+)
 @pass_context
-def update_upstream_versions(ctx: CliContext, job: int, n_jobs: int) -> None:
+def update_upstream_versions(
+    ctx: CliContext, job: int, n_jobs: int, package: Optional[str]
+) -> None:
+    """
+    Update the upstream versions of feedstocks in the graph.
+
+    If PACKAGE is given, only update that package, otherwise update all packages.
+    """
     from . import update_upstream_versions
 
     check_job_param_relative(job, n_jobs)
 
-    update_upstream_versions.main(ctx, job=job, n_jobs=n_jobs)
+    update_upstream_versions.main(ctx, job=job, n_jobs=n_jobs, package=package)
 
 
 @main.command(name="auto-tick")

--- a/conda_forge_tick/update_prs.py
+++ b/conda_forge_tick/update_prs.py
@@ -23,10 +23,6 @@ from .utils import github_client, load_graph, setup_logger
 
 # from conda_forge_tick.profiler import profiling
 
-
-if typing.TYPE_CHECKING:
-    from .cli import CLIArgs
-
 logger = logging.getLogger("conda_forge_tick.update_prs")
 
 NUM_GITHUB_THREADS = 2

--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -351,7 +351,7 @@ def update_upstream_versions(
 
     payload_extracted = map(extract_payload, job_nodes)
 
-    to_update = list(
+    to_update: List[Tuple[str, Mapping]] = list(
         filter(
             lambda node: include_node(node[0], node[1]),
             payload_extracted,

--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -35,7 +35,7 @@ from .update_sources import (
     RawURL,
     ROSDistro,
 )
-from .utils import get_keys_default, load_graph
+from .utils import get_keys_default, load_graph, setup_logger
 
 T = TypeVar("T")
 
@@ -393,6 +393,11 @@ def main(
     :param n_jobs: The total number of jobs.
     :param package: The package to update. If None, update all packages.
     """
+    if ctx.debug:
+        setup_logger(logger, level="debug")
+    else:
+        setup_logger(logger)
+
     logger.info("Reading graph")
     # Graph enabled for inspection
     gx = load_graph()

--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -4,7 +4,18 @@ import os
 import random
 import time
 from concurrent.futures import as_completed
-from typing import Any, Iterable
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    Literal,
+    Mapping,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 import networkx as nx
 import tqdm
@@ -24,37 +35,50 @@ from .update_sources import (
     RawURL,
     ROSDistro,
 )
-from .utils import get_keys_default, load_graph, setup_logger
+from .utils import get_keys_default, load_graph
+
+T = TypeVar("T")
 
 # conda_forge_tick :: cft
-logger = logging.getLogger("conda_forge_tick.update_upstream_versions")
+logger = logging.getLogger(__name__)
 
 
-def _filter_ignored_versions(attrs, version):
+def ignore_version(attrs: Mapping[str, Any], version: str) -> bool:
+    """
+    Check if a version should be ignored based on the `conda-forge.yml` file.
+    :param attrs: The node attributes
+    :param version: The version to check
+    :return: True if the version should be ignored, False otherwise
+    """
     versions_to_ignore = get_keys_default(
         attrs,
         ["conda-forge.yml", "bot", "version_updates", "exclude"],
         {},
         [],
     )
-    if (
-        str(version).replace("-", ".") in versions_to_ignore
-        or str(version) in versions_to_ignore
-    ):
-        return False
-    else:
-        return version
+    return (
+        version.replace("-", ".") in versions_to_ignore or version in versions_to_ignore
+    )
 
 
 def get_latest_version(
     name: str,
-    attrs: Any,
+    attrs: Mapping[str, Any],
     sources: Iterable[AbstractSource],
-) -> dict:
-    version_data = {"new_version": False}
+) -> Dict[str, Union[bool, str]]:
+    """
+    Given a package, return the new version information to be written into the cf-graph.
+    :param name: the name of the package.
+    :param attrs: the node attributes of the package
+    :param sources: the version sources to use (sources can be excluded by the package but not added)
+    """
+    version_data: Dict[str, Union[Literal[False], str]] = {"new_version": False}
 
-    # avoid this one since it runs too long and hangs the bot
     if name == "ca-policy-lcg":
+        logger.warning(
+            "ca-policy-lcg is manually excluded from automatic version updates because it runs too long "
+            "and hangs the bot",
+        )
         return version_data
 
     version_sources = get_keys_default(
@@ -71,82 +95,124 @@ def get_latest_version(
                 if source.name.lower() == vs:
                     sources_to_use.append(source)
 
-        for source in sources:
-            if source not in sources_to_use:
-                logger.debug("skipped source: %s", source.name)
+        logger.debug(
+            f"{name} defines the following custom version sources: {[source.name for source in sources_to_use]}",
+        )
+        skipped_sources = [
+            source.name for source in sources if source not in sources_to_use
+        ]
+        if skipped_sources:
+            logger.debug(f"Therefore, we skip the following sources: {skipped_sources}")
+        else:
+            logger.debug("No sources are skipped.")
+
     else:
         sources_to_use = sources
 
-    excs = []
+    exceptions = []
     for source in sources_to_use:
         try:
-            logger.debug("source: %s", source.name)
+            logger.debug(f"Fetching latest version for {name} from {source.name}...")
             url = source.get_url(attrs)
-            logger.debug("url: %s", url)
             if url is None:
                 continue
+            logger.debug(f"Using URL {url}")
             ver = source.get_version(url)
-            logger.debug("ver: %s", ver)
-            if ver:
-                version_data["new_version"] = ver
-                break
-            else:
+            if not ver:
                 logger.debug(f"Upstream: Could not find version on {source.name}")
+                continue
+            logger.debug(f"Found version {ver} on {source.name}")
+            version_data["new_version"] = ver
+            break
         except Exception as e:
-            excs.append(e)
+            logger.error(
+                f"An exception occurred while fetching {name} from {source.name}: {e}",
+            )
+            exceptions.append(e)
 
-    if version_data["new_version"] is False and len(excs) > 0:
-        raise excs[0]
+    new_version = version_data["new_version"]
 
-    if version_data["new_version"]:
-        version_data["new_version"] = _filter_ignored_versions(
-            attrs,
-            version_data["new_version"],
+    if not new_version and exceptions:
+        logger.error(
+            "Cannot find version on any source, exceptions occurred. Raising the first exception.",
         )
+        raise exceptions[0]
+
+    if not new_version:
+        logger.debug(f"Upstream: Could not find version on any source")
+        return version_data
+
+    if ignore_version(attrs, new_version):
+        logger.debug(
+            f"Ignoring version {new_version} because it is in the exclude list.",
+        )
+        version_data["new_version"] = False
 
     return version_data
 
 
-def _filter_nodes_for_job(_all_nodes, job, n_jobs):
-    job_index = job - 1
-    return [
-        t
-        for t in _all_nodes
-        if abs(int(hashlib.sha1(t[0].encode("utf-8")).hexdigest(), 16)) % n_jobs
-        == job_index
-    ]
+def get_job_number_for_package(name: str, n_jobs: int):
+    return abs(int(hashlib.sha1(name.encode("utf-8")).hexdigest(), 16)) % n_jobs + 1
+
+
+def filter_nodes_for_job(
+    all_nodes: Iterable[Tuple[str, T]],
+    job: int,
+    n_jobs: int,
+) -> Iterator[Tuple[str, T]]:
+    return (t for t in all_nodes if get_job_number_for_package(t[0], n_jobs) == job)
+
+
+def include_node(package_name: str, payload_attrs: Mapping) -> bool:
+    """
+    Given a package name and its node attributes, determine whether
+    the package should be included in the update process.
+
+    Also log the reason why a package is not included.
+
+    :param package_name: The name of the package
+    :param payload_attrs: The cf-graph node payload attributes for the package
+    :return: True if the package should be included, False otherwise
+    """
+    pr_info = payload_attrs.get("pr_info", {})
+
+    if payload_attrs.get("parsing_error"):
+        logger.debug(
+            f"Skipping {package_name} because it is marked as having a parsing error. The error is printed below.\n"
+            f"{payload_attrs['parsing_error']}",
+        )
+        return False
+
+    if payload_attrs.get("archived"):
+        logger.debug(
+            f"Skipping {package_name} because it is marked as archived.",
+        )
+        return False
+
+    if pr_info.get("bad") and "Upstream" not in pr_info.get("bad"):
+        logger.debug(
+            f"Skipping {package_name} because its corresponding Pull Request is "
+            f"marked as bad with a non-upstream issue. The error is printed below.\n"
+            f"{pr_info['bad']}",
+        )
+        return False
+
+    if pr_info.get("bad"):
+        logger.debug(
+            f"Note: {package_name} has a bad Pull Request, but this is marked as an upstream issue. "
+            f"Therefore, it will be included in the update process. The error is printed below.\n"
+            f"{pr_info['bad']}",
+        )
+        # no return here
+
+    return True
 
 
 def _update_upstream_versions_sequential(
-    gx: nx.DiGraph,
+    to_update: Iterable[Tuple[str, Mapping]],
     sources: Iterable[AbstractSource] = None,
-    job=1,
-    n_jobs=1,
 ) -> None:
-
-    _all_nodes = [t for t in gx.nodes.items()]
-    _all_nodes = _filter_nodes_for_job(
-        _all_nodes,
-        job,
-        n_jobs,
-    )
-    random.shuffle(_all_nodes)
-
-    # Inspection the graph object and node update:
-    # print(f"Number of nodes: {len(gx.nodes)}")
     node_count = 0
-    to_update = []
-    for node, node_attrs in _all_nodes:
-        attrs = node_attrs["payload"]
-        pri = attrs.get("pr_info", {})
-        if (
-            attrs.get("parsing_error", False)
-            or (pri.get("bad") and "Upstream" not in pri.get("bad"))
-            or attrs.get("archived")
-        ):
-            continue
-        to_update.append((node, attrs))
-
     for node, attrs in to_update:
         # checking each node
         version_data = {}
@@ -169,45 +235,26 @@ def _update_upstream_versions_sequential(
             )
 
         logger.debug("writing out file")
-        lzj = LazyJson(f"versions/{node}.json")
-        with lzj as attrs:
-            attrs.clear()
-            attrs.update(version_data)
+        lazyjson = LazyJson(f"versions/{node}.json")
+        with lazyjson as version_attrs:
+            version_attrs.clear()
+            version_attrs.update(version_data)
         node_count += 1
 
 
 def _update_upstream_versions_process_pool(
-    gx: nx.DiGraph,
+    to_update: Iterable[Tuple[str, Mapping]],
     sources: Iterable[AbstractSource],
-    job=1,
-    n_jobs=1,
 ) -> None:
     futures = {}
     # this has to be threads because the url hashing code uses a Pipe which
     # cannot be spawned from a process
     with executor(kind="dask", max_workers=5) as pool:
-        _all_nodes = [t for t in gx.nodes.items()]
-        _all_nodes = _filter_nodes_for_job(
-            _all_nodes,
-            job,
-            n_jobs,
-        )
-        random.shuffle(_all_nodes)
-
-        for node, node_attrs in tqdm.tqdm(
-            _all_nodes,
+        for node, attrs in tqdm.tqdm(
+            to_update,
             ncols=80,
             desc="submitting version update jobs",
         ):
-            attrs = node_attrs["payload"]
-            pri = attrs.get("pr_info", {})
-            if (
-                attrs.get("parsing_error", False)
-                or (pri.get("bad") and "Upstream" not in pri.get("bad"))
-                or attrs.get("archived")
-            ):
-                continue
-
             futures.update(
                 {
                     pool.submit(get_latest_version, node, attrs, sources): (
@@ -223,7 +270,6 @@ def _update_upstream_versions_process_pool(
         # eta :: elapsed time average
         eta = -1
         for f in as_completed(futures):
-
             n_left -= 1
             if n_left % 10 == 0:
                 eta = (time.time() - start) / (n_tot - n_left) * n_left
@@ -256,10 +302,10 @@ def _update_upstream_versions_process_pool(
                     ),
                 )
             # writing out file
-            lzj = LazyJson(f"versions/{node}.json")
-            with lzj as attrs:
-                attrs.clear()
-                attrs.update(version_data)
+            lazyjson = LazyJson(f"versions/{node}.json")
+            with lazyjson as version_attrs:
+                version_attrs.clear()
+                version_attrs.update(version_data)
 
 
 def update_upstream_versions(
@@ -268,7 +314,47 @@ def update_upstream_versions(
     debug: bool = False,
     job=1,
     n_jobs=1,
+    package: Optional[str] = None,
 ) -> None:
+    """
+    Update the upstream versions of packages.
+    :param gx: The conda forge graph
+    :param sources: The sources to use for fetching the upstream versions
+    :param debug: Whether to run in debug mode
+    :param job: The job number
+    :param n_jobs: The total number of jobs
+    :param package: The package to update. If None, update all packages.
+    """
+    if package and package not in gx.nodes:
+        logger.error(f"Package {package} not found in graph. Exiting.")
+        return
+
+    # In the future, we should have some sort of typed graph structure
+    all_nodes: Iterable[Tuple[str, Mapping[str, Mapping]]] = (
+        [(package, gx.nodes.get(package))] if package else gx.nodes.items()
+    )
+
+    job_nodes = filter_nodes_for_job(all_nodes, job, n_jobs)
+
+    if not job_nodes:
+        logger.info(f"No packages to update for job {job}")
+        return
+
+    def extract_payload(node: Tuple[str, Mapping[str, Mapping]]) -> Tuple[str, Mapping]:
+        name, attrs = node
+        return name, attrs["payload"]
+
+    payload_extracted = map(extract_payload, job_nodes)
+
+    to_update = list(
+        filter(
+            lambda node: include_node(node[0], node[1]),
+            payload_extracted,
+        ),
+    )
+
+    random.shuffle(to_update)
+
     sources = (
         (
             PyPI(),
@@ -283,21 +369,30 @@ def update_upstream_versions(
         if sources is None
         else sources
     )
+
     updater = (
         _update_upstream_versions_sequential
-        if debug
+        if debug or package
         else _update_upstream_versions_process_pool
     )
+
     logger.info("Updating upstream versions")
-    updater(gx, sources, job=job, n_jobs=n_jobs)
+    updater(to_update, sources)
 
 
-def main(ctx: CliContext, job: int = 1, n_jobs: int = 1) -> None:
-    if ctx.debug:
-        setup_logger(logger, level="debug")
-    else:
-        setup_logger(logger)
-
+def main(
+    ctx: CliContext,
+    job: int = 1,
+    n_jobs: int = 1,
+    package: Optional[str] = None,
+) -> None:
+    """
+    Main function for updating the upstream versions of packages.
+    :param ctx: The CLI context.
+    :param job: The job number.
+    :param n_jobs: The total number of jobs.
+    :param package: The package to update. If None, update all packages.
+    """
     logger.info("Reading graph")
     # Graph enabled for inspection
     gx = load_graph()
@@ -305,4 +400,10 @@ def main(ctx: CliContext, job: int = 1, n_jobs: int = 1) -> None:
     # Check if 'versions' folder exists or create a new one;
     os.makedirs("versions", exist_ok=True)
     # call update
-    update_upstream_versions(gx, debug=ctx.debug, job=job, n_jobs=n_jobs)
+    update_upstream_versions(
+        gx,
+        debug=ctx.debug,
+        job=job,
+        n_jobs=n_jobs,
+        package=package,
+    )

--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -94,6 +94,11 @@ def get_latest_version(
             for source in sources:
                 if source.name.lower() == vs:
                     sources_to_use.append(source)
+                    break
+            else:
+                logger.warning(
+                    f"Package {name} requests version source '{vs}' which is not available. Skipping.",
+                )
 
         logger.debug(
             f"{name} defines the following custom version sources: {[source.name for source in sources_to_use]}",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,10 @@
+from unittest import mock
+
 import pytest
 from click.testing import CliRunner
 
 from conda_forge_tick.cli import main
+from conda_forge_tick.cli_context import CliContext
 
 commands = (
     "auto-tick",
@@ -64,3 +67,70 @@ def test_invalid_job(command: str, job: int, n_jobs: int):
     result = runner.invoke(main, [command, f"--job={job}", f"--n-jobs={n_jobs}"])
     assert result.exit_code == 2
     assert "in the range" in result.output
+
+
+takes_context_commands = (
+    "gather-all-feedstocks",
+    "make-graph",
+    "update-upstream-versions",
+    "auto-tick",
+    "update-prs",
+    "deploy-to-github",
+    "backup-lazy-json",
+    "sync-lazy-json-across-backends",
+    "cache-lazy-json-to-disk",
+)
+
+
+@pytest.mark.parametrize("debug", [True, False])
+@pytest.mark.parametrize("dry_run", [True, False])
+@pytest.mark.parametrize(
+    "command, patch_function",
+    [
+        ("gather-all-feedstocks", "conda_forge_tick.all_feedstocks.main"),
+        ("make-graph", "conda_forge_tick.make_graph.main"),
+        (
+            "update-upstream-versions",
+            "conda_forge_tick.update_upstream_versions.main",
+        ),
+        ("auto-tick", "conda_forge_tick.auto_tick.main"),
+        ("make-status-report", "conda_forge_tick.status_report.main"),
+        ("update-prs", "conda_forge_tick.update_prs.main"),
+        ("make-mappings", "conda_forge_tick.mappings.main"),
+        ("deploy-to-github", "conda_forge_tick.deploy.deploy"),
+        ("backup-lazy-json", "conda_forge_tick.lazy_json_backups.main_backup"),
+        (
+            "sync-lazy-json-across-backends",
+            "conda_forge_tick.lazy_json_backends.main_sync",
+        ),
+        (
+            "cache-lazy-json-to-disk",
+            "conda_forge_tick.lazy_json_backends.main_cache",
+        ),
+    ],
+)
+def test_cli_mock_commands_pass_context(
+    debug: bool,
+    dry_run: bool,
+    command: str,
+    patch_function: str,
+):
+    runner = CliRunner()
+    debug_flag = "--debug" if debug else "--no-debug"
+    dry_run_flag = "--dry-run" if dry_run else "--no-dry-run"
+
+    with mock.patch(patch_function) as cmd_mock:
+        result = runner.invoke(main, [debug_flag, dry_run_flag, command])
+        assert result.exit_code == 0
+        cmd_mock.assert_called_once()
+
+        if command not in takes_context_commands:
+            for arg in cmd_mock.call_args.args:
+                assert not isinstance(arg, CliContext)
+            for kwarg in cmd_mock.call_args.kwargs.values():
+                assert not isinstance(kwarg, CliContext)
+            return
+
+        command_context: CliContext = cmd_mock.call_args.args[0]
+        assert command_context.debug is debug
+        assert command_context.dry_run is dry_run

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from unittest.mock import MagicMock
 
 import pytest
 from click.testing import CliRunner
@@ -134,3 +135,29 @@ def test_cli_mock_commands_pass_context(
         command_context: CliContext = cmd_mock.call_args.args[0]
         assert command_context.debug is debug
         assert command_context.dry_run is dry_run
+
+
+@pytest.mark.parametrize("job, n_jobs", [(1, 5), (3, 7), (4, 4)])
+@pytest.mark.parametrize("package", ["foo", "bar", "baz"])
+@mock.patch("conda_forge_tick.update_upstream_versions.main")
+def test_cli_mock_update_upstream_versions(
+    cmd_mock: MagicMock, job: int, n_jobs: int, package: str
+):
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["update-upstream-versions", f"--job={job}", f"--n-jobs={n_jobs}", package],
+    )
+
+    assert result.exit_code == 0
+    cmd_mock.assert_called_once_with(mock.ANY, job=job, n_jobs=n_jobs, package=package)
+
+
+@pytest.mark.parametrize("job, n_jobs", [(1, 5), (3, 7), (4, 4)])
+@mock.patch("conda_forge_tick.update_prs.main")
+def test_cli_mock_update_prs(cmd_mock: MagicMock, job: int, n_jobs: int):
+    runner = CliRunner()
+    result = runner.invoke(main, ["update-prs", f"--job={job}", f"--n-jobs={n_jobs}"])
+
+    assert result.exit_code == 0
+    cmd_mock.assert_called_once_with(mock.ANY, job=job, n_jobs=n_jobs)

--- a/tests/test_upstream_versions.py
+++ b/tests/test_upstream_versions.py
@@ -557,6 +557,25 @@ def test_latest_version_error_and_no_new_version(caplog):
     assert "Cannot find version on any source, exceptions occurred" in caplog.text
 
 
+def test_latest_version_ignore_version(caplog):
+    caplog.set_level(logging.DEBUG)
+
+    source_a = Mock(AbstractSource)
+    source_a.name = "source a"
+    source_a.get_url.return_value = "https://source-a.com"
+    source_a.get_version.return_value = "1.2.3"
+
+    with patch(
+        "conda_forge_tick.update_upstream_versions.ignore_version", return_value=True
+    ):
+        result = get_latest_version("crazy-package", {}, [source_a])
+
+    assert "Using URL https://source-a.com" in caplog.text
+    assert "Ignoring version 1.2.3" in caplog.text
+
+    assert result == {"new_version": False}
+
+
 @pytest.mark.parametrize(
     "in_ver, ver_test",
     [

--- a/tests/test_upstream_versions.py
+++ b/tests/test_upstream_versions.py
@@ -2,7 +2,7 @@ import logging
 import os
 import random
 from concurrent.futures import Future
-from typing import Mapping
+from typing import Dict, Mapping
 from unittest import mock
 from unittest.mock import MagicMock, Mock, patch
 
@@ -1145,7 +1145,7 @@ def test_include_node_parsing_error(caplog):
 
 def test_include_node_no_payload():
     package_name = "testpackage"
-    payload_attrs = {}
+    payload_attrs: Dict = {}
 
     assert include_node(package_name, payload_attrs)
 
@@ -1467,8 +1467,8 @@ def test_update_upstream_versions_process_pool(
         ("testpackage2", {"version": "1.2.4"}),
     ]
 
-    future_1 = Future()
-    future_2 = Future()
+    future_1: Future[Dict[str, str]] = Future()
+    future_2: Future[Dict[str, str]] = Future()
 
     pool_mock = executor_mock.return_value.__enter__.return_value
     pool_mock.submit.side_effect = [future_1, future_2]
@@ -1518,7 +1518,7 @@ def test_update_upstream_versions_process_pool_exception(
         ("testpackage", {"version": "2.2.3"}),
     ]
 
-    future = Future()
+    future: Future[Dict[str, str]] = Future()
 
     pool_mock = executor_mock.return_value.__enter__.return_value
     pool_mock.submit.return_value = future
@@ -1561,7 +1561,7 @@ def test_update_upstream_versions_process_pool_exception_repr_exception(
         ("testpackage", {"version": "2.2.3"}),
     ]
 
-    future = Future()
+    future: Future[Dict[str, str]] = Future()
 
     pool_mock = executor_mock.return_value.__enter__.return_value
     pool_mock.submit.return_value = future

--- a/tests/test_upstream_versions.py
+++ b/tests/test_upstream_versions.py
@@ -439,6 +439,12 @@ def test_latest_version_rawurl(name, inp, curr_ver, ver, source, urls, tmpdir):
         assert ver == attempt["new_version"]
 
 
+def test_latest_version_ca_policy_lcg(caplog):
+    assert get_latest_version("ca-policy-lcg", {}, [RawURL()]) == {"new_version": False}
+    assert "ca-policy-lcg" in caplog.text
+    assert "manually excluded" in caplog.text
+
+
 @pytest.mark.parametrize(
     "in_ver, ver_test",
     [

--- a/tests/test_upstream_versions.py
+++ b/tests/test_upstream_versions.py
@@ -576,6 +576,31 @@ def test_latest_version_ignore_version(caplog):
     assert result == {"new_version": False}
 
 
+def test_latest_version_no_sources_are_skipped(caplog):
+    caplog.set_level(logging.DEBUG)
+
+    source_a = Mock(AbstractSource)
+    source_a.name = "source a"
+    source_a.get_url.return_value = "https://source-a.com"
+    source_a.get_version.return_value = "1.2.3"
+
+    attrs = {
+        "conda-forge.yml": {
+            "bot": {
+                "version_updates": {
+                    "sources": ["source a"],
+                },
+            },
+        },
+    }
+
+    result = get_latest_version("crazy-package", attrs, [source_a])
+
+    assert "No sources are skipped" in caplog.text
+
+    assert result == {"new_version": "1.2.3"}
+
+
 @pytest.mark.parametrize(
     "in_ver, ver_test",
     [


### PR DESCRIPTION
This part of #2131 adds the functionality of updating one single package and refactors the `update_upstream_versions.py` code. It also adds helpful debug output and tests the entire refactored code.