### PR TITLE
BUG some recipes use load_file_regex

### DIFF
--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -60,6 +60,7 @@ CB_CONFIG = dict(
     cdt=lambda *args, **kwargs: "cdt_stub",
     cran_mirror="https://cran.r-project.org",
     datetime=datetime,
+    load_file_regex=lambda *args, **kwargs: None,
 )
 
 
@@ -85,6 +86,7 @@ CB_CONFIG_PINNING = dict(
     cdt=lambda *args, **kwargs: "cdt_stub",
     cran_mirror="https://cran.r-project.org",
     datetime=datetime,
+    load_file_regex=lambda *args, **kwargs: None,
 )
 
 DEFAULT_GRAPH_FILENAME = "graph.json"


### PR DESCRIPTION
This PR adds `load_file_regex` to our custom jinja2 env. I am not going to add all of the others quite yet since it is actually nice to see the errors from what is missing.