### PR TITLE
ENH dump migrators to json

### DIFF
--- a/conda_forge_tick/migrators/__init__.py
+++ b/conda_forge_tick/migrators/__init__.py
@@ -2,7 +2,13 @@
 from .arch import ArchRebuild, OSXArm
 from .broken_rebuild import RebuildBroken
 from .conda_forge_yaml_cleanup import CondaForgeYAMLCleanup
-from .core import GraphMigrator, Migrator, MiniMigrator, Replacement
+from .core import (
+    GraphMigrator,
+    Migrator,
+    MiniMigrator,
+    Replacement,
+    make_from_lazy_json_data,
+)
 from .cos7 import Cos7Config
 from .cross_compile import (
     Build2HostMigrator,

--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -106,6 +106,17 @@ class ArchRebuild(GraphMigrator):
         pr_limit: int = 0,
         piggy_back_migrations: Optional[Sequence[MiniMigrator]] = None,
     ):
+        if not hasattr(self, "_init_args"):
+            self._init_args = []
+
+        if not hasattr(self, "_init_kwargs"):
+            self._init_kwargs = {
+                "graph": graph,
+                "name": name,
+                "pr_limit": pr_limit,
+                "piggy_back_migrations": piggy_back_migrations,
+            }
+
         # rebuild the graph to only use edges from the arm and power requirements
         graph2 = nx.create_empty_copy(graph)
         for node, attrs in graph.nodes(data="payload"):
@@ -226,6 +237,17 @@ class OSXArm(GraphMigrator):
         pr_limit: int = 0,
         piggy_back_migrations: Optional[Sequence[MiniMigrator]] = None,
     ):
+        if not hasattr(self, "_init_args"):
+            self._init_args = []
+
+        if not hasattr(self, "_init_kwargs"):
+            self._init_kwargs = {
+                "graph": graph,
+                "name": name,
+                "pr_limit": pr_limit,
+                "piggy_back_migrations": piggy_back_migrations,
+            }
+
         # rebuild the graph to only use edges from the arm osx requirements
         graph2 = nx.create_empty_copy(graph)
         for node, attrs in graph.nodes(data="payload"):

--- a/conda_forge_tick/migrators/broken_rebuild.py
+++ b/conda_forge_tick/migrators/broken_rebuild.py
@@ -325,6 +325,15 @@ class RebuildBroken(Migrator):
         outputs_lut,
         pr_limit: int = 0,
     ):
+        if not hasattr(self, "_init_args"):
+            self._init_args = []
+
+        if not hasattr(self, "_init_kwargs"):
+            self._init_kwargs = {
+                "outputs_lut": outputs_lut,
+                "pr_limit": pr_limit,
+            }
+
         super().__init__(1, check_solvable=False)
         self.name = "rebuild-broken"
 

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -81,6 +81,24 @@ def _migratror_hash(klass, args, kwargs):
     return hashlib.sha1(dumps(data).encode("utf-8")).hexdigest()
 
 
+def _make_migrator_lazy_json_name(mgr, data):
+    return (
+        mgr.name
+        if hasattr(mgr, "name")
+        else mgr.__class__.__name__
+        + (
+            ""
+            if len(mgr._init_args) == 0 and len(mgr._init_kwargs) == 0
+            else "_h"
+            + _migratror_hash(
+                data["class"],
+                data["args"],
+                data["kwargs"],
+            )
+        )
+    )
+
+
 def make_from_lazy_json_data(data):
     """Deserialize the migrator from LazyJson-compatible data."""
     import conda_forge_tick.migrators
@@ -151,17 +169,7 @@ class MiniMigrator:
             "args": self._init_args,
             "kwargs": self._init_kwargs,
         }
-        data["name"] = (
-            self.name
-            if hasattr(self, "name")
-            else self.__class__.__name__
-            + "_h"
-            + _migratror_hash(
-                data["class"],
-                data["args"],
-                data["kwargs"],
-            )
-        )
+        data["name"] = _make_migrator_lazy_json_name(self, data)
         return data
 
 
@@ -234,17 +242,7 @@ class Migrator:
             "args": self._init_args,
             "kwargs": kwargs,
         }
