### PR TITLE
FIx Typo In Test GitHub Actions Workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           conda install --file requirements-dev.txt --yes
           export GIT_FULL_HASH=`git rev-parse HEAD`
-          export CICLE_BUILD_URL="https://www.youtube.com/watch?v=R7qT-C-0ajI"
+          export CIRCLE_BUILD_URL="https://www.youtube.com/watch?v=R7qT-C-0ajI"
           pip install --no-deps --no-build-isolation -e .
 
       - name: conda info and env


### PR DESCRIPTION
Although in the current situation this error has no effect, the GitHub Actions workflow should not contain typos in environment variables.