### PR TITLE
Add static name mapping for lrcalc

### DIFF
--- a/conda_forge_tick/pypi_name_mapping_static.yaml
+++ b/conda_forge_tick/pypi_name_mapping_static.yaml
@@ -107,3 +107,7 @@
 - pypi_name: flit_core
   import_name: flit_core
   conda_name: flit-core
+
+- pypi_name: lrcalc
+  import_name: lrcalc
+  conda_name: python-lrcalc


### PR DESCRIPTION
`lrcalc` refers to the c library, while `python-lrcalc` is the python wrapper, see https://github.com/conda-forge/lrcalc-feedstock/blob/main/recipe/meta.yaml#L42C11-L42C24.

CC: @isuruf 