-        data["name"] = (
-            self.name
-            if hasattr(self, "name")
-            else self.__class__.__name__
-            + "_h"
-            + _migratror_hash(
-                data["class"],
-                data["args"],
-                data["kwargs"],
-            )
-        )
+        data["name"] = _make_migrator_lazy_json_name(self, data)
         return data
 
     def bind_to_ctx(self, migrator_ctx: MigratorContext) -> None:

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -107,7 +107,7 @@ def make_from_lazy_json_data(data):
 
     kwargs = copy.deepcopy(data["kwargs"])
     if (
-        "pigg_back_migrations" in kwargs
+        "piggy_back_migrations" in kwargs
         and kwargs["piggy_back_migrations"]
         and isinstance(kwargs["piggy_back_migrations"][0], dict)
     ):

--- a/conda_forge_tick/migrators/dep_updates.py
+++ b/conda_forge_tick/migrators/dep_updates.py
@@ -16,6 +16,12 @@ class DependencyUpdateMigrator(MiniMigrator):
     post_migration = True
 
     def __init__(self, python_nodes):
+        if not hasattr(self, "_init_args"):
+            self._init_args = [python_nodes]
+
+        if not hasattr(self, "_init_kwargs"):
+            self._init_kwargs = {}
+
         self.python_nodes = python_nodes
 
     def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -138,6 +138,26 @@ class MigrationYaml(GraphMigrator):
         max_solver_attempts=3,
         **kwargs: Any,
     ):
+        if not hasattr(self, "_init_args"):
+            self._init_args = [yaml_contents, name]
+
+        if not hasattr(self, "_init_kwargs"):
+            self._init_kwargs = {
+                "graph": graph,
+                "pr_limit": pr_limit,
+                "top_level": top_level,
+                "cycles": cycles,
+                "migration_number": migration_number,
+                "bump_number": bump_number,
+                "piggy_back_migrations": piggy_back_migrations,
+                "automerge": automerge,
+                "check_solvable": check_solvable,
+                "conda_forge_yml_patches": conda_forge_yml_patches,
+                "ignored_deps_per_node": ignored_deps_per_node,
+                "max_solver_attempts": max_solver_attempts,
+            }
+            self._init_kwargs.update(copy.deepcopy(kwargs))
+
         super().__init__(
             graph=graph,
             pr_limit=pr_limit,
@@ -436,6 +456,24 @@ class MigrationYamlCreator(Migrator):
         bump_number: int = 1,
         **kwargs: Any,
     ):
+        if not hasattr(self, "_init_args"):
+            self._init_args = [
+                package_name,
+                new_pin_version,
+                current_pin,
+                pin_spec,
+                feedstock_name,
+                graph,
+                full_graph,
+            ]
+
+        if not hasattr(self, "_init_kwargs"):
+            self._init_kwargs = {
+                "pr_limit": pr_limit,
+                "bump_number": bump_number,
+            }
+            self._init_kwargs.update(copy.deepcopy(kwargs))
+
         super().__init__(pr_limit=pr_limit)
         self.feedstock_name = feedstock_name
         self.pin_spec = pin_spec

--- a/conda_forge_tick/migrators/version.py
+++ b/conda_forge_tick/migrators/version.py
@@ -1,3 +1,4 @@
+import copy
 import functools
 import logging
 import os
@@ -56,6 +57,12 @@ class Version(Migrator):
     name = MigratorName.VERSION
 
     def __init__(self, python_nodes, *args, **kwargs):
+        if not hasattr(self, "_init_args"):
+            self._init_args = [python_nodes, *args]
+
+        if not hasattr(self, "_init_kwargs"):
+            self._init_kwargs = copy.deepcopy(kwargs)
+
         self.python_nodes = python_nodes
         if "check_solvable" in kwargs:
             kwargs.pop("check_solvable")

--- a/tests/test_migrator_to_json.py
+++ b/tests/test_migrator_to_json.py
@@ -75,3 +75,23 @@ def test_migrator_to_json_minimigrators():
             assert migrator2._init_kwargs == {}
             assert isinstance(migrator2, migrator.__class__)
             assert migrator2.to_lazy_json_data() == data
+
+
+def test_migrator_to_json_version():
+    migrator = conda_forge_tick.migrators.Version(
+        set(),
+        piggy_back_migrations=[
+            conda_forge_tick.migrators.DependencyUpdateMigrator(["blah"]),
+            conda_forge_tick.migrators.DependencyUpdateMigrator(["blah2"]),
+            conda_forge_tick.migrators.LibboostMigrator(),
+            conda_forge_tick.migrators.DuplicateLinesCleanup(),
+        ],
+    )
+    data = migrator.to_lazy_json_data()
+    dumps(data)
+    assert data["__migrator__"] is True
+    assert data["class"] == "Version"
+
+    migrator2 = conda_forge_tick.migrators.Migrator.from_lazy_json_data(data)
+    assert isinstance(migrator2, conda_forge_tick.migrators.Version)
+    assert migrator2.to_lazy_json_data() == data

