### PR TITLE
REF use BOT_TOKEN as only cred

### DIFF
--- a/.github/workflows/bot-bot.yml
+++ b/.github/workflows/bot-bot.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           source cf-scripts/autotick-bot/install_bot_code.sh
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: run migrations
         if: success() && ! env.CI_SKIP
@@ -88,7 +88,7 @@ jobs:
           conda-forge-tick auto-tick
         env:
           USERNAME: regro-cf-autotick-bot
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           MEMORY_LIMIT_GB: 7
           CF_TICK_GRAPH_DATA_BACKENDS: "${{ vars.CF_TICK_GRAPH_DATA_BACKENDS }}"
@@ -109,7 +109,7 @@ jobs:
           export CIRCLE_BUILD_NUM="actually-actions-${RUN_ID}"
           conda-forge-tick deploy-to-github
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
 
       - name: bump on fail
@@ -118,7 +118,7 @@ jobs:
           export ACTION_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           python cf-scripts/autotick-bot/bump_bot_team.py
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           ACTION_NAME: ${{ github.workflow }}
 

--- a/.github/workflows/bot-delete-old-runs.yml
+++ b/.github/workflows/bot-delete-old-runs.yml
@@ -29,4 +29,4 @@ jobs:
           cd cf-scripts
           python autotick-bot/delete_old_runs.py
         env:
-          GITHUB_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}

--- a/.github/workflows/bot-feedstocks.yml
+++ b/.github/workflows/bot-feedstocks.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           source cf-scripts/autotick-bot/install_bot_code.sh
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: feedstocks
         if: success() && ! env.CI_SKIP
@@ -44,7 +44,7 @@ jobs:
 
           conda-forge-tick gather-all-feedstocks
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: deploy
         if: github.ref == 'refs/heads/master' && ! cancelled() && ! env.CI_SKIP
@@ -55,7 +55,7 @@ jobs:
           export CIRCLE_BUILD_NUM="actually-actions-${RUN_ID}"
           conda-forge-tick deploy-to-github
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
 
       - name: bump on fail
@@ -64,6 +64,6 @@ jobs:
           export ACTION_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           python cf-scripts/autotick-bot/bump_bot_team.py
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           ACTION_NAME: ${{ github.workflow }}

--- a/.github/workflows/bot-make-graph.yml
+++ b/.github/workflows/bot-make-graph.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           source cf-scripts/autotick-bot/install_bot_code.sh
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: make graph
         if: success() && ! env.CI_SKIP
@@ -62,7 +62,7 @@ jobs:
           export CIRCLE_BUILD_NUM="actually-actions-${RUN_ID}"
           conda-forge-tick deploy-to-github
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
 
       - name: bump on fail
@@ -71,7 +71,7 @@ jobs:
           export ACTION_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           python cf-scripts/autotick-bot/bump_bot_team.py
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           ACTION_NAME: ${{ github.workflow }}
 
@@ -104,7 +104,7 @@ jobs:
         run: |
           source cf-scripts/autotick-bot/install_bot_code.sh
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: make graph
         if: success() && ! env.CI_SKIP
@@ -126,7 +126,7 @@ jobs:
           export CIRCLE_BUILD_NUM="actually-actions-${RUN_ID}"
           conda-forge-tick deploy-to-github
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
 
       - name: trigger next job
@@ -143,6 +143,6 @@ jobs:
           export ACTION_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           python cf-scripts/autotick-bot/bump_bot_team.py
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           ACTION_NAME: ${{ github.workflow }}

--- a/.github/workflows/bot-prs.yml
+++ b/.github/workflows/bot-prs.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           source cf-scripts/autotick-bot/install_bot_code.sh
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: update prs
         if: success() && ! env.CI_SKIP
@@ -51,7 +51,7 @@ jobs:
           conda-forge-tick update-prs --job=${BOT_JOB} --n-jobs=4
         env:
           USERNAME: regro-cf-autotick-bot
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           BOT_JOB: ${{ matrix.job_num }}
           CF_TICK_GRAPH_DATA_BACKENDS: "${{ vars.CF_TICK_GRAPH_DATA_BACKENDS }}"
@@ -66,7 +66,7 @@ jobs:
           export CIRCLE_BUILD_NUM="actually-actions-${RUN_ID}"
           conda-forge-tick deploy-to-github
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
 
       - name: bump on fail
@@ -75,7 +75,7 @@ jobs:
           export ACTION_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           python cf-scripts/autotick-bot/bump_bot_team.py
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           ACTION_NAME: ${{ github.workflow }}
 
