### PR TITLE
REF use local import to pkg mappings

### DIFF
--- a/conda_forge_tick/backend_settings.py
+++ b/conda_forge_tick/backend_settings.py
@@ -1,3 +1,0 @@
-GITHUB_GRAPH_BACKEND_BASE_URL = (
-    "https://github.com/regro/cf-graph-countyfair/raw/master"
-)

--- a/conda_forge_tick/depfinder_api.py
+++ b/conda_forge_tick/depfinder_api.py
@@ -33,40 +33,13 @@ from concurrent.futures._base import as_completed
 from concurrent.futures.thread import ThreadPoolExecutor
 from fnmatch import fnmatch
 
-import requests.exceptions
-from conda_forge_metadata.autotick_bot import map_import_to_package
-from conda_forge_metadata.libcfgraph import get_libcfgraph_pkgs_for_import
 from depfinder.inspection import iterate_over_library
 from depfinder.stdliblist import builtin_modules as _builtin_modules
 from depfinder.utils import SKETCHY_TYPES_TABLE
 
+from conda_forge_tick.import_to_pkg import extract_pkg_from_import
+
 logger = logging.getLogger(__name__)
-
-
-def extract_pkg_from_import(name):
-    """Provide the name of the package that matches with the import provided,
-    with the maps between the imports and artifacts and packages that matches
-
-    Parameters
-    ----------
-    name : str
-        The name of the import to be searched for
-
-    Returns
-    -------
-    most_likely_pkg : str
-        The most likely conda-forge package.
-    import_to_pkg : dict mapping str to sets
-        A dict mapping the import name to a set of possible packages that supply that import.
-    """
-    try:
-        supplying_pkgs, _ = get_libcfgraph_pkgs_for_import(name)
-        best_import = map_import_to_package(name)
-    except requests.exceptions.HTTPError:
-        supplying_pkgs = set()
-        best_import = name
-    import_to_pkg = {name: supplying_pkgs or set()}
-    return best_import, import_to_pkg
 
 
 def recursively_search_for_name(name, module_names):