--- a/tests/test_migrator_to_json.py
+++ b/tests/test_migrator_to_json.py
@@ -102,7 +102,14 @@ def test_migrator_to_json_migration_yaml_creator():
     pin_spec = "x.x"
 
     migrator = conda_forge_tick.migrators.MigrationYamlCreator(
-        pname, pin_ver, curr_pin, pin_spec, "hi", gx, gx
+        pname,
+        pin_ver,
+        curr_pin,
+        pin_spec,
+        "hi",
+        gx,
+        gx,
+        blah="foo",
     )
     data = migrator.to_lazy_json_data()
     pprint.pprint(data)

--- a/tests/test_migrator_to_json.py
+++ b/tests/test_migrator_to_json.py
@@ -3,6 +3,7 @@ import inspect
 
 import conda_forge_tick.migrators
 from conda_forge_tick.lazy_json_backends import dumps
+from conda_forge_tick.migrators import make_from_lazy_json_data
 
 
 def test_migrator_to_json_dep_update_minimigrator():
@@ -30,7 +31,7 @@ def test_migrator_to_json_dep_update_minimigrator():
         "class": "DependencyUpdateMigrator",
     }
 
-    migrator2 = conda_forge_tick.migrators.MiniMigrator.from_lazy_json_data(data)
+    migrator2 = make_from_lazy_json_data(data)
     assert migrator2._init_args == [python_nodes]
     assert migrator2._init_kwargs == {}
     assert isinstance(migrator2, conda_forge_tick.migrators.DependencyUpdateMigrator)
@@ -68,9 +69,7 @@ def test_migrator_to_json_minimigrators():
                 "class": migrator_name,
             }
 
-            migrator2 = conda_forge_tick.migrators.MiniMigrator.from_lazy_json_data(
-                data
-            )
+            migrator2 = make_from_lazy_json_data(data)
             assert migrator2._init_args == []
             assert migrator2._init_kwargs == {}
             assert isinstance(migrator2, migrator.__class__)
@@ -92,6 +91,6 @@ def test_migrator_to_json_version():
     assert data["__migrator__"] is True
     assert data["class"] == "Version"
 
-    migrator2 = conda_forge_tick.migrators.Migrator.from_lazy_json_data(data)
+    migrator2 = make_from_lazy_json_data(data)
     assert isinstance(migrator2, conda_forge_tick.migrators.Version)
     assert migrator2.to_lazy_json_data() == data

--- a/tests/test_migrator_to_json.py
+++ b/tests/test_migrator_to_json.py
@@ -93,7 +93,7 @@ def test_migrator_to_json_version():
 
 def test_migrator_to_json_migration_yaml_creator():
     gx = nx.DiGraph()
-    gx.add_node("conda", reqs=["python"], payload={})
+    gx.add_node("conda", reqs=["python"], payload={}, blah="foo")
     gx.graph["outputs_lut"] = {}
 
     pname = "boost"
@@ -106,8 +106,11 @@ def test_migrator_to_json_migration_yaml_creator():
     )
     data = migrator.to_lazy_json_data()
     pprint.pprint(data)
+    assert data["kwargs"]["blah"] == "foo"
+
     lzj_data = dumps(data)
     print("lazy json data:\n", lzj_data)
+
     assert data["__migrator__"] is True
     assert data["class"] == "MigrationYamlCreator"
     assert data["name"] == pname + " pinning"
@@ -142,13 +145,17 @@ def test_migrator_to_json_matplotlib_base():
 
 def test_migrator_to_json_migration_yaml():
     migrator = conda_forge_tick.migrators.MigrationYaml(
-        yaml_contents="hello world", name="hi"
+        yaml_contents="hello world",
+        name="hi",
+        blah="foo",
     )
 
     data = migrator.to_lazy_json_data()
     pprint.pprint(data)
+    assert data["kwargs"]["blah"] == "foo"
     lzj_data = dumps(data)
     print("lazy json data:\n", lzj_data)
+
     assert data["__migrator__"] is True
     assert data["class"] == "MigrationYaml"
     assert data["name"] == "hi"

