### PR TITLE
DEP do not set attrs on migrator

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -202,9 +202,6 @@ def run(
     os.chdir(BOT_HOME_DIR)
 
     # get the repo
-    # TODO: stop doing this.
-    migrator.attrs = feedstock_ctx.attrs  # type: ignore
-
     branch_name = migrator.remote_branch(feedstock_ctx) + "_h" + uuid4().hex[0:6]
 
     if hasattr(migrator, "name"):


### PR DESCRIPTION
I am cleaning up yet more shared state in prep for running migrators in separate processes.