### PR TITLE
Create alias for opencv-python-headless to opencv

### DIFF
--- a/conda_forge_tick/pypi_name_mapping_static.yaml
+++ b/conda_forge_tick/pypi_name_mapping_static.yaml
@@ -16,6 +16,10 @@
   import_name: cv2
   conda_name: opencv
 
+- pypi_name: opencv-python-headless
+  import_name: cv2
+  conda_name: opencv
+
 - pypi_name: pyqt4
   import_name: PyQt4
   conda_name: pyqt


### PR DESCRIPTION
We are trying for a push on https://github.com/conda-forge/opencv-feedstock/issues/293 to help users moving from pypi

Thanks!