### PR TITLE
add stdlib piggyback to version_migrator

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -1052,6 +1052,7 @@ def initialize_migrators(
                 PipWheelMigrator(),
                 MPIPinRunAsBuildCleanup(),
                 DependencyUpdateMigrator(python_nodes),
+                StdlibMigrator(),
             ],
         )
 

--- a/conda_forge_tick/migrators/cstdlib.py
+++ b/conda_forge_tick/migrators/cstdlib.py
@@ -20,7 +20,7 @@ pat_compiler = re.compile(
 )
 pat_stdlib = re.compile(r".*\{\{\s*stdlib\([\"\']c[\"\']\)\s*\}\}.*")
 # no version other than 2.17 currently available (except 2.12 as default on linux-64)
-pat_sysroot_217 = re.compile(r"- sysroot_linux-64\s*=?=?2\.17")
+pat_sysroot_217 = re.compile(r"- sysroot_(linux-64|\{\{.*\}\})\s*=?=?2\.17")
 
 
 def _process_section(name, attrs, lines):


### PR DESCRIPTION
This was already brought up in #2372, and discussed in today's core call as well (no objection to turning it on despite the limitation about templated output names). Since we haven't had any notable issues I can remember over the last ~2 weeks, I think it's a good time to add it to the version migrator as well now.

Also pick up a drive-by fix for making the sysroot regex pattern catch some more relevant cases.