### PR TITLE
keep formatting of migrator commit_message; consistently use quote indent

### DIFF
--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -305,8 +305,8 @@ class MigrationYaml(GraphMigrator):
                 )
             )
 
-        commit_body = " ".join(
-            [e for e in self.commit_message(feedstock_ctx).splitlines()[1:] if e],
+        commit_body = "\n> ".join(
+            self.commit_message(feedstock_ctx).splitlines()[1:],
         )
         if commit_body:
             additional_body += (


### PR DESCRIPTION
The formatting of the commit message in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5790 gets completely busted by stripping all linebreaks here (presumably done to use a single quote indent?!), see for example: https://github.com/conda-forge/matplotlib-feedstock/pull/376.

To fix this, keep whitespace unchanged and indent the quote correctly, the processed `additional_body` would look like this:

<details>
<summary>raw</summary>

Note extra `> ` at the top because we're only slicing the `splitlines()` from `[1:]`, which I've kept because it's a security if someone forgets the double-linebreak. It doesn't get rendered anyway.

```
>
> TL;DR: The way we build against numpy has changed as of numpy 2.0. This bot
> PR has updated the recipe to account for the changes (see below for details).
> The numpy 2.0 package itself is currently only available from a special release
> channel (`conda-forge/label/numpy_rc`) and will not be available on the main
> `conda-forge` channel until the release of numpy 2.0 GA.
>
> The biggest change is that we no longer need to use the oldest available numpy
> version at build time in order to support old numpy version at runtime - numpy
> will by default use a compatible ABI for the oldest still-supported numpy versions.
>
> Additionally, we no longer need to use `{{ pin_compatible("numpy") }}` as a
> run requirement - this has been handled for more than two years now by a
> run-export on the numpy package itself. The migrator will therefore remove
> any occurrences of this.
>
> However, by default, building against numpy 2.0 will assume that the package
> is compatible with numpy 2.0, which is not necessarily the case. You should
> check that the upstream package explicitly supports numpy 2.0, otherwise you
> need to add a `- numpy <2` run requirement until that happens (check numpy
> issue 26191 for an overview of the most important packages).
>
> Note that the numpy release candidate promises to be ABI-compatible with the
> final 2.0 release. This means that building against 2.0.0rc1 produces packages
> that can be published to our main channels.
>
> If you already want to use the numpy 2.0 release candidate yourself, you can do
> ```
> conda config --add channels conda-forge/label/numpy_rc
> ```
> or add this channel to your `.condarc` file directly.
>
> ### To-Dos:
>   * [ ] Match run-requirements for numpy (i.e. check upstream `pyproject.toml` or however the project specifies numpy compatibility)
>     * If upstream is not yet compatible with numpy 2.0, add `numpy <2` upper bound under `run:`.
>     * If upstream is already compatible with numpy 2.0, nothing else should be necessary in most cases.
>     * If upstream requires a minimum numpy version newer than 1.19, you can add `numpy >=x.y` under `run:`.
>   * [ ] Remove any remaining occurrences of `{{ pin_compatible("numpy") }}` that the bot may have missed.
>
> PS. If the build does not compile anymore, this is almost certainly a sign that
> the upstream project is not yet ready for numpy 2.0; do not close this PR until
> a version compatible with numpy 2.0 has been released upstream and on this
> feedstock (in the meantime, you can keep the bot from reopening this PR in
> case of git conflicts by marking it as a draft).

<hr>
```

</details>

<details>
<summary>rendered</summary>

>
> TL;DR: The way we build against numpy has changed as of numpy 2.0. This bot
> PR has updated the recipe to account for the changes (see below for details).
> The numpy 2.0 package itself is currently only available from a special release
> channel (`conda-forge/label/numpy_rc`) and will not be available on the main
> `conda-forge` channel until the release of numpy 2.0 GA.
>
> The biggest change is that we no longer need to use the oldest available numpy
> version at build time in order to support old numpy version at runtime - numpy
> will by default use a compatible ABI for the oldest still-supported numpy versions.
>
> Additionally, we no longer need to use `{{ pin_compatible("numpy") }}` as a
> run requirement - this has been handled for more than two years now by a
> run-export on the numpy package itself. The migrator will therefore remove
> any occurrences of this.
>
> However, by default, building against numpy 2.0 will assume that the package
> is compatible with numpy 2.0, which is not necessarily the case. You should
> check that the upstream package explicitly supports numpy 2.0, otherwise you
> need to add a `- numpy <2` run requirement until that happens (check numpy
> issue 26191 for an overview of the most important packages).
>
> Note that the numpy release candidate promises to be ABI-compatible with the
> final 2.0 release. This means that building against 2.0.0rc1 produces packages
> that can be published to our main channels.
>
> If you already want to use the numpy 2.0 release candidate yourself, you can do
> ```
> conda config --add channels conda-forge/label/numpy_rc
> ```
> or add this channel to your `.condarc` file directly.
>
> ### To-Dos:
>   * [ ] Match run-requirements for numpy (i.e. check upstream `pyproject.toml` or however the project specifies numpy compatibility)
>     * If upstream is not yet compatible with numpy 2.0, add `numpy <2` upper bound under `run:`.
>     * If upstream is already compatible with numpy 2.0, nothing else should be necessary in most cases.
>     * If upstream requires a minimum numpy version newer than 1.19, you can add `numpy >=x.y` under `run:`.
>   * [ ] Remove any remaining occurrences of `{{ pin_compatible("numpy") }}` that the bot may have missed.
>
> PS. If the build does not compile anymore, this is almost certainly a sign that
> the upstream project is not yet ready for numpy 2.0; do not close this PR until
> a version compatible with numpy 2.0 has been released upstream and on this
> feedstock (in the meantime, you can keep the bot from reopening this PR in
> case of git conflicts by marking it as a draft).

<hr>

</details>