### PR TITLE
TST run tests mostly without containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,33 @@ If your migrator needs special configuration, you should write a new factory fun
 
 ## Developer Documentation
 
+### Useful Environment Variables
+
+- `CF_TICK_GRAPH_DATA_BACKENDS`: See [`LazyJson` Data Structures and Backends](#lazyjson-data-structures-and-backends) below.
+- `CF_TICK_GRAPH_DATA_USE_FILE_CACHE`: See [`LazyJson` Data Structures and Backends](#lazyjson-data-structures-and-backends) below.
+- `MONGODB_CONNECTION_STRING`: See [`LazyJson` Data Structures and Backends](#lazyjson-data-structures-and-backends) below.
+- `CF_TICK_IN_CONTAINER`: set to `true` to indicate that the bot is running in a container, prevents container in container issues
+- `TIMEOUT`: set to the number of seconds to wait before timing out the bot
+- `RUN_URL`: set to the URL of the CI build (now set to a GHA run URL)
+- `MEMORY_LIMIT_GB`: set to the memory limit in GB for the bot
+- `BOT_TOKEN`: a GitHub token for the bot user
+
+### Running Tests
+
+The test suite relies on `pytest` and uses `docker`. To run the tests, use the following command:
+
+```bash
+pytest -v
+```
+
+If you want to test the `container` parts of the bot, you need to build the image first and use the `test` tag:
+
+```bash
+docker build -t conda-forge-tick:test .
+```
+
+The test suite will not run the container-based tests unless an image with this name and tag is present.
+
 ### Debugging Locally
 
 You can use the CLI of the bot to debug it locally. To do so, install the bot with the following command:
@@ -168,17 +195,6 @@ print(len(graph))
 ```
 
 This is an important number to know when proposing a migration
-
-### Useful Environment Variables
-
-- `CF_TICK_GRAPH_DATA_BACKENDS`: See [`LazyJson` Data Structures and Backends](#lazyjson-data-structures-and-backends) below.
-- `CF_TICK_GRAPH_DATA_USE_FILE_CACHE`: See [`LazyJson` Data Structures and Backends](#lazyjson-data-structures-and-backends) below.
-- `MONGODB_CONNECTION_STRING`: See [`LazyJson` Data Structures and Backends](#lazyjson-data-structures-and-backends) below.
-- `CF_TICK_IN_CONTAINER`: set to `true` to indicate that the bot is running in a container, prevents container in container issues
-- `TIMEOUT`: set to the number of seconds to wait before timing out the bot
-- `RUN_URL`: set to the URL of the CI build (now set to a GHA run URL)
-- `MEMORY_LIMIT_GB`: set to the memory limit in GB for the bot
-- `BOT_TOKEN`: a GitHub token for the bot user
 
 ### `conda-forge-tick` Container Image and Dockerfile
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,18 +39,26 @@ def set_cf_tick_pytest_envvar():
 
 
 @pytest.fixture(autouse=True, scope="session")
-def turn_off_containers_if_missing():
-    import subprocess
-
-    ret = subprocess.run(["docker", "--version"], capture_output=True)
-    have_docker = ret.returncode == 0
-
+def turn_off_containers_by_default():
     old_in_container = os.environ.get("CF_TICK_IN_CONTAINER")
 
-    if not have_docker:
-        # tell the code we are in a container so that it
-        # doesn't try to run docker commands
-        os.environ["CF_TICK_IN_CONTAINER"] = "true"
+    # tell the code we are in a container so that it
+    # doesn't try to run docker commands
+    os.environ["CF_TICK_IN_CONTAINER"] = "true"
+
+    yield
+
+    if old_in_container is None:
+        os.environ.pop("CF_TICK_IN_CONTAINER", None)
+    else:
+        os.environ["CF_TICK_IN_CONTAINER"] = old_in_container
+
+
+@pytest.fixture
+def use_containers():
+    old_in_container = os.environ.get("CF_TICK_IN_CONTAINER")
+
+    os.environ["CF_TICK_IN_CONTAINER"] = "false"
 
     yield
 

--- a/tests/test_container_tasks.py
+++ b/tests/test_container_tasks.py
@@ -2,7 +2,6 @@ import copy
 import glob
 import json
 import os
-import platform
 import subprocess
 import tempfile
 
@@ -30,7 +29,7 @@ from conda_forge_tick.utils import parse_meta_yaml_containerized, run_container_
 
 HAVE_CONTAINERS = (
     subprocess.run(["docker", "--version"], capture_output=True).returncode == 0
-) and platform.system() in ["Linux", "Darwin"]
+)
 
 if HAVE_CONTAINERS:
     HAVE_TEST_IMAGE = False

--- a/tests/test_container_tasks.py
+++ b/tests/test_container_tasks.py
@@ -32,7 +32,7 @@ HAVE_CONTAINERS = (
 
 
 @pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
-def test_container_tasks_get_latest_version():
+def test_container_tasks_get_latest_version(use_containers):
     data = run_container_task(
         "get-latest-version",
         ["--existing-feedstock-node-attrs", "conda-smithy"],
@@ -41,7 +41,7 @@ def test_container_tasks_get_latest_version():
 
 
 @pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
-def test_container_tasks_get_latest_version_json():
+def test_container_tasks_get_latest_version_json(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
         pushd(tmpdir),
@@ -61,7 +61,7 @@ def test_container_tasks_get_latest_version_json():
 
 
 @pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
-def test_get_latest_version_containerized():
+def test_get_latest_version_containerized(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
         pushd(tmpdir),
@@ -77,7 +77,7 @@ def test_get_latest_version_containerized():
 
 
 @pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
-def test_get_latest_version_containerized_mpas_tools():
+def test_get_latest_version_containerized_mpas_tools(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
         pushd(tmpdir),
@@ -93,7 +93,7 @@ def test_get_latest_version_containerized_mpas_tools():
 
 
 @pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
-def test_container_tasks_parse_feedstock():
+def test_container_tasks_parse_feedstock(use_containers):
     with tempfile.TemporaryDirectory() as tmpdir, pushd(tmpdir):
         data = run_container_task(
             "parse-feedstock",
@@ -112,7 +112,7 @@ def test_container_tasks_parse_feedstock():
 
 
 @pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
-def test_container_tasks_parse_feedstock_json():
+def test_container_tasks_parse_feedstock_json(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
         pushd(tmpdir),
@@ -132,7 +132,7 @@ def test_container_tasks_parse_feedstock_json():
 
 
 @pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
-def test_load_feedstock_containerized():
+def test_load_feedstock_containerized(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
         pushd(tmpdir),
@@ -148,7 +148,7 @@ def test_load_feedstock_containerized():
 
 
 @pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
-def test_load_feedstock_containerized_mpas_tools():
+def test_load_feedstock_containerized_mpas_tools(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
         pushd(tmpdir),
@@ -164,7 +164,7 @@ def test_load_feedstock_containerized_mpas_tools():
 
 
 @pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
-def test_parse_meta_yaml_containerized():
+def test_parse_meta_yaml_containerized(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
         pushd(tmpdir),
@@ -180,7 +180,7 @@ def test_parse_meta_yaml_containerized():
 
 
 @pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
-def test_rerender_feedstock_containerized_same_as_local(capfd):
+def test_rerender_feedstock_containerized_same_as_local(use_containers, capfd):
     with (
         tempfile.TemporaryDirectory() as tmpdir_cont,
         tempfile.TemporaryDirectory() as tmpdir_local,
@@ -294,7 +294,7 @@ def test_rerender_feedstock_containerized_same_as_local(capfd):
 
 
 @pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
-def test_rerender_feedstock_containerized_empty():
+def test_rerender_feedstock_containerized_empty(use_containers):
     with tempfile.TemporaryDirectory() as tmpdir_local:
         # first run the rerender locally
         with pushd(tmpdir_local):
@@ -344,7 +344,7 @@ def test_rerender_feedstock_containerized_empty():
 
 
 @pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
-def test_rerender_feedstock_containerized_permissions():
+def test_rerender_feedstock_containerized_permissions(use_containers):
     with tempfile.TemporaryDirectory() as tmpdir:
         with pushd(tmpdir):
             subprocess.run(
@@ -412,7 +412,7 @@ def test_rerender_feedstock_containerized_permissions():
 
 
 @pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
-def test_provide_source_code_containerized():
+def test_provide_source_code_containerized(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
         pushd(tmpdir),
@@ -435,7 +435,7 @@ def test_provide_source_code_containerized():
 
 
 @pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
-def test_is_recipe_solvable_containerized():
+def test_is_recipe_solvable_containerized(use_containers):
     with tempfile.TemporaryDirectory() as tmpdir:
         with pushd(tmpdir):
             subprocess.run(

--- a/tests/test_container_tasks.py
+++ b/tests/test_container_tasks.py
@@ -86,7 +86,7 @@ def test_container_tasks_get_latest_version_json(use_containers):
 @pytest.mark.skipif(
     not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
 )
-def test_get_latest_version_containerized(use_containers):
+def test_container_tasks_get_latest_version_containerized(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
         pushd(tmpdir),
@@ -104,7 +104,7 @@ def test_get_latest_version_containerized(use_containers):
 @pytest.mark.skipif(
     not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
 )
-def test_get_latest_version_containerized_mpas_tools(use_containers):
+def test_container_tasks_get_latest_version_containerized_mpas_tools(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
         pushd(tmpdir),
@@ -165,7 +165,7 @@ def test_container_tasks_parse_feedstock_json(use_containers):
 @pytest.mark.skipif(
     not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
 )
-def test_load_feedstock_containerized(use_containers):
+def test_container_tasks_load_feedstock_containerized(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
         pushd(tmpdir),
@@ -183,7 +183,7 @@ def test_load_feedstock_containerized(use_containers):
 @pytest.mark.skipif(
     not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
 )
-def test_load_feedstock_containerized_mpas_tools(use_containers):
+def test_container_tasks_load_feedstock_containerized_mpas_tools(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
         pushd(tmpdir),
@@ -201,7 +201,7 @@ def test_load_feedstock_containerized_mpas_tools(use_containers):
 @pytest.mark.skipif(
     not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
 )
-def test_parse_meta_yaml_containerized(use_containers):
+def test_container_tasks_parse_meta_yaml_containerized(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
         pushd(tmpdir),
@@ -219,7 +219,9 @@ def test_parse_meta_yaml_containerized(use_containers):
 @pytest.mark.skipif(
     not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
 )
-def test_rerender_feedstock_containerized_same_as_local(use_containers, capfd):
+def test_container_tasks_rerender_feedstock_containerized_same_as_local(
+    use_containers, capfd
+):
     with (
         tempfile.TemporaryDirectory() as tmpdir_cont,
         tempfile.TemporaryDirectory() as tmpdir_local,
@@ -335,7 +337,7 @@ def test_rerender_feedstock_containerized_same_as_local(use_containers, capfd):
 @pytest.mark.skipif(
     not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
 )
-def test_rerender_feedstock_containerized_empty(use_containers):
+def test_container_tasks_rerender_feedstock_containerized_empty(use_containers):
     with tempfile.TemporaryDirectory() as tmpdir_local:
         # first run the rerender locally
         with pushd(tmpdir_local):
@@ -387,7 +389,7 @@ def test_rerender_feedstock_containerized_empty(use_containers):
 @pytest.mark.skipif(
     not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
 )
-def test_rerender_feedstock_containerized_permissions(use_containers):
+def test_container_tasks_rerender_feedstock_containerized_permissions(use_containers):
     with tempfile.TemporaryDirectory() as tmpdir:
         with pushd(tmpdir):
             subprocess.run(
@@ -457,7 +459,7 @@ def test_rerender_feedstock_containerized_permissions(use_containers):
 @pytest.mark.skipif(
     not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
 )
-def test_provide_source_code_containerized(use_containers):
+def test_container_tasks_provide_source_code_containerized(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
         pushd(tmpdir),
@@ -482,7 +484,7 @@ def test_provide_source_code_containerized(use_containers):
 @pytest.mark.skipif(
     not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
 )
-def test_is_recipe_solvable_containerized(use_containers):
+def test_container_tasks_is_recipe_solvable_containerized(use_containers):
     with tempfile.TemporaryDirectory() as tmpdir:
         with pushd(tmpdir):
             subprocess.run(

--- a/tests/test_container_tasks.py
+++ b/tests/test_container_tasks.py
@@ -1,6 +1,7 @@
 import copy
 import glob
 import os
+import platform
 import subprocess
 import tempfile
 
@@ -28,7 +29,7 @@ from conda_forge_tick.utils import parse_meta_yaml_containerized, run_container_
 
 HAVE_CONTAINERS = (
     subprocess.run(["docker", "--version"], capture_output=True).returncode == 0
-)
+) and platform.system() in ["Linux", "Darwin"]
 
 
 @pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")

--- a/tests/test_container_tasks.py
+++ b/tests/test_container_tasks.py
@@ -1,5 +1,6 @@
 import copy
 import glob
+import json
 import os
 import platform
 import subprocess
@@ -31,8 +32,28 @@ HAVE_CONTAINERS = (
     subprocess.run(["docker", "--version"], capture_output=True).returncode == 0
 ) and platform.system() in ["Linux", "Darwin"]
 
+if HAVE_CONTAINERS:
+    HAVE_TEST_IMAGE = False
+    for line in subprocess.run(
+        [
+            "docker",
+            "images",
+            "--format",
+            "json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines():
+        image = json.loads(line)
+        if image["Repository"] == "conda-forge-tick" and image["Tag"] == "test":
+            HAVE_TEST_IMAGE = True
+            break
 
-@pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
+
+@pytest.mark.skipif(
+    not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
+)
 def test_container_tasks_get_latest_version(use_containers):
     data = run_container_task(
         "get-latest-version",
@@ -41,7 +62,9 @@ def test_container_tasks_get_latest_version(use_containers):
     assert data["new_version"] == conda_smithy.__version__
 
 
-@pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
+@pytest.mark.skipif(
+    not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
+)
 def test_container_tasks_get_latest_version_json(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
@@ -61,7 +84,9 @@ def test_container_tasks_get_latest_version_json(use_containers):
         assert data["new_version"] == conda_smithy.__version__
 
 
-@pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
+@pytest.mark.skipif(
+    not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
+)
 def test_get_latest_version_containerized(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
@@ -77,7 +102,9 @@ def test_get_latest_version_containerized(use_containers):
         assert data["new_version"] == conda_smithy.__version__
 
 
-@pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
+@pytest.mark.skipif(
+    not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
+)
 def test_get_latest_version_containerized_mpas_tools(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
@@ -93,7 +120,9 @@ def test_get_latest_version_containerized_mpas_tools(use_containers):
         assert data["new_version"] is not False
 
 
-@pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
+@pytest.mark.skipif(
+    not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
+)
 def test_container_tasks_parse_feedstock(use_containers):
     with tempfile.TemporaryDirectory() as tmpdir, pushd(tmpdir):
         data = run_container_task(
@@ -112,7 +141,9 @@ def test_container_tasks_parse_feedstock(use_containers):
         assert data["raw_meta_yaml"] == attrs["raw_meta_yaml"]
 
 
-@pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
+@pytest.mark.skipif(
+    not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
+)
 def test_container_tasks_parse_feedstock_json(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
@@ -132,7 +163,9 @@ def test_container_tasks_parse_feedstock_json(use_containers):
         assert data["raw_meta_yaml"] == attrs["raw_meta_yaml"]
 
 
-@pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
+@pytest.mark.skipif(
+    not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
+)
 def test_load_feedstock_containerized(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
@@ -148,7 +181,9 @@ def test_load_feedstock_containerized(use_containers):
         assert data["raw_meta_yaml"] == attrs["raw_meta_yaml"]
 
 
-@pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
+@pytest.mark.skipif(
+    not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
+)
 def test_load_feedstock_containerized_mpas_tools(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
@@ -164,7 +199,9 @@ def test_load_feedstock_containerized_mpas_tools(use_containers):
         assert data["raw_meta_yaml"] == attrs["raw_meta_yaml"]
 
 
-@pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
+@pytest.mark.skipif(
+    not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
+)
 def test_parse_meta_yaml_containerized(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
@@ -180,7 +217,9 @@ def test_parse_meta_yaml_containerized(use_containers):
         assert data["package"]["name"] == "conda-smithy"
 
 
-@pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
+@pytest.mark.skipif(
+    not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
+)
 def test_rerender_feedstock_containerized_same_as_local(use_containers, capfd):
     with (
         tempfile.TemporaryDirectory() as tmpdir_cont,
@@ -294,7 +333,9 @@ def test_rerender_feedstock_containerized_same_as_local(use_containers, capfd):
                 assert cdata == ldata, f"{cfname} not equal to local"
 
 
-@pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
+@pytest.mark.skipif(
+    not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
+)
 def test_rerender_feedstock_containerized_empty(use_containers):
     with tempfile.TemporaryDirectory() as tmpdir_local:
         # first run the rerender locally
@@ -344,7 +385,9 @@ def test_rerender_feedstock_containerized_empty(use_containers):
         assert msg is None
 
 
-@pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
+@pytest.mark.skipif(
+    not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
+)
 def test_rerender_feedstock_containerized_permissions(use_containers):
     with tempfile.TemporaryDirectory() as tmpdir:
         with pushd(tmpdir):
@@ -412,7 +455,9 @@ def test_rerender_feedstock_containerized_permissions(use_containers):
             assert orig_exec == cont_rerend_exec
 
 
-@pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
+@pytest.mark.skipif(
+    not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
+)
 def test_provide_source_code_containerized(use_containers):
     with (
         tempfile.TemporaryDirectory() as tmpdir,
@@ -435,7 +480,9 @@ def test_provide_source_code_containerized(use_containers):
             assert "pyproject.toml" in os.listdir(source_dir)
 
 
-@pytest.mark.skipif(not HAVE_CONTAINERS, reason="containers not available")
+@pytest.mark.skipif(
+    not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
+)
 def test_is_recipe_solvable_containerized(use_containers):
     with tempfile.TemporaryDirectory() as tmpdir:
         with pushd(tmpdir):

--- a/tests/test_upstream_versions.py
+++ b/tests/test_upstream_versions.py
@@ -451,10 +451,12 @@ def test_latest_version_rawurl(name, inp, curr_ver, ver, source, urls, tmpdir):
         assert ver == attempt["new_version"]
 
 
-def test_latest_version_ca_policy_lcg(capfd):
+def test_latest_version_ca_policy_lcg(capfd, caplog):
     assert get_latest_version("ca-policy-lcg", {}, [RawURL()]) == {"new_version": False}
     out, err = capfd.readouterr()
     all_output = out + err
+    for record in caplog.records:
+        all_output += record.getMessage()
     assert "ca-policy-lcg" in all_output
     assert "manually excluded" in all_output
 


### PR DESCRIPTION
This PR changes the tests to run mostly without containers. It also turns off container tests unless docker is available and the right image has been built locally.

closes #2550 
