### PR TITLE
PROD more log clean up

### DIFF
--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -1,4 +1,20 @@
-#!/bin/bash -il
+#!/bin/bash
+
+# replicate bash profile loading
+# if we use -il above, we get extra output to stderr that we cannot
+# suppress, so we do this manually
+if [ -f /etc/profile ]; then
+    source /etc/profile
+fi
+for fname in  ".bash_profile" ".bash_login" ".profile"; do
+    if [ -f $HOME/$fname ]; then
+        source $HOME/$fname
+        break
+    fi
+done
+if [ -f $HOME/.bashrc ]; then
+    source $HOME/.bashrc
+fi
 
 conda activate cf-scripts
 

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -1,20 +1,4 @@
-#!/bin/bash
-
-# replicate bash profile loading
-# if we use -il above, we get extra output to stderr that we cannot
-# suppress, so we do this manually
-if [ -f /etc/profile ]; then
-    source /etc/profile
-fi
-for fname in  ".bash_profile" ".bash_login" ".profile"; do
-    if [ -f $HOME/$fname ]; then
-        source $HOME/$fname
-        break
-    fi
-done
-if [ -f $HOME/.bashrc ]; then
-    source $HOME/.bashrc
-fi
+#!/bin/bash -il
 
 conda activate cf-scripts
 

--- a/tests/test_rerender_feedstock.py
+++ b/tests/test_rerender_feedstock.py
@@ -6,7 +6,7 @@ from conda_forge_tick.os_utils import pushd
 from conda_forge_tick.rerender_feedstock import rerender_feedstock_local
 
 
-def test_rerender_feedstock_stderr(capfd):
+def test_rerender_feedstock_local_stderr(capfd):
     with tempfile.TemporaryDirectory() as tmpdir, pushd(tmpdir):
         subprocess.run(
             ["git", "clone", "https://github.com/conda-forge/ngmix-feedstock.git"]
@@ -41,7 +41,7 @@ def test_rerender_feedstock_stderr(capfd):
         ), f"msg: {msg}\nout: {captured.out}\nerr: {captured.err}"
 
 
-def test_rerender_feedstock_git_staged():
+def test_rerender_feedstock_local_git_staged():
     with tempfile.TemporaryDirectory() as tmpdir, pushd(tmpdir):
         subprocess.run(
             ["git", "clone", "https://github.com/conda-forge/ngmix-feedstock.git"]


### PR DESCRIPTION
So `set +m` is broken maybe and that might happen too late, so we load the profile bits by hand.

https://stackoverflow.com/questions/13300764/how-to-tell-bash-not-to-issue-warnings-cannot-set-terminal-process-group-and