--- a/tests/test_migrator_to_json.py
+++ b/tests/test_migrator_to_json.py
@@ -82,11 +82,18 @@ def test_migrator_to_json_version():
         ],
     )
     data = migrator.to_lazy_json_data()
+    pprint.pprint(data)
+
     lzj_data = dumps(data)
+    print("lazy json data:\n", lzj_data)
+
     assert data["__migrator__"] is True
     assert data["class"] == "Version"
 
     migrator2 = make_from_lazy_json_data(loads(lzj_data))
+    assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [
+        pgm.__class__.__name__ for pgm in migrator.piggy_back_migrations
+    ]
     assert isinstance(migrator2, conda_forge_tick.migrators.Version)
     assert dumps(migrator2.to_lazy_json_data()) == lzj_data
 
@@ -123,6 +130,9 @@ def test_migrator_to_json_migration_yaml_creator():
     assert data["name"] == pname + " pinning"
 
     migrator2 = make_from_lazy_json_data(loads(lzj_data))
+    assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [
+        pgm.__class__.__name__ for pgm in migrator.piggy_back_migrations
+    ]
     assert isinstance(migrator2, conda_forge_tick.migrators.MigrationYamlCreator)
     assert dumps(migrator2.to_lazy_json_data()) == lzj_data
 
@@ -146,6 +156,9 @@ def test_migrator_to_json_matplotlib_base():
     assert data["name"] == "matplotlib-to-matplotlib-base"
 
     migrator2 = make_from_lazy_json_data(loads(lzj_data))
+    assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [
+        pgm.__class__.__name__ for pgm in migrator.piggy_back_migrations
+    ]
     assert isinstance(migrator2, conda_forge_tick.migrators.MatplotlibBase)
     assert dumps(migrator2.to_lazy_json_data()) == lzj_data
 
@@ -168,6 +181,9 @@ def test_migrator_to_json_migration_yaml():
     assert data["name"] == "hi"
 
     migrator2 = make_from_lazy_json_data(loads(lzj_data))
+    assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [
+        pgm.__class__.__name__ for pgm in migrator.piggy_back_migrations
+    ]
     assert isinstance(migrator2, conda_forge_tick.migrators.MigrationYaml)
     assert dumps(migrator2.to_lazy_json_data()) == lzj_data
 
@@ -192,5 +208,8 @@ def test_migrator_to_json_rebuild():
     assert data["name"] == "matplotlib-to-matplotlib-base"
 
     migrator2 = make_from_lazy_json_data(loads(lzj_data))
+    assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [
+        pgm.__class__.__name__ for pgm in migrator.piggy_back_migrations
+    ]
     assert isinstance(migrator2, conda_forge_tick.migrators.Replacement)
     assert dumps(migrator2.to_lazy_json_data()) == lzj_data

--- a/tests/test_migrator_to_json.py
+++ b/tests/test_migrator_to_json.py
@@ -1,0 +1,77 @@
+import hashlib
+import inspect
+
+import conda_forge_tick.migrators
+from conda_forge_tick.lazy_json_backends import dumps
+
+
+def test_migrator_to_json_dep_update_minimigrator():
+    python_nodes = ["blah"]
+    migrator = conda_forge_tick.migrators.DependencyUpdateMigrator(python_nodes)
+    assert migrator._init_args == [python_nodes]
+    assert migrator._init_kwargs == {}
+    data = migrator.to_lazy_json_data()
+    dumps(data)
+    hsh = hashlib.sha1(
+        dumps(
+            {
+                "class": data["class"],
+                "args": data["args"],
+                "kwargs": data["kwargs"],
+            }
+        ).encode("utf-8")
+    ).hexdigest()
+
+    assert data == {
+        "__mini_migrator__": True,
+        "args": [python_nodes],
+        "kwargs": {},
+        "name": f"DependencyUpdateMigrator_h{hsh}",
+        "class": "DependencyUpdateMigrator",
+    }
+
+    migrator2 = conda_forge_tick.migrators.MiniMigrator.from_lazy_json_data(data)
+    assert migrator2._init_args == [python_nodes]
+    assert migrator2._init_kwargs == {}
+    assert isinstance(migrator2, conda_forge_tick.migrators.DependencyUpdateMigrator)
+    assert migrator2.to_lazy_json_data() == data
+
+
+def test_migrator_to_json_minimigrators():
+    possible_migrators = dir(conda_forge_tick.migrators)
+    for migrator_name in possible_migrators:
+        migrator = getattr(conda_forge_tick.migrators, migrator_name)
+        if (
+            inspect.isclass(migrator)
+            and issubclass(migrator, conda_forge_tick.migrators.MiniMigrator)
+            and migrator != conda_forge_tick.migrators.MiniMigrator
+            and migrator != conda_forge_tick.migrators.DependencyUpdateMigrator
+        ):
+            migrator = migrator()
+            data = migrator.to_lazy_json_data()
+            dumps(data)
+            hsh = hashlib.sha1(
+                dumps(
+                    {
+                        "class": data["class"],
+                        "args": data["args"],
+                        "kwargs": data["kwargs"],
+                    }
+                ).encode("utf-8")
+            ).hexdigest()
+
+            assert data == {
+                "__mini_migrator__": True,
+                "args": [],
+                "kwargs": {},
+                "name": f"{migrator_name}_h{hsh}",
+                "class": migrator_name,
+            }
+
+            migrator2 = conda_forge_tick.migrators.MiniMigrator.from_lazy_json_data(
+                data
+            )
+            assert migrator2._init_args == []
+            assert migrator2._init_kwargs == {}
+            assert isinstance(migrator2, migrator.__class__)
+            assert migrator2.to_lazy_json_data() == data

