### PR TITLE
fix: link to VersionPrInfo model

### DIFF
--- a/conda_forge_tick/models/README.md
+++ b/conda_forge_tick/models/README.md
@@ -67,6 +67,8 @@ Pydantic Model: `PullRequestData` in [pr_json.py](pr_json.py).
 This directory is NOT analogous to `pr_info`. It contains metadata about attempted version migrations, and is
 referenced by the `NodeAttributes.version_pr_info` field using a Lazy JSON reference.
 
+Pydantic Model: `VersionPrInfo` in [version_pr_info.py](version_pr_info.py)
+
 ### `versions`
 One file per conda-forge package containing upstream version update information about the package.
 For some packages, this file may not exist, indicating absent upstream version update information.


### PR DESCRIPTION
<!-- Put your changes here -->
This was forgotten in #2265.

<!--
Thanks for contributing to cf-scripts!
We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

- [x] Pydantic model updated or no update needed
