### PR TITLE
PROD move file to primary backend

### DIFF
--- a/.github/workflows/bot-bot.yml
+++ b/.github/workflows/bot-bot.yml
@@ -65,7 +65,7 @@ jobs:
           PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           MEMORY_LIMIT_GB: 7
-          CF_TICK_GRAPH_DATA_BACKENDS: "mongodb:file"
+          CF_TICK_GRAPH_DATA_BACKENDS: "${{ vars. CF_TICK_GRAPH_DATA_BACKENDS }}"
           MONGODB_CONNECTION_STRING: ${{ secrets.MONGODB_CONNECTION_STRING }}
 
       - name: status of changes

--- a/.github/workflows/bot-cache.yml
+++ b/.github/workflows/bot-cache.yml
@@ -60,7 +60,7 @@ jobs:
           cd ..
           tar --zstd -cf cf-graph.tar.zstd cf-graph
         env:
-          CF_TICK_GRAPH_DATA_BACKENDS: "mongodb:file"
+          CF_TICK_GRAPH_DATA_BACKENDS: "${{ vars. CF_TICK_GRAPH_DATA_BACKENDS }}"
           MONGODB_CONNECTION_STRING: ${{ secrets.MONGODB_CONNECTION_STRING }}
 
   bot-cache-trigger:

--- a/.github/workflows/bot-make-graph.yml
+++ b/.github/workflows/bot-make-graph.yml
@@ -48,7 +48,7 @@ jobs:
           conda-forge-tick make-graph
         env:
           USERNAME: regro-cf-autotick-bot
-          CF_TICK_GRAPH_DATA_BACKENDS: "mongodb:file"
+          CF_TICK_GRAPH_DATA_BACKENDS: "${{ vars. CF_TICK_GRAPH_DATA_BACKENDS }}"
           MONGODB_CONNECTION_STRING: ${{ secrets.MONGODB_CONNECTION_STRING }}
 
       - name: deploy

--- a/.github/workflows/bot-prs.yml
+++ b/.github/workflows/bot-prs.yml
@@ -56,7 +56,7 @@ jobs:
           PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           BOT_JOB: ${{ matrix.job_num }}
-          CF_TICK_GRAPH_DATA_BACKENDS: "mongodb:file"
+          CF_TICK_GRAPH_DATA_BACKENDS: "${{ vars. CF_TICK_GRAPH_DATA_BACKENDS }}"
           MONGODB_CONNECTION_STRING: ${{ secrets.MONGODB_CONNECTION_STRING }}
 
       - name: deploy

--- a/.github/workflows/bot-versions.yml
+++ b/.github/workflows/bot-versions.yml
@@ -51,7 +51,7 @@ jobs:
           conda-forge-tick update-upstream-versions --job=${BOT_JOB} --n-jobs=8
         env:
           BOT_JOB: ${{ matrix.job_num }}
-          CF_TICK_GRAPH_DATA_BACKENDS: "mongodb:file"
+          CF_TICK_GRAPH_DATA_BACKENDS: "${{ vars. CF_TICK_GRAPH_DATA_BACKENDS }}"
           MONGODB_CONNECTION_STRING: ${{ secrets.MONGODB_CONNECTION_STRING }}
 
       - name: deploy


### PR DESCRIPTION
This PR moves the primary backend to the file interface so that changes made in the github repo are propagated to mongodb automatically. 🤞 

closes #2262 