--- a/conda_forge_tick/import_to_pkg.py
+++ b/conda_forge_tick/import_to_pkg.py
@@ -18,6 +18,7 @@ from tqdm import tqdm
 from conda_forge_tick.cli_context import CliContext
 from conda_forge_tick.lazy_json_backends import (
     CF_TICK_GRAPH_DATA_BACKENDS,
+    CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL,
     LazyJson,
     dump,
     get_sharded_path,
@@ -77,8 +78,10 @@ def _get_head_letters(name):
 @lru_cache(maxsize=1)
 def _ranked_hubs_authorities() -> list[str]:
     req = requests.get(
-        "https://raw.githubusercontent.com/regro/cf-graph-countyfair/"
-        "master/ranked_hubs_authorities.json"
+        os.path.join(
+            CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL,
+            "ranked_hubs_authorities.json",
+        )
     )
     req.raise_for_status()
     return req.json()
@@ -94,7 +97,10 @@ def _import_to_pkg_maps_cache(import_first_letters: str) -> dict[str, set[str]]:
             return load(f)
     else:
         req = requests.get(
-            "https://raw.githubusercontent.com/regro/cf-graph-countyfair/master/" + pth
+            os.path.join(
+                CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL,
+                pth,
+            )
         )
         req.raise_for_status()
         return {k: set(v["elements"]) for k, v in req.json().items()}

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -24,7 +24,6 @@ from typing import (
 import rapidjson as json
 import requests
 
-from .backend_settings import GITHUB_GRAPH_BACKEND_BASE_URL
 from .cli_context import CliContext
 
 logger = logging.getLogger(__name__)
@@ -41,6 +40,10 @@ CF_TICK_GRAPH_DATA_HASHMAPS = [
     "versions",
     "node_attrs",
 ]
+
+CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL = (
+    "https://github.com/regro/cf-graph-countyfair/raw/master"
+)
 
 
 def get_sharded_path(file_path, n_dirs=5):
@@ -191,7 +194,7 @@ class GithubLazyJsonBackend(LazyJsonBackend):
     _n_requests = 0
 
     def __init__(self) -> None:
-        self.base_url = GITHUB_GRAPH_BACKEND_BASE_URL
+        self.base_url = CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL
 
     @property
     def base_url(self) -> str:

--- a/conda_forge_tick/migrators/pip_wheel_dep.py
+++ b/conda_forge_tick/migrators/pip_wheel_dep.py
@@ -1,4 +1,5 @@
 import functools
+import os
 import tempfile
 import typing
 from typing import Any, Dict
@@ -6,6 +7,7 @@ from typing import Any, Dict
 import requests
 from ruamel.yaml import YAML
 
+from conda_forge_tick.lazy_json_backends import CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL
 from conda_forge_tick.migrators import MiniMigrator
 from conda_forge_tick.os_utils import pushd
 from conda_forge_tick.utils import get_keys_default
@@ -22,7 +24,12 @@ def pypi_conda_mapping() -> Dict[str, str]:
     """
     yaml = YAML()
     content = requests.get(
-        "https://raw.githubusercontent.com/regro/cf-graph-countyfair/master/mappings/pypi/grayskull_pypi_mapping.yaml",  # noqa
+        os.path.join(
+            CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL,
+            "mappings",
+            "pypi",
+            "grayskull_pypi_mapping.yaml",
+        )
     ).text
     mappings = yaml.load(content)
     return {

--- a/conda_forge_tick/pypi_name_mapping.py
+++ b/conda_forge_tick/pypi_name_mapping.py
@@ -8,6 +8,7 @@ Builds and maintains mapping of pypi-names to conda-forge names
 import functools
 import json
 import math
+import os
 import pathlib
 import traceback
 from collections import Counter, defaultdict
@@ -19,7 +20,13 @@ import yaml
 from packaging.utils import NormalizedName as PypiName
 from packaging.utils import canonicalize_name as canonicalize_pypi_name
 
-from .lazy_json_backends import LazyJson, dump, get_all_keys_for_hashmap, loads
+from .lazy_json_backends import (
+    CF_TICK_GRAPH_DATA_BACKENDS,
+    LazyJson,
+    dump,
+    get_all_keys_for_hashmap,
+    loads,
+)
 from .utils import as_iterable, load_existing_graph
 
 
@@ -302,12 +309,17 @@ def determine_best_matches_for_pypi_import(
     # TODO: filter out archived feedstocks?
 
     try:
-        clobberers = loads(
-            requests.get(
-                "https://raw.githubusercontent.com/regro/libcfgraph/master/"
-                "clobbering_pkgs.json",
-            ).text,
-        )
+        clobberers_pth = "import_to_pkg_maps/import_to_pkg_maps_clobbering_pkgs.json"
+        if "file" in CF_TICK_GRAPH_DATA_BACKENDS and os.path.exists(clobberers_pth):
+            with open(clobberers_pth) as fp:
+                clobberers = loads(fp.read())
+        else:
+            clobberers = loads(
+                requests.get(
+                    "https://raw.githubusercontent.com/regro/cf-graph-countyfair/master/"
+                    "import_to_pkg_maps/import_to_pkg_maps_clobbering_pkgs.json"
+                ).text,
+            )
     except Exception as e:
         print(e)
         clobberers = set()

--- a/conda_forge_tick/pypi_name_mapping.py
+++ b/conda_forge_tick/pypi_name_mapping.py
@@ -20,8 +20,10 @@ import yaml
 from packaging.utils import NormalizedName as PypiName
 from packaging.utils import canonicalize_name as canonicalize_pypi_name
 
+from .import_to_pkg import IMPORT_TO_PKG_DIR_CLOBBERING
 from .lazy_json_backends import (
     CF_TICK_GRAPH_DATA_BACKENDS,
+    CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL,
     LazyJson,
     dump,
     get_all_keys_for_hashmap,
@@ -309,15 +311,18 @@ def determine_best_matches_for_pypi_import(
     # TODO: filter out archived feedstocks?
 
     try:
-        clobberers_pth = "import_to_pkg_maps/import_to_pkg_maps_clobbering_pkgs.json"
-        if "file" in CF_TICK_GRAPH_DATA_BACKENDS and os.path.exists(clobberers_pth):
-            with open(clobberers_pth) as fp:
+        if "file" in CF_TICK_GRAPH_DATA_BACKENDS and os.path.exists(
+            IMPORT_TO_PKG_DIR_CLOBBERING
+        ):
+            with open(IMPORT_TO_PKG_DIR_CLOBBERING) as fp:
                 clobberers = loads(fp.read())
         else:
             clobberers = loads(
                 requests.get(
-                    "https://raw.githubusercontent.com/regro/cf-graph-countyfair/master/"
-                    "import_to_pkg_maps/import_to_pkg_maps_clobbering_pkgs.json"
+                    os.path.join(
+                        CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL,
+                        IMPORT_TO_PKG_DIR_CLOBBERING,
+                    )
                 ).text,
             )
     except Exception as e:

--- a/conda_forge_tick/update_deps.py
+++ b/conda_forge_tick/update_deps.py
@@ -11,6 +11,7 @@ from stdlib_list import stdlib_list
 
 from conda_forge_tick.depfinder_api import simple_import_to_pkg_map
 from conda_forge_tick.feedstock_parser import load_feedstock
+from conda_forge_tick.lazy_json_backends import CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL
 from conda_forge_tick.make_graph import COMPILER_STUBS_WITH_STRONG_EXPORTS
 from conda_forge_tick.os_utils import pushd
 from conda_forge_tick.pypi_name_mapping import _KNOWN_NAMESPACE_PACKAGES
@@ -65,7 +66,10 @@ STATIC_EXCLUDES = (
 RANKINGS = []
 for _ in range(10):
     r = requests.get(
-        "https://raw.githubusercontent.com/regro/cf-graph-countyfair/master/ranked_hubs_authorities.json",
+        os.path.join(
+            CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL,
+            "ranked_hubs_authorities.json",
+        )
     )
     if r.status_code == 200:
         RANKINGS = r.json()

--- a/tests/test_lazy_json_backends.py
+++ b/tests/test_lazy_json_backends.py
@@ -9,8 +9,8 @@ from unittest.mock import MagicMock
 import pytest
 
 import conda_forge_tick.utils
-from conda_forge_tick.backend_settings import GITHUB_GRAPH_BACKEND_BASE_URL
 from conda_forge_tick.lazy_json_backends import (
+    GITHUB_GRAPH_BACKEND_BASE_URL,
     LAZY_JSON_BACKENDS,
     GithubLazyJsonBackend,
     LazyJson,
@@ -652,7 +652,7 @@ def test_github_hget_success(
     mock_get.return_value.text = "{'key': 'value'}"
     assert backend.hget("name", "key") == "{'key': 'value'}"
     mock_get.assert_called_once_with(
-        f"https://github.com/lorem/ipsum/name/4/4/0/9/d/key.json",
+        "https://github.com/lorem/ipsum/name/4/4/0/9/d/key.json",
     )
 
 
@@ -666,7 +666,7 @@ def test_github_offline_hget_not_found(
     with pytest.raises(KeyError):
         backend.hget("name", "key")
     mock_get.assert_called_once_with(
-        f"https://github.com/lorem/ipsum/name/4/4/0/9/d/key.json",
+        "https://github.com/lorem/ipsum/name/4/4/0/9/d/key.json",
     )
 
 

--- a/tests/test_lazy_json_backends.py
+++ b/tests/test_lazy_json_backends.py
@@ -10,7 +10,7 @@ import pytest
 
 import conda_forge_tick.utils
 from conda_forge_tick.lazy_json_backends import (
-    GITHUB_GRAPH_BACKEND_BASE_URL,
+    CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL,
     LAZY_JSON_BACKENDS,
     GithubLazyJsonBackend,
     LazyJson,
@@ -515,7 +515,7 @@ def test_lazy_json_backends_hashmap(tmpdir):
 
 def test_github_base_url() -> None:
     github_backend = GithubLazyJsonBackend()
-    assert github_backend.base_url == GITHUB_GRAPH_BACKEND_BASE_URL + "/"
+    assert github_backend.base_url == CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL + "/"
     github_backend.base_url = "https://github.com/lorem/ipsum"
     assert github_backend.base_url == "https://github.com/lorem/ipsum" + "/"
 


### PR DESCRIPTION
This PR changes the code to use the import to package mappings generated by the bot. With this change, we can turn off libcfgraph and deprecate it. 