### PR TITLE
Update pypi_name_mapping_static.yaml to add igl

### DIFF
--- a/conda_forge_tick/pypi_name_mapping_static.yaml
+++ b/conda_forge_tick/pypi_name_mapping_static.yaml
@@ -115,3 +115,7 @@
 - pypi_name: lrcalc
   import_name: lrcalc
   conda_name: python-lrcalc
+
+- pypi_name: libigl
+  import_name: igl
+  conda_name: igl


### PR DESCRIPTION
igl-feedstock is the python bindings. After install of igl, `pip check` fails, e.g.:
`napari-threedee 0.0.17 requires libigl, which is not installed.`
On pypi this package is `libigl`, even though the import is igl.
I think this PR should harmonize that?

<!--
Thanks for contributing to cf-scripts!
We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

- [x] Pydantic model updated or no update needed