@@ -125,6 +125,6 @@ jobs:
           export ACTION_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           python cf-scripts/autotick-bot/bump_bot_team.py
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           ACTION_NAME: ${{ github.workflow }}

--- a/.github/workflows/bot-pypi-mapping.yml
+++ b/.github/workflows/bot-pypi-mapping.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           source cf-scripts/autotick-bot/install_bot_code.sh
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: build import to package mapping
         if: success() && ! env.CI_SKIP
@@ -44,7 +44,7 @@ jobs:
 
           conda-forge-tick make-import-to-package-mapping
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: build pypi mapping
         if: success() && ! env.CI_SKIP
@@ -53,7 +53,7 @@ jobs:
 
           conda-forge-tick make-mappings
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: deploy
         if: github.ref == 'refs/heads/master' && ! cancelled() && ! env.CI_SKIP
@@ -64,7 +64,7 @@ jobs:
           export CIRCLE_BUILD_NUM="actually-actions-${RUN_ID}"
           conda-forge-tick deploy-to-github
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
 
       - name: bump on fail
@@ -73,6 +73,6 @@ jobs:
           export ACTION_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           python cf-scripts/autotick-bot/bump_bot_team.py
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           ACTION_NAME: ${{ github.workflow }}

--- a/.github/workflows/bot-update-status-page.yml
+++ b/.github/workflows/bot-update-status-page.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           source cf-scripts/autotick-bot/install_bot_code.sh
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: update status page
         if: success() && ! env.CI_SKIP
@@ -42,7 +42,7 @@ jobs:
 
           conda-forge-tick make-status-report
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: deploy
         if: github.ref == 'refs/heads/master' && ! cancelled() && ! env.CI_SKIP
@@ -53,7 +53,7 @@ jobs:
           export CIRCLE_BUILD_NUM="actually-actions-${RUN_ID}"
           conda-forge-tick deploy-to-github
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
 
       - name: bump on fail
@@ -62,6 +62,6 @@ jobs:
           export ACTION_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           python cf-scripts/autotick-bot/bump_bot_team.py
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           ACTION_NAME: ${{ github.workflow }}

--- a/.github/workflows/bot-versions.yml
+++ b/.github/workflows/bot-versions.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           source cf-scripts/autotick-bot/install_bot_code.sh
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: get versions
         if: success() && ! env.CI_SKIP
@@ -61,7 +61,7 @@ jobs:
           export CIRCLE_BUILD_NUM="actually-actions-${RUN_ID}"
           conda-forge-tick deploy-to-github
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
 
       - name: bump on fail
@@ -70,6 +70,6 @@ jobs:
           export ACTION_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           python cf-scripts/autotick-bot/bump_bot_team.py
         env:
-          PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           ACTION_NAME: ${{ github.workflow }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,8 +77,8 @@ jobs:
 
       - name: run pytest
         run: |
-          export TEST_PASSWORD_VAL=unpassword
-          export PASSWORD=${TEST_PASSWORD_VAL}
+          export TEST_BOT_TOKEN_VAL=unpassword
+          export BOT_TOKEN=${TEST_BOT_TOKEN_VAL}
           pytest \
             -v \
             --cov=conda_forge_tick \

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ This is an important number to know when proposing a migration
 - `CIRCLE_BUILD_NUM`: set to the build number of the CI build (now set to `actually-actions-<GHA run id>`)
 - `MEMORY_LIMIT_GB`: set to the memory limit in GB for the bot
 - `USERNAME`: the username of the GitHub account being used as the bot (usually `regro-cf-autotick-bot`)
-- `PASSWORD`: a GitHub token for the bot user
+- `BOT_TOKEN`: a GitHub token for the bot user
 
 ### `conda-forge-tick` Container Image and Dockerfile
 

--- a/autotick-bot/bump_bot_team.py
+++ b/autotick-bot/bump_bot_team.py
@@ -8,7 +8,7 @@ if os.environ["ACTION_NAME"] == "bot-bot":
 else:
     user = "@beckermr"
 
-gh = github.Github(os.environ["PASSWORD"])
+gh = github.Github(os.environ["BOT_TOKEN"])
 
 repo = gh.get_repo("regro/cf-scripts")
 

--- a/autotick-bot/delete_old_runs.py
+++ b/autotick-bot/delete_old_runs.py
@@ -6,7 +6,7 @@ import time
 import github
 import requests
 
-gh = github.Github(os.environ["GITHUB_TOKEN"])
+gh = github.Github(os.environ["BOT_TOKEN"])
 r = gh.get_repo("regro/cf-scripts")
 done = 0
 for w in r.get_workflows():
@@ -16,7 +16,7 @@ for w in r.get_workflows():
         ):
             requests.delete(
                 rn.url,
-                headers={"Authorization": "Bearer " + os.environ["GITHUB_TOKEN"]},
+                headers={"Authorization": "Bearer " + os.environ["BOT_TOKEN"]},
             )
             done += 1
             time.sleep(1)

