### PR TITLE
BUG special-case bootstrapping stuff

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -29,7 +29,6 @@ from typing import (
 import tqdm
 
 from .cli_context import CliContext
-from .deploy import deploy
 from .lazy_json_backends import (
     LazyJson,
     get_all_keys_for_hashmap,
@@ -57,6 +56,7 @@ from conda_forge_tick.contexts import (
     MigratorContext,
     MigratorSessionContext,
 )
+from conda_forge_tick.feedstock_parser import BOOTSTRAP_MAPPINGS
 from conda_forge_tick.git_utils import (
     comment_on_pr,
     get_repo,
@@ -351,6 +351,8 @@ def run(
                 False,
             )
         )
+        # feedstocks that have problematic bootstrapping will not always be solvable
+        and feedstock_ctx.feedstock_name not in BOOTSTRAP_MAPPINGS
     ):
         solvable, errors, _ = is_recipe_solvable(
             feedstock_dir,

--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -68,7 +68,6 @@ def _get_requirements(
         for output in outputs_:
             if output.get("name") in outputs_to_keep:
                 reqs |= _parse_requirements(output.get("requirements", {}) or {}, **kw)
-                break
     else:
         reqs = _parse_requirements(meta_yaml.get("requirements", {}), **kw)
         outputs_ = meta_yaml.get("outputs", []) or [] if outputs else []

--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -26,6 +26,14 @@ logger = logging.getLogger(__name__)
 
 PIN_SEP_PAT = re.compile(r" |>|<|=|\[")
 
+# this dictionary maps feedstocks to their output
+# that would be available in a bootstrapping scenario
+# for these nodes, we only use the bootstrap requirements
+# to build graph edges
+BOOTSTRAP_MAPPINGS = {
+    "flit": {"flit-core"},
+}
+
 
 def _get_requirements(
     meta_yaml: "MetaYamlTypedDict",
@@ -33,6 +41,7 @@ def _get_requirements(
     build: bool = True,
     host: bool = True,
     run: bool = True,
+    outputs_to_keep: Optional[Set["PackageName"]] = None,
 ) -> "Set[PackageName]":
     """Get the list of recipe requirements from a meta.yaml dict
 
@@ -53,11 +62,19 @@ def _get_requirements(
         the set of recipe requirements
     """
     kw = dict(build=build, host=host, run=run)
-    reqs = _parse_requirements(meta_yaml.get("requirements", {}), **kw)
-    outputs_ = meta_yaml.get("outputs", []) or [] if outputs else []
-    for output in outputs_:
-        for req in _parse_requirements(output.get("requirements", {}) or {}, **kw):
-            reqs.add(req)
+    if outputs_to_keep is None:
+        reqs = _parse_requirements(meta_yaml.get("requirements", {}), **kw)
+        outputs_ = meta_yaml.get("outputs", []) or [] if outputs else []
+        for output in outputs_:
+            for req in _parse_requirements(output.get("requirements", {}) or {}, **kw):
+                reqs.add(req)
+    else:
+        reqs = set()
+        outputs_ = meta_yaml.get("outputs", []) or [] if outputs else []
+        for output in outputs_:
+            if output.get("name") in outputs_to_keep:
+                reqs |= _parse_requirements(output.get("requirements", {}) or {}, **kw)
+                break
     return reqs
 
 
@@ -82,10 +99,19 @@ def _parse_requirements(
     return {typing.cast("PackageName", pkg) for pkg in packages}
 
 
-def _extract_requirements(meta_yaml):
+def _extract_requirements(meta_yaml, outputs_to_keep=None):
     strong_exports = False
     requirements_dict = defaultdict(set)
-    for block in [meta_yaml] + meta_yaml.get("outputs", []) or []:
+
+    if outputs_to_keep is None:
+        metas = [meta_yaml] + meta_yaml.get("outputs", []) or []
+    else:
+        metas = []
+        for output in meta_yaml.get("outputs", []) or []:
+            if output.get("name") in outputs_to_keep:
+                metas.append(output)
+
+    for block in metas:
         req: "RequirementsTypedDict" = block.get("requirements", {}) or {}
         if isinstance(req, list):
             requirements_dict["run"].update(set(req))
@@ -309,13 +335,19 @@ def populate_feedstock_attributes(
     for k, v in zip(plat_arch, variant_yamls):
         plat_arch_name = "_".join(k)
         sub_graph[f"{plat_arch_name}_meta_yaml"] = v
-        _, sub_graph[f"{plat_arch_name}_requirements"], _ = _extract_requirements(v)
+        _, sub_graph[f"{plat_arch_name}_requirements"], _ = _extract_requirements(
+            v,
+            outputs_to_keep=BOOTSTRAP_MAPPINGS.get(name, []),
+        )
 
     (
         sub_graph["total_requirements"],
         sub_graph["requirements"],
         sub_graph["strong_exports"],
-    ) = _extract_requirements(meta_yaml)
+    ) = _extract_requirements(
+        meta_yaml,
+        outputs_to_keep=BOOTSTRAP_MAPPINGS.get(name, []),
+    )
 
     # handle multi outputs
     outputs_names = set()
@@ -335,7 +367,10 @@ def populate_feedstock_attributes(
 
     # TODO: Write schema for dict
     # TODO: remove this
-    req = _get_requirements(yaml_dict)
+    req = _get_requirements(
+        yaml_dict,
+        outputs_to_keep=BOOTSTRAP_MAPPINGS.get(name, []),
+    )
     sub_graph["req"] = req
 
     # set name and version


### PR DESCRIPTION
This PR adds special casing for feedstocks that have weird circular deps for bootstrapping. The example here is flit vs flit-core.

closes #2275

xref: https://github.com/conda-forge/flit-feedstock/issues/38 which if addressed would mean we do not need this PR