### PR TITLE
ENH use fast compression on heavy json blobs to reduce network i/o

### DIFF
--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -3,9 +3,9 @@ metadata:
     - url: conda-forge
       used_env_vars: []
   content_hash:
-    linux-64: 3ea859e02824400c324f00b04180d60cc5d84ade180b32baef845620961db745
-    osx-64: 9ce6adce11a702ae9d326bb87d16beecd0ea2ab20bec183b464af880d6abce26
-    osx-arm64: ff2db3b42ec322ce9ce453b52107dc68b8250a6706c4393d116ab9a95f9101fa
+    linux-64: bf0a05a72873f5f067c795249de177546d2d2e7dcbc7a4ea6cb349a4cc76c03e
+    osx-64: 3070e41a834a8f9d7ef6dfe744d6a7e19d5c77ea21f1cfa06373fd02c26fe1b2
+    osx-arm64: 503bd6b379cfde05cf5eadf9dfcbc16de19c56eee77ed4203d6a7a66a7fba76d
   platforms:
     - osx-arm64
     - linux-64
@@ -1890,39 +1890,39 @@ package:
   - category: main
     dependencies: {}
     hash:
-      md5: 7624e85bf892b66044acef26c0bd70d4
-      sha256: 1c66a7df00d7811c4dfb00a4b35880f972ccd8b0f1d3b20d288b80ae0c0c5d8b
+      md5: e61d5b2a1c7a1e6762ce232c6eedfa27
+      sha256: cb9a81f98a3a770df6994c49f6b44ef96a8c13bd4906083e43bae571c94ce255
     manager: conda
     name: conda-forge-pinning
     optional: false
     platform: linux-64
     url:
-      https://conda.anaconda.org/conda-forge/noarch/conda-forge-pinning-2024.04.10.16.59.40-hd8ed1ab_0.conda
-    version: 2024.04.10.16.59.40
+      https://conda.anaconda.org/conda-forge/noarch/conda-forge-pinning-2024.04.11.22.26.35-hd8ed1ab_0.conda
+    version: 2024.04.11.22.26.35
   - category: main
     dependencies: {}
     hash:
-      md5: 7624e85bf892b66044acef26c0bd70d4
-      sha256: 1c66a7df00d7811c4dfb00a4b35880f972ccd8b0f1d3b20d288b80ae0c0c5d8b
+      md5: e61d5b2a1c7a1e6762ce232c6eedfa27
+      sha256: cb9a81f98a3a770df6994c49f6b44ef96a8c13bd4906083e43bae571c94ce255
     manager: conda
     name: conda-forge-pinning
     optional: false
     platform: osx-64
     url:
-      https://conda.anaconda.org/conda-forge/noarch/conda-forge-pinning-2024.04.10.16.59.40-hd8ed1ab_0.conda
-    version: 2024.04.10.16.59.40
+      https://conda.anaconda.org/conda-forge/noarch/conda-forge-pinning-2024.04.11.22.26.35-hd8ed1ab_0.conda
+    version: 2024.04.11.22.26.35
   - category: main
     dependencies: {}
     hash:
-      md5: 7624e85bf892b66044acef26c0bd70d4
-      sha256: 1c66a7df00d7811c4dfb00a4b35880f972ccd8b0f1d3b20d288b80ae0c0c5d8b
+      md5: e61d5b2a1c7a1e6762ce232c6eedfa27
+      sha256: cb9a81f98a3a770df6994c49f6b44ef96a8c13bd4906083e43bae571c94ce255
     manager: conda
     name: conda-forge-pinning
     optional: false
     platform: osx-arm64
     url:
-      https://conda.anaconda.org/conda-forge/noarch/conda-forge-pinning-2024.04.10.16.59.40-hd8ed1ab_0.conda
-    version: 2024.04.10.16.59.40
+      https://conda.anaconda.org/conda-forge/noarch/conda-forge-pinning-2024.04.11.22.26.35-hd8ed1ab_0.conda
+    version: 2024.04.11.22.26.35
   - category: main
     dependencies:
       click: '>=8'
@@ -9893,6 +9893,49 @@ package:
       https://conda.anaconda.org/conda-forge/osx-arm64/py-lief-0.14.1-py311h6376970_1.conda
     version: 0.14.1
   - category: main