--- a/tests/test_migrator_to_json.py
+++ b/tests/test_migrator_to_json.py
@@ -1,8 +1,11 @@
 import hashlib
 import inspect
+import pprint
+
+import networkx as nx
 
 import conda_forge_tick.migrators
-from conda_forge_tick.lazy_json_backends import dumps
+from conda_forge_tick.lazy_json_backends import dumps, loads
 from conda_forge_tick.migrators import make_from_lazy_json_data
 
 
@@ -12,7 +15,8 @@ def test_migrator_to_json_dep_update_minimigrator():
     assert migrator._init_args == [python_nodes]
     assert migrator._init_kwargs == {}
     data = migrator.to_lazy_json_data()
-    dumps(data)
+    pprint.pprint(data)
+    lzj_data = dumps(data)
     hsh = hashlib.sha1(
         dumps(
             {
@@ -31,14 +35,14 @@ def test_migrator_to_json_dep_update_minimigrator():
         "class": "DependencyUpdateMigrator",
     }
 
-    migrator2 = make_from_lazy_json_data(data)
+    migrator2 = make_from_lazy_json_data(loads(lzj_data))
     assert migrator2._init_args == [python_nodes]
     assert migrator2._init_kwargs == {}
     assert isinstance(migrator2, conda_forge_tick.migrators.DependencyUpdateMigrator)
-    assert migrator2.to_lazy_json_data() == data
+    assert dumps(migrator2.to_lazy_json_data()) == lzj_data
 
 
-def test_migrator_to_json_minimigrators():
+def test_migrator_to_json_minimigrators_nodeps():
     possible_migrators = dir(conda_forge_tick.migrators)
     for migrator_name in possible_migrators:
         migrator = getattr(conda_forge_tick.migrators, migrator_name)
@@ -50,30 +54,21 @@ def test_migrator_to_json_minimigrators():
         ):
             migrator = migrator()
             data = migrator.to_lazy_json_data()
-            dumps(data)
-            hsh = hashlib.sha1(
-                dumps(
-                    {
-                        "class": data["class"],
-                        "args": data["args"],
-                        "kwargs": data["kwargs"],
-                    }
-                ).encode("utf-8")
-            ).hexdigest()
-
+            pprint.pprint(data)
+            lzj_data = dumps(data)
             assert data == {
                 "__mini_migrator__": True,
                 "args": [],
                 "kwargs": {},
-                "name": f"{migrator_name}_h{hsh}",
+                "name": migrator_name,
                 "class": migrator_name,
             }
 
-            migrator2 = make_from_lazy_json_data(data)
+            migrator2 = make_from_lazy_json_data(loads(lzj_data))
             assert migrator2._init_args == []
             assert migrator2._init_kwargs == {}
             assert isinstance(migrator2, migrator.__class__)
-            assert migrator2.to_lazy_json_data() == data
+            assert dumps(migrator2.to_lazy_json_data()) == lzj_data
 
 
 def test_migrator_to_json_version():
@@ -87,10 +82,101 @@ def test_migrator_to_json_version():
         ],
     )
     data = migrator.to_lazy_json_data()
