### PR TITLE
ENH attempt to deploy as we go to avoid GHA kills

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -29,6 +29,7 @@ from typing import (
 import tqdm
 
 from .cli_context import CliContext
+from .deploy import deploy
 from .lazy_json_backends import (
     LazyJson,
     get_all_keys_for_hashmap,
@@ -1622,7 +1623,15 @@ def main(ctx: CliContext) -> None:
             pass
             # this has been causing issues with bad deploys
             # turning off for now
-            # deploy(dry_run=ctx.dry_run)
+            deploy(
+                ctx,
+                dirs_to_deploy=[
+                    "pr_json",
+                    "pr_info",
+                    "version_pr_info",
+                    "nodes",
+                ],
+            )
 
     logger.info("API Calls Remaining: %d", mctx.gh_api_requests_left)
     logger.info("Done")

--- a/conda_forge_tick/deploy.py
+++ b/conda_forge_tick/deploy.py
@@ -15,7 +15,7 @@ def _run_git_cmd(cmd):
     return subprocess.run(cmd, shell=True, check=True)
 
 
-def deploy(ctx: CliContext):
+def deploy(ctx: CliContext, dirs_to_deploy: list[str] = None):
     """Deploy the graph to GitHub"""
     if ctx.dry_run:
         print("(dry run) deploying")
@@ -31,17 +31,21 @@ def deploy(ctx: CliContext):
         print(e)
 
     files_to_add = set()
-    drs_to_deploy = [
-        "status",
-        "mappings",
-        "mappings/pypi",
-        "ranked_hubs_authorities.json",
-        "all_feedstocks.json",
-        "import_to_pkg_maps",
-    ]
-    if "file" in get_lazy_json_backends():
-        drs_to_deploy += CF_TICK_GRAPH_DATA_HASHMAPS
-        drs_to_deploy += ["graph.json"]
+    if dirs_to_deploy is None:
+        drs_to_deploy = [
+            "status",
+            "mappings",
+            "mappings/pypi",
+            "ranked_hubs_authorities.json",
+            "all_feedstocks.json",
+            "import_to_pkg_maps",
+        ]
+        if "file" in get_lazy_json_backends():
+            drs_to_deploy += CF_TICK_GRAPH_DATA_HASHMAPS
+            drs_to_deploy += ["graph.json"]
+    else:
+        drs_to_deploy = dirs_to_deploy
+
     for dr in drs_to_deploy:
         # untracked
         files_to_add |= set(


### PR DESCRIPTION
This PR tries deploying the data to github as we go to keep the bot's state safer. We had tried this before but had had trouble with it. A lot has changed including easier github deploys due to changes in the backend schema. So let's try again.