--- a/conda_forge_tick/all_feedstocks.py
+++ b/conda_forge_tick/all_feedstocks.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 def get_all_feedstocks_from_github():
     with sensitive_env() as env:
-        gh = github.Github(env["PASSWORD"], per_page=100)
+        gh = github.Github(env["BOT_TOKEN"], per_page=100)
 
     org = gh.get_organization("conda-forge")
     archived = set()

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -1568,8 +1568,8 @@ def main(ctx: CliContext) -> None:
 
     with sensitive_env() as env:
         github_username = env.get("USERNAME", "")
-        github_password = env.get("PASSWORD", "")
-        github_token = env.get("GITHUB_TOKEN")
+        github_password = env.get("BOT_TOKEN", "")
+        github_token = env.get("BOT_TOKEN")
 
     mctx, temp, migrators = initialize_migrators(
         github_username=github_username,

--- a/conda_forge_tick/deploy.py
+++ b/conda_forge_tick/deploy.py
@@ -69,12 +69,12 @@ def _deploy_batch(*, files_to_add, batch, n_added, max_per_batch=100):
                         "git",
                         "push",
                         "https://{token}@github.com/{deploy_repo}.git".format(
-                            token=env.get("PASSWORD", ""),
+                            token=env.get("BOT_TOKEN", ""),
                             deploy_repo="regro/cf-graph-countyfair",
                         ),
                         "master",
                     ],
-                    token=env.get("PASSWORD", "").encode("utf-8"),
+                    token=env.get("BOT_TOKEN", "").encode("utf-8"),
                 )
             num_try += 1
 

