### PR TITLE
add mini-piggyback migrator for removing `pin_compatible("numpy"...)`

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -85,6 +85,7 @@ from conda_forge_tick.migrators import (
     Migrator,
     MPIPinRunAsBuildCleanup,
     NoCondaInspectMigrator,
+    Numpy2Migrator,
     PipMigrator,
     PipWheelMigrator,
     QtQtMainMigrator,
@@ -679,6 +680,8 @@ def add_rebuild_migration_yaml(
         piggy_back_migrations.append(JpegTurboMigrator())
     if migration_name == "boost_cpp_to_libboost":
         piggy_back_migrations.append(LibboostMigrator())
+    if migration_name == "numpy2":
+        piggy_back_migrations.append(Numpy2Migrator())
     # stdlib migrator runs on top of ALL migrations, see
     # https://github.com/conda-forge/conda-forge.github.io/issues/2102
     piggy_back_migrations.append(StdlibMigrator())

--- a/conda_forge_tick/migrators/__init__.py
+++ b/conda_forge_tick/migrators/__init__.py
@@ -25,6 +25,7 @@ from .license import LicenseMigrator
 from .matplotlib_base import MatplotlibBase
 from .migration_yaml import MigrationYaml, MigrationYamlCreator, merge_migrator_cbc
 from .mpi_pin_run_as_build import MPIPinRunAsBuildCleanup
+from .numpy2 import Numpy2Migrator
 from .pip_check import PipCheckMigrator
 from .pip_wheel_dep import PipWheelMigrator
 from .qt_to_qt_main import QtQtMainMigrator

--- a/conda_forge_tick/migrators/numpy2.py
+++ b/conda_forge_tick/migrators/numpy2.py
@@ -1,0 +1,47 @@
+import os
+import re
+
+from conda_forge_tick.migrators.core import MiniMigrator
+from conda_forge_tick.migrators.libboost import _replacer, _slice_into_output_sections
+
+# pin_compatible("numpy"...)
+# ^   ^           ^
+# p   c           n
+raw_pat_pcn = r".*\{\{\s*pin_compatible\([\"\']numpy[\"\'].*"
+pat_pcn = re.compile(raw_pat_pcn)
+
+
+def _process_section(name, attrs, lines):
+    """
+    Migrate requirements per section.
+
+    We want to migrate as follows:
+    - remove all occurrences of `{{ pin_compatible("numpy",...) }}`;
+      these will be taken care of henceforth by numpy's run-export
+    """
+    # _replacer take the raw pattern, not the compiled one
+    lines = _replacer(lines, raw_pat_pcn, "")
+    return lines
+
+
+class Numpy2Migrator(MiniMigrator):
+    def filter(self, attrs, not_bad_str_start=""):
+        lines = attrs["raw_meta_yaml"].splitlines()
+        has_pcn = any(pat_pcn.search(line) for line in lines)
+        # filter() returns True if we _don't_ want to migrate
+        return not (has_pcn)
+
+    def migrate(self, recipe_dir, attrs, **kwargs):
+        fname = os.path.join(recipe_dir, "meta.yaml")
+        if os.path.exists(fname):
+            with open(fname) as fp:
+                lines = fp.readlines()
+
+            new_lines = []
+            sections = _slice_into_output_sections(lines, attrs)
+            for name, section in sections.items():
+                # _process_section returns list of lines already
+                new_lines += _process_section(name, attrs, section)
+
+            with open(fname, "w") as fp:
+                fp.write("".join(new_lines))

--- a/conda_forge_tick/migrators/numpy2.py
+++ b/conda_forge_tick/migrators/numpy2.py
@@ -2,26 +2,13 @@ import os
 import re
 
 from conda_forge_tick.migrators.core import MiniMigrator
-from conda_forge_tick.migrators.libboost import _replacer, _slice_into_output_sections
+from conda_forge_tick.migrators.libboost import _replacer
 
 # pin_compatible("numpy"...)
 # ^   ^           ^
 # p   c           n
 raw_pat_pcn = r".*\{\{\s*pin_compatible\([\"\']numpy[\"\'].*"
 pat_pcn = re.compile(raw_pat_pcn)
-
-
-def _process_section(name, attrs, lines):
-    """
-    Migrate requirements per section.
-
-    We want to migrate as follows:
-    - remove all occurrences of `{{ pin_compatible("numpy",...) }}`;
-      these will be taken care of henceforth by numpy's run-export
-    """
-    # _replacer take the raw pattern, not the compiled one
-    lines = _replacer(lines, raw_pat_pcn, "")
-    return lines
 
 
 class Numpy2Migrator(MiniMigrator):
@@ -37,11 +24,8 @@ class Numpy2Migrator(MiniMigrator):
             with open(fname) as fp:
                 lines = fp.readlines()
 
-            new_lines = []
-            sections = _slice_into_output_sections(lines, attrs)
-            for name, section in sections.items():
-                # _process_section returns list of lines already
-                new_lines += _process_section(name, attrs, section)
+            # _replacer take the raw pattern, not the compiled one
+            new_lines = _replacer(lines, raw_pat_pcn, "")
 
             with open(fname, "w") as fp:
                 fp.write("".join(new_lines))


### PR DESCRIPTION
Fixes #2469; goes hand-in-hand with (the migrator filename used in) https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5790

This is a baby version of #2135 / #1668, where we've already extensively tested the used functionality. Strictly speaking, we could even avoid the whole dance with `_slice_into_output_sections` and just directly remove any lines matching the regex pattern for `pin_compatible("numpy",...)` in the meta.yaml. However, I left it in for now in case anyone wants to add some logic that takes into account existing host-/run-dependencies, because then we need to operate on a per-section basis.