### PR TITLE
BUG did not set container run env var properly

### DIFF
--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -124,7 +124,8 @@ def get_default_container_run_args(tmpfs_size_mb: int = 10):
     return [
         "docker",
         "run",
-        "-e CF_TICK_IN_CONTAINER='true'",
+        "-e",
+        "CF_TICK_IN_CONTAINER=true",
         "--security-opt=no-new-privileges",
         "--read-only",
         "--cap-drop=all",


### PR DESCRIPTION
This one fixes a bug where the container run env var was not being set properly.