+    dependencies:
+      libgcc-ng: '>=12'
+      python: '>=3.11,<3.12.0a0'
+      python_abi: 3.11.*
+    hash:
+      md5: ef2d7b9e6458efbbbc86fb77b8b90118
+      sha256: 7d385cdf9cee6f423d9543b678fca9d2d1ce50a34940322419370ac2a25e884a
+    manager: conda
+    name: py-lz4framed
+    optional: false
+    platform: linux-64
+    url:
+      https://conda.anaconda.org/conda-forge/linux-64/py-lz4framed-0.14.0-py311h459d7ec_7.conda
+    version: 0.14.0
+  - category: main
+    dependencies:
+      python: '>=3.11,<3.12.0a0'
+      python_abi: 3.11.*
+    hash:
+      md5: eb02a17101158f3dc56487433c342177
+      sha256: 004a3d05ac9aec473163eb0387b470437124c463a962037b5723da70e1453c36
+    manager: conda
+    name: py-lz4framed
+    optional: false
+    platform: osx-64
+    url:
+      https://conda.anaconda.org/conda-forge/osx-64/py-lz4framed-0.14.0-py311he705e18_7.conda
+    version: 0.14.0
+  - category: main
+    dependencies:
+      python: '>=3.11,<3.12.0a0'
+      python_abi: 3.11.*
+    hash:
+      md5: 91a5b7d764b6b7dfb8e9d99b356767aa
+      sha256: 9bcb6c3fcf34b8c4ad64ef4e6cb015263407a4c3a69037383aa490160eaf7c68
+    manager: conda
+    name: py-lz4framed
+    optional: false
+    platform: osx-arm64
+    url:
+      https://conda.anaconda.org/conda-forge/osx-arm64/py-lz4framed-0.14.0-py311h05b510d_7.conda
+    version: 0.14.0
+  - category: main
     dependencies: {}
     hash:
       md5: 878f923dd6acc8aeb47a75da6c4098be
@@ -10053,48 +10096,48 @@ package:
   - category: main
     dependencies:
       annotated-types: '>=0.4.0'
-      pydantic-core: 2.16.3
+      pydantic-core: 2.18.1
       python: '>=3.7'
       typing-extensions: '>=4.6.1'
     hash:
-      md5: 2e8e9f16431085f4b5a218b31fe557a3
-      sha256: 9747044e91a607c175bbce67fdb5865de5373151098bbb4a2cd79bc05666a299
+      md5: 369c93f0209568e7c33892d8960fe583
+      sha256: e7b58685010aaeb64524d430b7fd9e732d81644a7185810f567097fc16804e88
     manager: conda
     name: pydantic
     optional: false
     platform: linux-64
-    url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.6.4-pyhd8ed1ab_0.conda
-    version: 2.6.4
+    url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.7.0-pyhd8ed1ab_0.conda
+    version: 2.7.0
   - category: main
     dependencies:
       annotated-types: '>=0.4.0'
-      pydantic-core: 2.16.3
+      pydantic-core: 2.18.1
       python: '>=3.7'
       typing-extensions: '>=4.6.1'
     hash:
-      md5: 2e8e9f16431085f4b5a218b31fe557a3
-      sha256: 9747044e91a607c175bbce67fdb5865de5373151098bbb4a2cd79bc05666a299
+      md5: 369c93f0209568e7c33892d8960fe583
+      sha256: e7b58685010aaeb64524d430b7fd9e732d81644a7185810f567097fc16804e88
     manager: conda
     name: pydantic
     optional: false
     platform: osx-64
-    url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.6.4-pyhd8ed1ab_0.conda
-    version: 2.6.4
+    url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.7.0-pyhd8ed1ab_0.conda
+    version: 2.7.0
   - category: main
     dependencies:
       annotated-types: '>=0.4.0'
-      pydantic-core: 2.16.3
+      pydantic-core: 2.18.1
       python: '>=3.7'
       typing-extensions: '>=4.6.1'
     hash:
-      md5: 2e8e9f16431085f4b5a218b31fe557a3
-      sha256: 9747044e91a607c175bbce67fdb5865de5373151098bbb4a2cd79bc05666a299
+      md5: 369c93f0209568e7c33892d8960fe583
+      sha256: e7b58685010aaeb64524d430b7fd9e732d81644a7185810f567097fc16804e88
     manager: conda
     name: pydantic
     optional: false
     platform: osx-arm64
