### PR TITLE
ENH make sure branches are strings

### DIFF
--- a/conda_forge_tick/migrators/conda_forge_yaml_cleanup.py
+++ b/conda_forge_tick/migrators/conda_forge_yaml_cleanup.py
@@ -12,8 +12,6 @@ if typing.TYPE_CHECKING:
 
 
 class CondaForgeYAMLCleanup(MiniMigrator):
-    # if you add a key here, you need to add it to the set of
-    # keys kept in the graph in make_graph.py
     keys_to_remove = [
         "min_r_ver",
         "max_r_ver",
@@ -23,12 +21,13 @@ class CondaForgeYAMLCleanup(MiniMigrator):
     ]
     keys_to_change = [
         "test_on_native_only",
+        "abi_migration_branches",
     ]
 
     def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
-        """only remove the keys if they are there"""
+        """remove recipes without a conda-forge.yml file that has the keys to remove or change"""
         cfy = attrs.get("conda-forge.yml", {})
-        if any(k in cfy for k in self.keys_to_remove or k in self.keys_to_change):
+        if any(key in cfy for key in (self.keys_to_remove + self.keys_to_change)):
             return False
         else:
             return True
@@ -51,6 +50,11 @@ class CondaForgeYAMLCleanup(MiniMigrator):
                 del cfg["test_on_native_only"]
                 if value:
                     cfg["test"] = "native_and_emulated"
+
+            if "abi_migration_branches" in cfg:
+                cfg["abi_migration_branches"] = [
+                    str(v) for v in cfg["abi_migration_branches"]
+                ]
 
             with open(cfg_path, "w") as fp:
                 yaml.dump(cfg, fp)


### PR DESCRIPTION
This PR makes sure the abi_migration branches are strings so they pass the json schema validation.

xref: https://github.com/conda-forge/conda-smithy/issues/1890