### PR TITLE
REF make libboost migrator more robust

### DIFF
--- a/conda_forge_tick/migrators/libboost.py
+++ b/conda_forge_tick/migrators/libboost.py
@@ -58,7 +58,9 @@ def _slice_into_output_sections(meta_yaml_lines, attrs):
     if pos < len(meta_yaml_lines):
         sections[section_index] = meta_yaml_lines[pos:]
 
-    # output_names may contain duplicates; remove them but keep order
+    # double check length here to flag possible weird cases
+    # this check will fail incorrectly for outputs with the same name
+    # but different build strings.
     outputs = attrs["meta_yaml"].get("outputs", [])
     outputs = {o["name"] for o in outputs}
     if len(sections) != len(outputs) + 1:

--- a/conda_forge_tick/migrators/libboost.py
+++ b/conda_forge_tick/migrators/libboost.py
@@ -12,10 +12,10 @@ def _slice_into_output_sections(meta_yaml_lines, attrs):
     single or multi-output recipes, we need to be able to
     restrict which lines we're operating on.
 
-    Takes a list of lines and returns a dict from each output name to
+    Takes a list of lines and returns a dict from each output index to
     the list of lines where this output is described in the meta.yaml.
-    The result will always contain a "global" section (== everything
-    if there are no other outputs).
+    The result will always contain an index -1 for the top-level section (
+    == everything if there are no other outputs).
     """
     outputs_token_pos = None
     re_output_start = None
@@ -57,6 +57,15 @@ def _slice_into_output_sections(meta_yaml_lines, attrs):
 
     if pos < len(meta_yaml_lines):
         sections[section_index] = meta_yaml_lines[pos:]
+
+    # output_names may contain duplicates; remove them but keep order
+    outputs = attrs["meta_yaml"].get("outputs", [])
+    outputs = {o["name"] for o in outputs}
+    if len(sections) != len(outputs) + 1:
+        raise RuntimeError(
+            f"Could not find all output sections in meta.yaml! "
+            f"Found {len(sections)} sections for outputs names = {outputs}.",
+        )
 
     return sections
 

--- a/conda_forge_tick/migrators/libboost.py
+++ b/conda_forge_tick/migrators/libboost.py
@@ -43,7 +43,7 @@ def _slice_into_output_sections(meta_yaml_lines, attrs):
         # it could be anything from the indent of the `outputs:` line to that number
         # plus zero or more spaces. Typically, the indent is the same as the `outputs:`
         # plus one of [0, 2, 4] spaces.
-        # ocne we find the first output list element, we build a regex to match any list
+        # once we find the first output list element, we build a regex to match any list
         # element at that indent level.
         if (
             outputs_token_pos is not None

--- a/conda_forge_tick/migrators/libboost.py
+++ b/conda_forge_tick/migrators/libboost.py
@@ -19,9 +19,9 @@ def _slice_into_output_sections(meta_yaml_lines, attrs):
     """
     outputs_token_pos = None
     re_output_start = None
-    re_outputs_token = re.compile(r"^\W*outputs:.*")
-    re_outputs_token_list = re.compile(r"^\W*outputs:\W*\[.*")
-    re_match_block_list = re.compile(r"^\W*\-.*")
+    re_outputs_token = re.compile(r"^\s*outputs:.*")
+    re_outputs_token_list = re.compile(r"^\s*outputs:\s*\[.*")
+    re_match_block_list = re.compile(r"^\s*\-.*")
 
     pos = 0
     section_index = -1
@@ -73,7 +73,7 @@ def _slice_into_output_sections(meta_yaml_lines, attrs):
     # finally, if a block list at the same indent happens after the outputs section ends
     # we'll have extra outputs that are not real. We remove them
     # by checking if there is a name key in the dict
-    re_name = re.compile(r"^\W*name:.*")
+    re_name = re.compile(r"^\s*(-\s+)?name:.*")
     final_sections = {}
     final_sections[-1] = sections[-1]  # we always keep the first global section
     final_output_index = 0

--- a/tests/test_container_tasks.py
+++ b/tests/test_container_tasks.py
@@ -421,16 +421,16 @@ def test_provide_source_code_containerized():
             [
                 "git",
                 "clone",
-                "https://github.com/conda-forge/conda-forge-feedstock-check-solvable-feedstock.git",
+                "https://github.com/conda-forge/conda-smithy-feedstock.git",
             ]
         )
 
         with provide_source_code_containerized(
-            "conda-forge-feedstock-check-solvable-feedstock/recipe"
+            "conda-smithy-feedstock/recipe"
         ) as source_dir:
             assert os.path.exists(source_dir)
             assert os.path.isdir(source_dir)
-            assert "conda_forge_feedstock_check_solvable" in os.listdir(source_dir)
+            assert "conda_smithy" in os.listdir(source_dir)
             assert "pyproject.toml" in os.listdir(source_dir)
 
 

--- a/tests/test_libboost.py
+++ b/tests/test_libboost.py
@@ -80,6 +80,13 @@ outputs:
         host:
           - bar
     {{% jinja %}}