-    dumps(data)
+    lzj_data = dumps(data)
     assert data["__migrator__"] is True
     assert data["class"] == "Version"
 
-    migrator2 = make_from_lazy_json_data(data)
+    migrator2 = make_from_lazy_json_data(loads(lzj_data))
     assert isinstance(migrator2, conda_forge_tick.migrators.Version)
-    assert migrator2.to_lazy_json_data() == data
+    assert dumps(migrator2.to_lazy_json_data()) == lzj_data
+
+
+def test_migrator_to_json_migration_yaml_creator():
+    gx = nx.DiGraph()
+    gx.add_node("conda", reqs=["python"], payload={})
+    gx.graph["outputs_lut"] = {}
+
+    pname = "boost"
+    pin_ver = "1.99.0"
+    curr_pin = "1.70.0"
+    pin_spec = "x.x"
+
+    migrator = conda_forge_tick.migrators.MigrationYamlCreator(
+        pname, pin_ver, curr_pin, pin_spec, "hi", gx, gx
+    )
+    data = migrator.to_lazy_json_data()
+    pprint.pprint(data)
+    lzj_data = dumps(data)
+    print("lazy json data:\n", lzj_data)
+    assert data["__migrator__"] is True
+    assert data["class"] == "MigrationYamlCreator"
+    assert data["name"] == pname + " pinning"
+
+    migrator2 = make_from_lazy_json_data(loads(lzj_data))
+    assert isinstance(migrator2, conda_forge_tick.migrators.MigrationYamlCreator)
+    assert dumps(migrator2.to_lazy_json_data()) == lzj_data
+
+
+def test_migrator_to_json_matplotlib_base():
+    migrator = conda_forge_tick.migrators.MatplotlibBase(
+        old_pkg="matplotlib",
+        new_pkg="matplotlib-base",
+        rationale=(
+            "Unless you need `pyqt`, recipes should depend only on "
+            "`matplotlib-base`."
+        ),
+        pr_limit=5,
+    )
+    data = migrator.to_lazy_json_data()
+    pprint.pprint(data)
+    lzj_data = dumps(data)
+    print("lazy json data:\n", lzj_data)
+    assert data["__migrator__"] is True
+    assert data["class"] == "MatplotlibBase"
+    assert data["name"] == "matplotlib-to-matplotlib-base"
+
+    migrator2 = make_from_lazy_json_data(loads(lzj_data))
+    assert isinstance(migrator2, conda_forge_tick.migrators.MatplotlibBase)
+    assert dumps(migrator2.to_lazy_json_data()) == lzj_data
+
+
+def test_migrator_to_json_migration_yaml():
+    migrator = conda_forge_tick.migrators.MigrationYaml(
+        yaml_contents="hello world", name="hi"
+    )
+
+    data = migrator.to_lazy_json_data()
+    pprint.pprint(data)
+    lzj_data = dumps(data)
+    print("lazy json data:\n", lzj_data)
+    assert data["__migrator__"] is True
+    assert data["class"] == "MigrationYaml"
+    assert data["name"] == "hi"
+
+    migrator2 = make_from_lazy_json_data(loads(lzj_data))
+    assert isinstance(migrator2, conda_forge_tick.migrators.MigrationYaml)
+    assert dumps(migrator2.to_lazy_json_data()) == lzj_data
+
+
+def test_migrator_to_json_rebuild():
+    migrator = conda_forge_tick.migrators.Replacement(
+        old_pkg="matplotlib",
+        new_pkg="matplotlib-base",
+        rationale=(
+            "Unless you need `pyqt`, recipes should depend only on "
+            "`matplotlib-base`."
+        ),
+        pr_limit=5,
+    )
+
+    data = migrator.to_lazy_json_data()
+    pprint.pprint(data)
+    lzj_data = dumps(data)
+    print("lazy json data:\n", lzj_data)
+    assert data["__migrator__"] is True
+    assert data["class"] == "Replacement"
+    assert data["name"] == "matplotlib-to-matplotlib-base"
+
+    migrator2 = make_from_lazy_json_data(loads(lzj_data))
+    assert isinstance(migrator2, conda_forge_tick.migrators.Replacement)
+    assert dumps(migrator2.to_lazy_json_data()) == lzj_data


### PR DESCRIPTION
This PR is a start on dumping and loading migrators from JSON. The goal is to eventually separate out the creation of migrators from running them. 