--- a/conda_forge_tick/env_management.py
+++ b/conda_forge_tick/env_management.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 class SensitiveEnv:
     SENSITIVE_KEYS = [
         "USERNAME",
-        "PASSWORD",
+        "BOT_TOKEN",
         "GITHUB_TOKEN",
         "GH_TOKEN",
         "MONGODB_CONNECTION_STRING",

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -76,7 +76,7 @@ def get_default_branch(feedstock_name):
     """
     with sensitive_env() as env:
         return (
-            github.Github(env["PASSWORD"])
+            github.Github(env["BOT_TOKEN"])
             .get_repo(f"conda-forge/{feedstock_name}-feedstock")
             .default_branch
         )

--- a/conda_forge_tick/update_prs.py
+++ b/conda_forge_tick/update_prs.py
@@ -46,8 +46,8 @@ def _update_pr(update_function, dry_run, gx, job, n_jobs):
 
     with sensitive_env() as env:
         github_username = env.get("USERNAME", "")
-        github_password = env.get("PASSWORD", "")
-        github_token = env.get("GITHUB_TOKEN")
+        github_password = env.get("BOT_TOKEN", "")
+        github_token = env.get("BOT_TOKEN")
 
     ghctx = GithubContext(
         github_username=github_username,

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -672,10 +672,10 @@ def frozen_to_json_friendly(fz, pr: Optional[LazyJson] = None):
 
 def github_client() -> github3.GitHub:
     with sensitive_env() as env:
-        if env.get("GITHUB_TOKEN"):
-            return github3.login(token=env["GITHUB_TOKEN"])
+        if env.get("BOT_TOKEN"):
+            return github3.login(token=env["BOT_TOKEN"])
         else:
-            return github3.login(env["USERNAME"], env["PASSWORD"])
+            return github3.login(env["USERNAME"], env["BOT_TOKEN"])
 
 
 @typing.overload

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,9 @@ from conda_forge_tick import global_sensitive_env
 
 @pytest.fixture
 def env_setup():
-    if "TEST_PASSWORD_VAL" not in os.environ:
-        old_pwd = os.environ.pop("PASSWORD", None)
-        os.environ["PASSWORD"] = "unpassword"
+    if "TEST_BOT_TOKEN_VAL" not in os.environ:
+        old_pwd = os.environ.pop("BOT_TOKEN", None)
+        os.environ["BOT_TOKEN"] = "unpassword"
         global_sensitive_env.hide_env_vars()
 
     old_pwd2 = os.environ.pop("pwd", None)
@@ -17,10 +17,10 @@ def env_setup():
 
     yield
 
-    if "TEST_PASSWORD_VAL" not in os.environ:
+    if "TEST_BOT_TOKEN_VAL" not in os.environ:
         global_sensitive_env.reveal_env_vars()
         if old_pwd:
-            os.environ["PASSWORD"] = old_pwd
+            os.environ["BOT_TOKEN"] = old_pwd
 
     if old_pwd2:
         os.environ["pwd"] = old_pwd2

--- a/tests/test_env_management.py
+++ b/tests/test_env_management.py
@@ -4,29 +4,29 @@ from conda_forge_tick.env_management import SensitiveEnv
 
 
 def test_simple_sensitive_env(env_setup):
-    os.environ["PASSWORD"] = "hi"
+    os.environ["BOT_TOKEN"] = "hi"
     s = SensitiveEnv()
 
     s.hide_env_vars()
-    assert "PASSWORD" not in os.environ
+    assert "BOT_TOKEN" not in os.environ
 
     s.reveal_env_vars()
-    assert "PASSWORD" in os.environ
-    assert os.environ["PASSWORD"] == "hi"
+    assert "BOT_TOKEN" in os.environ
+    assert os.environ["BOT_TOKEN"] == "hi"
 
 
 def test_ctx_sensitive_env(env_setup):
-    os.environ["PASSWORD"] = "hi"
+    os.environ["BOT_TOKEN"] = "hi"
     s = SensitiveEnv()
 
     with s.sensitive_env():
-        assert "PASSWORD" in os.environ
-        assert os.environ["PASSWORD"] == "hi"
-    assert "PASSWORD" not in os.environ
+        assert "BOT_TOKEN" in os.environ
+        assert os.environ["BOT_TOKEN"] == "hi"
+    assert "BOT_TOKEN" not in os.environ
 
 
 def test_double_sensitive_env(env_setup):
-    os.environ["PASSWORD"] = "hi"
+    os.environ["BOT_TOKEN"] = "hi"
     os.environ["pwd"] = "hello"
     s = SensitiveEnv()
     s.hide_env_vars()
@@ -34,4 +34,4 @@ def test_double_sensitive_env(env_setup):
     s.hide_env_vars()
     s.reveal_env_vars()
     assert os.environ["pwd"] == "hello"
-    assert os.environ["PASSWORD"] == "hi"
+    assert os.environ["BOT_TOKEN"] == "hi"

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -16,7 +16,7 @@ def test_env_is_protected_against_malicious_recipes(tmpdir, caplog, env_setup):
 
     source:
       url:
-        - https://{{ os.environ["PASSWORD"][0] }}/{{ os.environ["PASSWORD"][1:] }}
+        - https://{{ os.environ["BOT_TOKEN"][0] }}/{{ os.environ["BOT_TOKEN"][1:] }}
         - {{ os.environ['pwd'] }}
       sha256: dca77e463c56d42bbf915197c9b95e98913c85bef150d2e1dd18626b8c2c9c32
     build:
@@ -49,7 +49,7 @@ def test_env_is_protected_against_malicious_recipes(tmpdir, caplog, env_setup):
     extra:
       recipe-maintainers:
         - kthyng
-        - {{ os.environ["PASSWORD"] }}
+        - {{ os.environ["BOT_TOKEN"] }}
     """  # noqa
     caplog.set_level(
         logging.DEBUG,
@@ -66,7 +66,7 @@ def test_env_is_protected_against_malicious_recipes(tmpdir, caplog, env_setup):
     pmy = populate_feedstock_attributes("blah", {}, in_yaml, "{}")
 
     # This url gets saved in https://github.com/regro/cf-graph-countyfair
-    pswd = os.environ.get("TEST_PASSWORD_VAL", "unpassword")
+    pswd = os.environ.get("TEST_BOT_TOKEN_VAL", "unpassword")
     tst_url = f"https://{pswd[0]}/{pswd[1:]}"
     assert pmy["url"][0] != tst_url
     assert pmy["url"][1] is None


### PR DESCRIPTION
This PR centralizes all of the tokens to just be BOT_TOKEN as opposed to GITHUB_TOKEN and PASSWORD.