+
+    {{% jinja %}}
+    - name: blarg-jinja
+      requirements:
+        host:
+          - baz
+    {{% jinja %}}
     - requirements:
         host:
           - baz
@@ -95,9 +102,17 @@ about:
 """
     sections = _slice_into_output_sections(
         lines.splitlines(),
-        {"meta_yaml": {"outputs": [{"name": "blarg"}, {"name": "blarg2"}]}},
+        {
+            "meta_yaml": {
+                "outputs": [
+                    {"name": "blarg"},
+                    {"name": "blarg-jinja"},
+                    {"name": "blarg2"},
+                ]
+            }
+        },
     )
-    assert len(sections) == 3
+    assert len(sections) == 4
     assert sections[-1] == [
         "package:",
         "  name: blah",
@@ -116,8 +131,17 @@ about:
         "        host:",
         "          - bar",
         "    {{% jinja %}}",
+        "",
+        "    {{% jinja %}}",
     ]
     assert sections[1] == [
+        "    - name: blarg-jinja",
+        "      requirements:",
+        "        host:",
+        "          - baz",
+        "    {{% jinja %}}",
+    ]
+    assert sections[2] == [
         "    - requirements:",
         "        host:",
         "          - baz",

--- a/tests/test_libboost.py
+++ b/tests/test_libboost.py
@@ -113,48 +113,57 @@ about:
         },
     )
     assert len(sections) == 4
-    assert sections[-1] == [
-        "package:",
-        "  name: blah",
-        "  version: 1.0.0",
-        "",
-        "requirements:",
-        "  host:",
-        "    - foo",
-        "",
-        "outputs:",
-        "  # comment",
-    ]
-    assert sections[0] == [
-        "    - name: blarg  # comment",
-        "      requirements:",
-        "        host:",
-        "          - bar",
-        "    {{% jinja %}}",
-        "",
-        "    {{% jinja %}}",
-    ]
-    assert sections[1] == [
-        "    - name: blarg-jinja",
-        "      requirements:",
-        "        host:",
-        "          - baz",
-        "    {{% jinja %}}",
-    ]
-    assert sections[2] == [
-        "    - requirements:",
-        "        host:",
-        "          - baz",
-        "      name: blarg2",
-        "  {{% jinja %}}",
-        "",
-        "about:",
-        "  home: http://example.com",
-        "  license: MIT",
-        "  license_file:",
-        "    - file1",
-        "    - file2",
-    ]
+    assert (
+        sections[-1]
+        == """\
+package:
+  name: blah
+  version: 1.0.0
+
+requirements:
+  host:
+    - foo
+
+outputs:
+  # comment
+""".splitlines()
+    )
+    assert (
+        sections[0]
+        == """\
+    - name: blarg  # comment
+      requirements:
+        host:
+          - bar
+    {{% jinja %}}
+
+    {{% jinja %}}""".splitlines()
+    )
+    assert (
+        sections[1]
+        == """\
+    - name: blarg-jinja
+      requirements:
+        host:
+          - baz
+    {{% jinja %}}""".splitlines()
+    )
+    assert (
+        sections[2]
+        == """\
+    - requirements:
+        host:
+          - baz
+      name: blarg2
+  {{% jinja %}}
+
+about:
+  home: http://example.com
+  license: MIT
+  license_file:
+    - file1
+    - file2""".splitlines()
+    )
 
 
 def test_slice_into_output_sections_global_only():

--- a/tests/test_libboost.py
+++ b/tests/test_libboost.py
@@ -63,7 +63,7 @@ def test_boost(feedstock, new_ver, tmpdir):
     )
 
 
-def test_slice_into_output_sections():
+def test_slice_into_output_sections_multioutput():
     lines = """\
 package:
   name: blah
@@ -131,3 +131,28 @@ about:
         "    - file1",
         "    - file2",
     ]
+
+
+def test_slice_into_output_sections_global_only():
+    lines = """\
+package:
+  name: blah
+  version: 1.0.0
+
+requirements:
+  host:
+    - foo
+
+about:
+  home: http://example.com
+  license: MIT
+  license_file:
+    - file1
+    - file2
+"""
+    sections = _slice_into_output_sections(
+        lines.splitlines(),
+        {"meta_yaml": {}},
+    )
+    assert len(sections) == 1
+    assert sections[-1] == lines.splitlines()

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -45,21 +45,15 @@ VERSION_WITH_STDLIB = Version(
         # no-op on noatrch: python recipe
         ("rucio-clients", "34.3.0", False),
         # test recipe with templated name
-        pytest.param(
+        (
             "gz-common",
             "5_5.6.0",
             False,
-            marks=pytest.mark.xfail(
-                reason="Cannot currently slice templated output names!"
-            ),
         ),
-        pytest.param(
+        (
             "libhdbpp-timescale",
             "2.1.0",
             False,
-            marks=pytest.mark.xfail(
-                reason="Cannot currently slice names that happen to be quoted but are valid yaml!"
-            ),
         ),
     ],
 )

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -45,16 +45,9 @@ VERSION_WITH_STDLIB = Version(
         # no-op on noatrch: python recipe
         ("rucio-clients", "34.3.0", False),
         # test recipe with templated name
-        (
-            "gz-common",
-            "5_5.6.0",
-            False,
-        ),
-        (
-            "libhdbpp-timescale",
-            "2.1.0",
-            False,
-        ),
+        ("gz-common", "5_5.6.0", False),
+        # test recipe with quoting
+        ("libhdbpp-timescale", "2.1.0", False),
     ],
 )
 def test_stdlib(feedstock, new_ver, expect_cbc, tmpdir):

