### PR TITLE
Fix corner case in stdlib piggyback

### DIFF
--- a/conda_forge_tick/migrators/cstdlib.py
+++ b/conda_forge_tick/migrators/cstdlib.py
@@ -201,7 +201,7 @@ class StdlibMigrator(MiniMigrator):
 
             sections = _slice_into_output_sections(lines, attrs)
             for name, section in sections.items():
-                if name == feedstock_name:
+                if (name == feedstock_name) and len(section) == 1:
                     # weird corner case of conda-build where output is build
                     # in global section and then again defined under outputs
                     new_lines += section

--- a/conda_forge_tick/migrators/cstdlib.py
+++ b/conda_forge_tick/migrators/cstdlib.py
@@ -190,6 +190,7 @@ class StdlibMigrator(MiniMigrator):
 
     def migrate(self, recipe_dir, attrs, **kwargs):
         outputs = attrs["meta_yaml"].get("outputs", [])
+        feedstock_name = attrs["meta_yaml"]["package"]["name"]
 
         new_lines = []
         write_stdlib_to_cbc = False
@@ -200,6 +201,11 @@ class StdlibMigrator(MiniMigrator):
 
             sections = _slice_into_output_sections(lines, attrs)
             for name, section in sections.items():
+                if name == feedstock_name:
+                    # weird corner case of conda-build where output is build
+                    # in global section and then again defined under outputs
+                    new_lines += section
+                    continue
                 # _process_section returns list of lines already
                 chunk, cbc = _process_section(name, attrs, section)
                 new_lines += chunk

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -30,6 +30,8 @@ VERSION_WITH_STDLIB = Version(
         # package with rust compilers
         ("polars", "1.10.0", False),
         # package without compilers, but with sysroot_linux-64
+        ("rdkit", "1.10.0", False),
+        # package without compilers, but with sysroot_linux-64
         ("sinabs", "1.10.0", True),
         # test that we skip recipes that already contain a {{ stdlib("c") }}
         ("skip_migration", "1.10.0", False),

--- a/tests/test_yaml/stdlib_rdkit_after_meta.yaml
+++ b/tests/test_yaml/stdlib_rdkit_after_meta.yaml
@@ -1,0 +1,113 @@
+{% set name = "rdkit" %}
+{% set version = "1.10.0" %}
+{% set filename = "Release_%s.tar.gz" % version.replace(".", "_") %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 3f9e587a96844a9b4ee7f998cfe4dc3964dc95c4ca94d7de6a77bffb99f873da
+  # fn: {{ filename }}
+  # url: https://github.com/rdkit/rdkit/archive/{{ filename }}
+  # sha256: e8f580db8fe14070d009adafb1f0e5b15c12ebe6c1cf4e99085c0615be3996fc
+
+  patches:
+    - pyproject.patch
+
+build:
+  number: 0
+  skip: true  # [aarch64]
+  missing_dso_whitelist:
+    - '*/RDKit*dll'  # [win]
+
+requirements:
+  build:
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - numpy                                  # [build_platform != target_platform]
+    - {{ compiler('cxx') }}
+    - {{ stdlib("c") }}
+    - cmake
+    - jom  # [win]
+    - make  # [unix]
+    - pkg-config
+  host:
+    - libboost-python-devel
+    - cairo
+    - eigen
+    - freetype
+    - python
+    - numpy
+    - pillow
+    - pandas <2.2
+    - pip
+    - setuptools
+    - setuptools_scm >=8
+    # For rdkit-stubs
+    - pybind11-stubgen
+  run:
+    - cairo
+    - python
+    - pillow
+    - pandas <2.2
+    - {{ pin_compatible('numpy') }}
+    - pycairo
+    - matplotlib-base
+    - sqlalchemy
+    - reportlab
+
+test:
+  commands:
+    - python -c "import rdkit; assert rdkit.__version__ == '{{ version }}'"
+  imports:
+    - rdkit
+    - rdkit.Avalon
+    - rdkit.Chem
+    - rdkit.Chem.AllChem
+    - rdkit.Chem.rdFreeSASA
+    - rdkit.DataManip
+    - rdkit.Dbase
+    - rdkit.DistanceGeometry
+    - rdkit.ForceField
+    - rdkit.Geometry
+    - rdkit.ML
+    - rdkit.Numerics
+    - rdkit.SimDivFilters
+    - rdkit.VLib
+    - rdkit.VLib.NodeLib
+    - rdkit.Chem.PandasTools
+
+outputs:
+  - name: rdkit
+  - name: rdkit-dev
+    script: install_rdkit_dev.bat  # [win]
+    requirements:
+      build:
+        - {{ stdlib("c") }}
+      run:
+        - rdkit
+    test:
+      commands:
+        - if not exist %LIBRARY_INC%\\rdkit\\Catalogs\\Catalog.h exit 1   # [win]
+    about:
+      summary: RDKit headers and library used in rdkit package
+      license: BSD-3-Clause
+      license_file: license.txt
+
+about:
+  home: http://rdkit.org
+  license: BSD-3-Clause
+  license_file: license.txt
+  summary: RDKit is a collection of cheminformatics and machine-learning software written in C++ and Python.
+  doc_url: http://www.rdkit.org/docs/index.html
+  dev_url: https://github.com/rdkit/rdkit
+
+extra:
+  recipe-maintainers:
+    - greglandrum
+    - pstjohn
+    - mcs07
+    - jaimergp

--- a/tests/test_yaml/stdlib_rdkit_before_meta.yaml
+++ b/tests/test_yaml/stdlib_rdkit_before_meta.yaml
@@ -1,0 +1,110 @@
+{% set name = "rdkit" %}
+{% set version = "1.9.0" %}
+{% set filename = "Release_%s.tar.gz" % version.replace(".", "_") %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: b6d893dc7dcd4138b9e9df59a13c59695e50e80dc5c2cacee0674670693951a1
+  # fn: {{ filename }}
+  # url: https://github.com/rdkit/rdkit/archive/{{ filename }}
+  # sha256: e8f580db8fe14070d009adafb1f0e5b15c12ebe6c1cf4e99085c0615be3996fc
+
+  patches:
+    - pyproject.patch
+
+build:
+  number: 0
+  skip: true  # [aarch64]
+  missing_dso_whitelist:
+    - '*/RDKit*dll'  # [win]
+
+requirements:
+  build:
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - numpy                                  # [build_platform != target_platform]
+    - {{ compiler('cxx') }}
+    - cmake
+    - jom  # [win]
+    - make  # [unix]
+    - pkg-config
+  host:
+    - libboost-python-devel
+    - cairo
+    - eigen
+    - freetype
+    - python
+    - numpy
+    - pillow
+    - pandas <2.2
+    - pip
+    - setuptools
+    - setuptools_scm >=8
+    # For rdkit-stubs
+    - pybind11-stubgen
+  run:
+    - cairo
+    - python
+    - pillow
+    - pandas <2.2
+    - {{ pin_compatible('numpy') }}
+    - pycairo
+    - matplotlib-base
+    - sqlalchemy
+    - reportlab
+
+test:
+  commands:
+    - python -c "import rdkit; assert rdkit.__version__ == '{{ version }}'"
+  imports:
+    - rdkit
+    - rdkit.Avalon
+    - rdkit.Chem
+    - rdkit.Chem.AllChem
+    - rdkit.Chem.rdFreeSASA
+    - rdkit.DataManip
+    - rdkit.Dbase
+    - rdkit.DistanceGeometry
+    - rdkit.ForceField
+    - rdkit.Geometry
+    - rdkit.ML
+    - rdkit.Numerics
+    - rdkit.SimDivFilters
+    - rdkit.VLib
+    - rdkit.VLib.NodeLib
+    - rdkit.Chem.PandasTools
+
+outputs:
+  - name: rdkit
+  - name: rdkit-dev
+    script: install_rdkit_dev.bat  # [win]
+    requirements:
+      run:
+        - rdkit
+    test:
+      commands:
+        - if not exist %LIBRARY_INC%\\rdkit\\Catalogs\\Catalog.h exit 1   # [win]
+    about:
+      summary: RDKit headers and library used in rdkit package
+      license: BSD-3-Clause
+      license_file: license.txt
+
+about:
+  home: http://rdkit.org
+  license: BSD-3-Clause
+  license_file: license.txt
+  summary: RDKit is a collection of cheminformatics and machine-learning software written in C++ and Python.
+  doc_url: http://www.rdkit.org/docs/index.html
+  dev_url: https://github.com/rdkit/rdkit
+
+extra:
+  recipe-maintainers:
+    - greglandrum
+    - pstjohn
+    - mcs07
+    - jaimergp


### PR DESCRIPTION
First follow-up to #2135 after looking at a failure in the rdkit feedstock, which uses a conda-build corner case that I hadn't thought of (and really dislike...)