### PR TITLE
Label relock PRs

### DIFF
--- a/.github/workflows/relock.yml
+++ b/.github/workflows/relock.yml
@@ -41,11 +41,7 @@ jobs:
         with:
           commit-message: relock w/ conda-lock
           title: relock w/ conda-lock
-          body: |
-            This pull request relocks the dependencies with conda-lock.
-            
-            
-            ${{ steps.relock.outputs.SUMMARY }}
+          body: "This pull request relocks the dependencies with conda-lock.\n\n${{ steps.relock.outputs.SUMMARY }}"
           branch: relock-deps
           delete-branch: true
           token: ${{ secrets.AUTOTICK_BOT_TOKEN }}

--- a/.github/workflows/relock.yml
+++ b/.github/workflows/relock.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           commit-message: relock w/ conda-lock
           title: relock w/ conda-lock
-          body: >
+          body: |
             This pull request relocks the dependencies with conda-lock.
             
             

--- a/.github/workflows/relock.yml
+++ b/.github/workflows/relock.yml
@@ -43,7 +43,8 @@ jobs:
           title: relock w/ conda-lock
           body: >
             This pull request relocks the dependencies with conda-lock.
-
+            
+            
             ${{ steps.relock.outputs.SUMMARY }}
           branch: relock-deps
           delete-branch: true

--- a/.github/workflows/relock.yml
+++ b/.github/workflows/relock.yml
@@ -50,6 +50,7 @@ jobs:
           token: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           committer: regro-cf-autotick-bot <36490558+regro-cf-autotick-bot@users.noreply.github.com>
           author: regro-cf-autotick-bot <36490558+regro-cf-autotick-bot@users.noreply.github.com>
+          labels: dependencies
 
       - name: automerge
         if: ${{ steps.pr.outputs.pull-request-number != '' }}

--- a/autotick-bot/relock_me.py
+++ b/autotick-bot/relock_me.py
@@ -91,6 +91,11 @@ try:
     relock_tuples = {platform: [] for platform in envyml["platforms"]}
     for spec in envyml["dependencies"]:
         spec = MatchSpec(spec)
+
+        # we always pull the latest on the fly when the bot runs
+        if spec.name == "conda-forge-pinning":
+            continue
+
         for platform in envyml["platforms"]:
             if old_platform_pkg_to_ver[platform].get(
                 spec.name


### PR DESCRIPTION
Auto-label the relock PRs so they can be easily omitted in PR searches (same label as Dependabot ones).