### PR TITLE
BUG fallback to feedstock names for long json blobs

### DIFF
--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -502,11 +502,20 @@ def load_feedstock_containerized(
     if mark_not_archived:
         args += ["--mark-not-archived"]
 
+    json_blob = dumps(sub_graph)
+    if len(json_blob) > 6000:
+        logger.warning(
+            f"The JSON blob is too large ({len(json_blob)} characters, limit is 6000), "
+            "using the feedstock name instead. This will force "
+            "the container to download the node attritbutes directly from GitHub."
+        )
+        json_blob = name
+
     data = run_container_task(
         "parse-feedstock",
         [
             "--existing-feedstock-node-attrs",
-            dumps(sub_graph),
+            json_blob,
             *args,
         ],
         json_loads=loads,

--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -20,7 +20,7 @@ if typing.TYPE_CHECKING:
     from .migrators_types import PackageName, RequirementsTypedDict
     from conda_forge_tick.migrators_types import MetaYamlTypedDict
 
-from conda_forge_tick.lazy_json_backends import dumps, loads, LazyJson
+from conda_forge_tick.lazy_json_backends import LazyJson, dumps, loads
 from conda_forge_tick.utils import run_container_task
 
 from .utils import as_iterable, parse_meta_yaml
@@ -502,7 +502,9 @@ def load_feedstock_containerized(
     if mark_not_archived:
         args += ["--mark-not-archived"]
 
-    json_blob = dumps(sub_graph.data) if isinstance(sub_graph, LazyJson) else dumps(sub_graph)
+    json_blob = (
+        dumps(sub_graph.data) if isinstance(sub_graph, LazyJson) else dumps(sub_graph)
+    )
     if len(json_blob) > 6000:
         logger.warning(
             f"The JSON blob is too large ({len(json_blob)} characters, limit is 6000), "

--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -532,7 +532,7 @@ def load_feedstock(
     meta_yaml: Optional[str] = None,
     conda_forge_yaml: Optional[str] = None,
     mark_not_archived: bool = False,
-    use_container: bool = False,
+    use_container: bool = True,
 ):
     """Load a feedstock into subgraph based on its name. If meta_yaml and/or
     conda_forge_yaml are not provided, they will be fetched from the feedstock.

--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -20,7 +20,7 @@ if typing.TYPE_CHECKING:
     from .migrators_types import PackageName, RequirementsTypedDict
     from conda_forge_tick.migrators_types import MetaYamlTypedDict
 
-from conda_forge_tick.lazy_json_backends import dumps, loads
+from conda_forge_tick.lazy_json_backends import dumps, loads, LazyJson
 from conda_forge_tick.utils import run_container_task
 
 from .utils import as_iterable, parse_meta_yaml
@@ -502,7 +502,7 @@ def load_feedstock_containerized(
     if mark_not_archived:
         args += ["--mark-not-archived"]
 
-    json_blob = dumps(sub_graph)
+    json_blob = dumps(sub_graph.data) if isinstance(sub_graph, LazyJson) else dumps(sub_graph)
     if len(json_blob) > 6000:
         logger.warning(
             f"The JSON blob is too large ({len(json_blob)} characters, limit is 6000), "

--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -200,10 +200,19 @@ def get_latest_version_containerized(
     if "feedstock_name" not in attrs:
         attrs["feedstock_name"] = name
 
+    json_blob = dumps(attrs.data) if isinstance(attrs, LazyJson) else dumps(attrs)
+    if len(json_blob) > 6000:
+        logger.warning(
+            f"The JSON blob is too large ({len(json_blob)} characters, limit is 6000), "
+            "using the feedstock name instead. This will force "
+            "the container to download the node attritbutes directly from GitHub."
+        )
+        json_blob = name
+
     task = "get-latest-version"
     args = [
         "--existing-feedstock-node-attrs",
-        dumps(attrs.data) if isinstance(attrs, LazyJson) else dumps(attrs),
+        json_blob,
         "--sources",
         ",".join([source.name for source in sources]),
     ]

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -152,7 +152,7 @@ def run_container_task(name, args, json_loads=json.loads):
         *get_default_container_run_args(),
         "-t",
         get_default_container_name(),
-        "python",
+        "/opt/conda/envs/cf-scripts/bin/python",
         "/opt/autotick-bot/docker/run_bot_task.py",
         name,
         *args,

--- a/tests/test_container_tasks.py
+++ b/tests/test_container_tasks.py
@@ -53,6 +53,18 @@ def test_get_latest_version_containerized():
         assert data["new_version"] == conda_smithy.__version__
 
 
+def test_get_latest_version_containerized_mpas_tools():
+    with tempfile.TemporaryDirectory() as tmpdir, pushd(tmpdir):
+        with lazy_json_override_backends(["github"], use_file_cache=False):
+            with LazyJson("node_attrs/mpas_tools.json") as lzj:
+                attrs = copy.deepcopy(lzj.data)
+
+        data = get_latest_version_containerized(
+            "mpas_tools", attrs, all_version_sources()
+        )
+        assert data["new_version"] is not False
+
+
 def test_container_tasks_parse_feedstock():
     with tempfile.TemporaryDirectory() as tmpdir, pushd(tmpdir):
         data = run_container_task(
@@ -93,6 +105,18 @@ def test_load_feedstock_containerized():
                 attrs = copy.deepcopy(lzj.data)
 
         data = load_feedstock_containerized("conda-smithy", attrs)
+        assert data["feedstock_name"] == attrs["feedstock_name"]
+        assert not data["parsing_error"]
+        assert data["raw_meta_yaml"] == attrs["raw_meta_yaml"]
+
+
+def test_load_feedstock_containerized_mpas_tools():
+    with tempfile.TemporaryDirectory() as tmpdir, pushd(tmpdir):
+        with lazy_json_override_backends(["github"], use_file_cache=False):
+            with LazyJson("node_attrs/mpas_tools.json") as lzj:
+                attrs = copy.deepcopy(lzj.data)
+
+        data = load_feedstock_containerized("mpas_tools", attrs)
         assert data["feedstock_name"] == attrs["feedstock_name"]
         assert not data["parsing_error"]
         assert data["raw_meta_yaml"] == attrs["raw_meta_yaml"]


### PR DESCRIPTION
This PR fixes issues where long JSON blobs caused problems at the CLI. For now we will fall back to redownloading the feedstock attributes from github via a raw url. It also puts in the absolute path of the python interpreter to try and speed things up.