-    url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.6.4-pyhd8ed1ab_0.conda
-    version: 2.6.4
+    url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.7.0-pyhd8ed1ab_0.conda
+    version: 2.7.0
   - category: main
     dependencies:
       libgcc-ng: '>=12'
@@ -10102,45 +10145,45 @@ package:
       python_abi: 3.11.*
       typing-extensions: '>=4.6.0,!=4.7.0'
     hash:
-      md5: b8241049c210406da1c9aa8eb4536470
-      sha256: 9ea66b121c1f110f9c323d00f6e849df4941b2c0356dd8380a96f56adefebf57
+      md5: 585ed61519d1dfe3a848959bf141826b
+      sha256: 761a297d8818b17c5428bf2289e47a88fc3c1444aef24051a0bf0eb98f3e9e30
     manager: conda
     name: pydantic-core
     optional: false
     platform: linux-64
     url:
-      https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.16.3-py311h46250e7_0.conda
-    version: 2.16.3
+      https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.18.1-py311h46250e7_0.conda
+    version: 2.18.1
   - category: main
     dependencies:
       python: '>=3.11,<3.12.0a0'
       python_abi: 3.11.*
       typing-extensions: '>=4.6.0,!=4.7.0'
     hash:
-      md5: 501a363399b9f0e87d6ecaf7636342cc
-      sha256: 222280c774852b1fce3d0fa7a19da8ed77c288583ff90a2b4c19519160f93bd6
+      md5: 116a2da8d10e736bf67d4de579c9eda5
+      sha256: 3867aa370fffc0022bdd98ab8dc23bf7332ad5cbf1012b602d2309dd15c243d7
     manager: conda
     name: pydantic-core
     optional: false
     platform: osx-64
     url:
-      https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.16.3-py311hd64b9fd_0.conda
-    version: 2.16.3
+      https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.18.1-py311hd64b9fd_0.conda
+    version: 2.18.1
   - category: main
     dependencies:
       python: '>=3.11,<3.12.0a0'
       python_abi: 3.11.*
       typing-extensions: '>=4.6.0,!=4.7.0'
     hash:
-      md5: bd21dac222b9114709c1cc8d57a66b69
-      sha256: 5cb74110e8cf4f9982f37b05e9879d71d0fbe931f18ae524b0f2bba66e2f05c5
+      md5: db31f2b8d05c7014f8d22296c0e8aaca
+      sha256: 28e21c0f242dbaa7bd532a5d3a70ab955a461bca03529ea0619959aaf7932dc2
     manager: conda
     name: pydantic-core
     optional: false
     platform: osx-arm64
     url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.16.3-py311h94f323b_0.conda
-    version: 2.16.3
+      https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.18.1-py311h94f323b_0.conda
+    version: 2.18.1
   - category: main
     dependencies:
       pydantic: '>=2.5.2'
@@ -13480,41 +13523,41 @@ package:
     dependencies:
       python: '>=3.7'
     hash:
-      md5: e565e537d9760fc5d6d02ae4521a144b
-      sha256: 909b4288bd2be8566f6d0a311d75a7e0e1cf81c42c19c97b1fc7d043c3db3301
+      md5: 9622d541e2314c0207bebdc0359fa478
+      sha256: cbc8e5c5f82b1eeff7aa21aaff77757336c1e6d64a4255b071c783acd60f4618
     manager: conda
     name: trove-classifiers
     optional: false
     platform: linux-64
     url:
-      https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.3.25-pyhd8ed1ab_0.conda
-    version: 2024.3.25
+      https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.4.10-pyhd8ed1ab_0.conda
+    version: 2024.4.10
   - category: main
     dependencies:
       python: '>=3.7'
     hash:
-      md5: e565e537d9760fc5d6d02ae4521a144b
-      sha256: 909b4288bd2be8566f6d0a311d75a7e0e1cf81c42c19c97b1fc7d043c3db3301
+      md5: 9622d541e2314c0207bebdc0359fa478
+      sha256: cbc8e5c5f82b1eeff7aa21aaff77757336c1e6d64a4255b071c783acd60f4618
     manager: conda
     name: trove-classifiers
     optional: false
     platform: osx-64
     url:
-      https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.3.25-pyhd8ed1ab_0.conda
-    version: 2024.3.25
+      https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.4.10-pyhd8ed1ab_0.conda
+    version: 2024.4.10
   - category: main
     dependencies:
       python: '>=3.7'
     hash:
-      md5: e565e537d9760fc5d6d02ae4521a144b
-      sha256: 909b4288bd2be8566f6d0a311d75a7e0e1cf81c42c19c97b1fc7d043c3db3301
+      md5: 9622d541e2314c0207bebdc0359fa478
+      sha256: cbc8e5c5f82b1eeff7aa21aaff77757336c1e6d64a4255b071c783acd60f4618
     manager: conda
     name: trove-classifiers
     optional: false
     platform: osx-arm64
     url:
-      https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.3.25-pyhd8ed1ab_0.conda
-    version: 2024.3.25
+      https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.4.10-pyhd8ed1ab_0.conda
+    version: 2024.4.10
   - category: main
     dependencies:
       python: '>=3.10'

--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -8,10 +8,10 @@ import re
 import tempfile
 import typing
 import zipfile
-import lz4framed
 from collections import defaultdict
 from typing import Optional, Set, Union
 
+import lz4framed
 import requests
 import yaml
 from requests.models import Response

--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -8,7 +8,7 @@ import re
 import tempfile
 import typing
 import zipfile
-import zlib as lz4framed
+import lz4framed
 from collections import defaultdict
 from typing import Optional, Set, Union
 

--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -5,7 +5,6 @@ import logging
 import os
 import random
 import time
-import lz4framed
 from concurrent.futures import as_completed
 from typing import (
     Any,
@@ -21,6 +20,7 @@ from typing import (
     Union,
 )
 
+import lz4framed
 import networkx as nx
 import tqdm
 

--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -5,6 +5,7 @@ import logging
 import os
 import random
 import time
+import zlib as lz4framed
 from concurrent.futures import as_completed
 from typing import (
     Any,
@@ -20,7 +21,6 @@ from typing import (
     Union,
 )
 
-import lz4framed
 import networkx as nx
 import tqdm
 

--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -5,7 +5,7 @@ import logging
 import os
 import random
 import time
-import zlib as lz4framed
+import lz4framed
 from concurrent.futures import as_completed
 from typing import (
     Any,

--- a/docker/run_bot_task.py
+++ b/docker/run_bot_task.py
@@ -12,10 +12,12 @@ one can use the `tempfile` module to create temporary files and directories.
 These tasks return their info to the bot by printing a JSON blob to stdout.
 """
 
+import base64
 import copy
 import os
 import tempfile
 import traceback
+import zlib as lz4framed
 from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from io import StringIO
 
@@ -66,10 +68,6 @@ def _get_existing_feedstock_node_attrs(*, existing_feedstock_node_attrs, is_comp
     )
 
     if is_compressed:
-        import base64
-
-        import lz4framed
-
         existing_feedstock_node_attrs = base64.urlsafe_b64decode(
             existing_feedstock_node_attrs
         )

--- a/docker/run_bot_task.py
+++ b/docker/run_bot_task.py
@@ -17,7 +17,7 @@ import copy
 import os
 import tempfile
 import traceback
-import zlib as lz4framed
+import lz4framed
 from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from io import StringIO
 

--- a/docker/run_bot_task.py
+++ b/docker/run_bot_task.py
@@ -17,11 +17,11 @@ import copy
 import os
 import tempfile
 import traceback
-import lz4framed
 from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from io import StringIO
 
 import click
+import lz4framed
 
 existing_feedstock_node_attrs_option = click.option(
     "--existing-feedstock-node-attrs",

--- a/environment.yml
+++ b/environment.yml
@@ -46,6 +46,7 @@ dependencies:
   - python-dateutil
   - python-graphviz
   - python-rapidjson
+  - py-lz4framed
   - requests
   - rever
   - ruamel.yaml

--- a/environment.yml
+++ b/environment.yml
@@ -46,7 +46,7 @@ dependencies:
   - python-dateutil
   - python-graphviz
   - python-rapidjson
-  # - py-lz4framed
+  - py-lz4framed
   - requests
   - rever
   - ruamel.yaml

--- a/environment.yml
+++ b/environment.yml
@@ -46,7 +46,7 @@ dependencies:
   - python-dateutil
   - python-graphviz
   - python-rapidjson
-  - py-lz4framed
+  # - py-lz4framed
   - requests
   - rever
   - ruamel.yaml


### PR DESCRIPTION
This PR uses LZ4 compression to try and reduce calls for recipe blobs from github from containers.

todo
 - [x] add py-lz4framed to osx-arm64 (https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5754)
 - [x] switch to it for the code in this PR