--- a/tests/test_yaml/stdlib_gz-common_after_meta.yaml
+++ b/tests/test_yaml/stdlib_gz-common_after_meta.yaml
@@ -1,6 +1,6 @@
 {% set repo_name = "gz-common" %}
 {% set component_name = repo_name.split('-')[1] %}
-{% set version = "5_5.5.1" %}
+{% set version = "5_5.6.0" %}
 {% set version_package = version.split('_')[1] %}
 {% set major_version = version.split('_')[0] %}
 {% set name = repo_name + major_version %}
@@ -13,7 +13,7 @@ package:
 
 source:
   - url: https://github.com/gazebosim/{{ repo_name }}/archive/{{ repo_name }}{{ version }}.tar.gz
-    sha256: d176a113db3324dd3598c3418285ea5afcb44286dba0b29f07ab1b0482df7748
+    sha256: 39d02930638c5da35bbdd4925385bfe10180a8166c9c649b8ae67e083a47130e
     patches:
       - librt_linkage.patch  # [linux]
       - macro_path_binary_relocation.patch
@@ -33,6 +33,7 @@ outputs:
       build:
         - {{ compiler('cxx') }}
         - {{ compiler('c') }}
+        - {{ stdlib("c") }}
         - ninja
         - cmake
         - pkg-config

--- a/tests/test_yaml/stdlib_libhdbpp-timescale_after_meta.yaml
+++ b/tests/test_yaml/stdlib_libhdbpp-timescale_after_meta.yaml
@@ -10,14 +10,14 @@ source:
   sha256: 6c8a9a906c29932bacb3ca68b5e8a164fd4ead7aa7965870d6889e9dbc201869
 
 build:
-  number: 1
+  number: 0
   skip: true  # [not linux]
   # Library doesn't link against libhdbpp (only headers used)
   ignore_run_exports:
     - libhdbpp
   # Prevent libhdb++timescale.so.{{ version }}.dbg to be modified
   # Will raise CRC mismatch otherwise!
-  binary_relocation:                               # [linux]
+  binary_relocation:   # [linux]
     - "lib/libhdb++timescale.so.{{ version }}"     # [linux]
   run_exports:
     - {{ pin_subpackage('libhdbpp-timescale', max_pin='x.x') }}
@@ -27,6 +27,7 @@ requirements:
     - cmake
     - make
     - {{ compiler('cxx') }}
+    - {{ stdlib("c") }}
     - libtool
     - pkg-config
   host:
@@ -42,26 +43,26 @@ test:
     - test -f ${PREFIX}/lib/libhdb++timescale${SHLIB_EXT}
     - test -f ${PREFIX}/lib/cmake/libhdbpp-timescale/libhdbpp-timescaleConfig.cmake
 
-outputs:                                                                              # [linux]
-  - name: "libhdbpp-timescale"                                                        # [linux]
-    files:                                                                            # [linux]
+outputs:   # [linux]
+  - name: "libhdbpp-timescale"  # [linux]
+    files:   # [linux]
       - "lib/libhdb++timescale.so"                                                    # [linux]
       - "lib/libhdb++timescale.so.2"                                                  # [linux]
       - "lib/libhdb++timescale.so.{{ version }}"                                      # [linux]
       - "lib/cmake/libhdbpp-timescale/"                                               # [linux]
 
-  - name: "libhdbpp-timescale-dbg"                                                    # [linux]
-    requirements:                                                                     # [linux]
-      host:                                                                           # [linux]
+  - name: "libhdbpp-timescale-dbg"  # [linux]
+    requirements:   # [linux]
+      host:   # [linux]
         # build string must depend on cpptango to have
         # different versions per cpptango
         - cpptango                                                                    # [linux]
-      run:                                                                            # [linux]
+      run:   # [linux]
         - "{{ pin_subpackage('libhdbpp-timescale', exact=True) }}"                    # [linux]
-    files:                                                                            # [linux]
+    files:   # [linux]
       - "lib/libhdb++timescale.so.{{ version }}.dbg"                                  # [linux]
-    test:                                                                             # [linux]
-      commands:                                                                       # [linux]
+    test:   # [linux]
+      commands:   # [linux]
         - "test -f ${PREFIX}/lib/libhdb++timescale${SHLIB_EXT}.${PKG_VERSION}.dbg"    # [linux]
 about:
   home: https://www.tango-controls.org


### PR DESCRIPTION
<!-- Put your changes here -->

<!--
Thanks for contributing to cf-scripts!
We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

- [ ] Pydantic model updated or no update needed
