### PR TITLE
DEP remove migrator context

### DIFF
--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -657,6 +657,7 @@ def initialize_migrators(
         )
         version_migrator = Version(
             python_nodes=python_nodes,
+            graph=gx,
             pr_limit=PR_LIMIT * 4,
             piggy_back_migrations=[
                 CondaForgeYAMLCleanup(),

--- a/conda_forge_tick/migrators/__init__.py
+++ b/conda_forge_tick/migrators/__init__.py
@@ -2,13 +2,7 @@
 from .arch import ArchRebuild, OSXArm
 from .broken_rebuild import RebuildBroken
 from .conda_forge_yaml_cleanup import CondaForgeYAMLCleanup
-from .core import (
-    GraphMigrator,
-    Migrator,
-    MiniMigrator,
-    Replacement,
-    make_from_lazy_json_data,
-)
+from .core import GraphMigrator, Migrator, MiniMigrator, make_from_lazy_json_data
 from .cos7 import Cos7Config
 from .cross_compile import (
     Build2HostMigrator,
@@ -35,5 +29,6 @@ from .numpy2 import Numpy2Migrator
 from .pip_check import PipCheckMigrator
 from .pip_wheel_dep import PipWheelMigrator
 from .qt_to_qt_main import QtQtMainMigrator
+from .replacement import Replacement
 from .use_pip import PipMigrator
 from .version import Version

--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -106,6 +106,7 @@ class ArchRebuild(GraphMigrator):
         pr_limit: int = 0,
         piggy_back_migrations: Optional[Sequence[MiniMigrator]] = None,
         target_packages: Optional[Sequence[str]] = None,
+        effective_graph: nx.DiGraph = None,
     ):
         if target_packages is None:
             # We are constraining the scope of this migrator
@@ -124,6 +125,7 @@ class ArchRebuild(GraphMigrator):
                 "pr_limit": pr_limit,
                 "piggy_back_migrations": piggy_back_migrations,
                 "target_packages": target_packages,
+                "effective_graph": effective_graph,
             }
 
         # rebuild the graph to only use edges from the arm and power requirements
@@ -144,6 +146,7 @@ class ArchRebuild(GraphMigrator):
             pr_limit=pr_limit,
             check_solvable=False,
             piggy_back_migrations=piggy_back_migrations,
+            effective_graph=effective_graph,
         )
 
         assert not self.check_solvable, "We don't want to check solvability for aarch!"
@@ -241,6 +244,7 @@ class OSXArm(GraphMigrator):
         pr_limit: int = 0,
         piggy_back_migrations: Optional[Sequence[MiniMigrator]] = None,
         target_packages: Optional[Sequence[str]] = None,
+        effective_graph: nx.DiGraph = None,
     ):
         if target_packages is None:
             # We are constraining the scope of this migrator
@@ -259,6 +263,7 @@ class OSXArm(GraphMigrator):
                 "pr_limit": pr_limit,
                 "piggy_back_migrations": piggy_back_migrations,
                 "target_packages": target_packages,
+                "effective_graph": effective_graph,
             }
 
         # rebuild the graph to only use edges from the arm osx requirements
@@ -288,6 +293,7 @@ class OSXArm(GraphMigrator):
             pr_limit=pr_limit,
             check_solvable=False,
             piggy_back_migrations=piggy_back_migrations,
+            effective_graph=effective_graph,
         )
 
         assert (

--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -158,6 +158,8 @@ class ArchRebuild(GraphMigrator):
         # filter out stub packages and ignored packages
         _filter_stubby_and_ignored_nodes(self.graph, self.ignored_packages)
 
+        self._reset_effective_graph()
+
     def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
         if super().filter(attrs):
             return True
@@ -308,6 +310,8 @@ class OSXArm(GraphMigrator):
 
         # filter out stub packages and ignored packages
         _filter_stubby_and_ignored_nodes(self.graph, self.ignored_packages)
+
+        self._reset_effective_graph()
 
     def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
         if super().filter(attrs):

--- a/conda_forge_tick/migrators/broken_rebuild.py
+++ b/conda_forge_tick/migrators/broken_rebuild.py
@@ -325,6 +325,7 @@ class RebuildBroken(Migrator):
         outputs_lut,
         pr_limit: int = 0,
         graph: nx.DiGraph = None,
+        effective_graph: nx.DiGraph = None,
     ):
         if not hasattr(self, "_init_args"):
             self._init_args = []
@@ -334,9 +335,12 @@ class RebuildBroken(Migrator):
                 "outputs_lut": outputs_lut,
                 "pr_limit": pr_limit,
                 "graph": graph,
+                "effective_graph": effective_graph,
             }
 
-        super().__init__(1, check_solvable=False, graph=graph)
+        super().__init__(
+            1, check_solvable=False, graph=graph, effective_graph=effective_graph
+        )
         self.name = "rebuild-broken"
 
         outputs_to_migrate = {split_pkg(pkg)[1] for pkg in BROKEN_PACKAGES}

--- a/conda_forge_tick/migrators/broken_rebuild.py
+++ b/conda_forge_tick/migrators/broken_rebuild.py
@@ -345,6 +345,8 @@ class RebuildBroken(Migrator):
             for fs in outputs_lut.get(output, {output}):
                 self.feedstocks_to_migrate |= {fs}
 
+        self._reset_effective_graph()
+
     def order(
         self,
         graph: nx.DiGraph,

--- a/conda_forge_tick/migrators/broken_rebuild.py
+++ b/conda_forge_tick/migrators/broken_rebuild.py
@@ -324,6 +324,7 @@ class RebuildBroken(Migrator):
         *,
         outputs_lut,
         pr_limit: int = 0,
+        graph: nx.DiGraph = None,
     ):
         if not hasattr(self, "_init_args"):
             self._init_args = []
@@ -332,9 +333,10 @@ class RebuildBroken(Migrator):
             self._init_kwargs = {
                 "outputs_lut": outputs_lut,
                 "pr_limit": pr_limit,
+                "graph": graph,
             }
 
-        super().__init__(1, check_solvable=False)
+        super().__init__(1, check_solvable=False, graph=graph)
         self.name = "rebuild-broken"
 
         outputs_to_migrate = {split_pkg(pkg)[1] for pkg in BROKEN_PACKAGES}

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -1,9 +1,8 @@
-"""Classes for migrating repos"""
+"""Base classes for migrating repos"""
 
 import copy
 import datetime
 import logging
-import os
 import re
 import typing
 from typing import Any, List, Optional, Sequence, Set
@@ -226,9 +225,6 @@ class Migrator:
         graph: nx.DiGraph = None,
         effective_graph: nx.DiGraph = None,
     ):
-        if graph is not None and effective_graph is None:
-            effective_graph = _make_effective_graph(graph, self)
-
         if not hasattr(self, "_init_args"):
             self._init_args = []
 
@@ -252,6 +248,8 @@ class Migrator:
             self.graph = graph
         if effective_graph is None:
             self.effective_graph = self.graph
+        else:
+            self.effective_graph = effective_graph
 
     def to_lazy_json_data(self):
         """Serialize the migrator to LazyJson-compatible data."""
@@ -275,6 +273,12 @@ class Migrator:
         }
         data["name"] = _make_migrator_lazy_json_name(self, data)
         return data
+
+    def _reset_effective_graph(self):
+        """This method is meant to be called by an non-abstract child class at the end
+        of its __init__ method."""
+        self.effective_graph = _make_effective_graph(self.graph, self)
+        self._init_kwargs["effective_graph"] = self.effective_graph
 
     def downstream_children(
         self,
@@ -768,138 +772,6 @@ class GraphMigrator(Migrator):
             return True
 
         return False
-
-    def migrator_uid(self, attrs: "AttrsTypedDict") -> "MigrationUidTypedDict":
-        n = super().migrator_uid(attrs)
-        n["name"] = self.name
-        return n
-
-
-class Replacement(Migrator):
-    """Migrator for replacing one package with another.
-
-    Parameters
-    ----------
-    old_pkg : str
-        The package to be replaced.
-    new_pkg : str
-        The package to replace the `old_pkg`.
-    rationale : str
-        The reason the for the migration. Should be a full statement.
-    graph : nx.DiGraph, optional
-        The graph of feedstocks.
-    pr_limit : int, optional
-        The maximum number of PRs made per run of the bot.
-    check_solvable : bool, optional
-        If True, uses mamba to check if the final recipe is solvable.
-    """
-
-    migrator_version = 0
-    rerender = True
-
-    def __init__(
-        self,
-        *,
-        old_pkg: "PackageName",
-        new_pkg: "PackageName",
-        rationale: str,
-        graph: nx.DiGraph = None,
-        pr_limit: int = 0,
-        check_solvable=True,
-    ):
-        if not hasattr(self, "_init_args"):
-            self._init_args = []
-
-        if not hasattr(self, "_init_kwargs"):
-            self._init_kwargs = {
-                "old_pkg": old_pkg,
-                "new_pkg": new_pkg,
-                "rationale": rationale,
-                "graph": graph,
-                "pr_limit": pr_limit,
-                "check_solvable": check_solvable,
-            }
-
-        super().__init__(pr_limit, check_solvable=check_solvable, graph=graph)
-        self.old_pkg = old_pkg
-        self.new_pkg = new_pkg
-        self.pattern = re.compile(r"\s*-\s*(%s)(\s+|$)" % old_pkg)
-        self.packages = {old_pkg}
-        self.rationale = rationale
-        self.name = f"{old_pkg}-to-{new_pkg}"
-
-    def order(
-        self,
-        graph: nx.DiGraph,
-        total_graph: nx.DiGraph,
-    ) -> Sequence["PackageName"]:
-        """Order to run migrations in
-
-        Parameters
-        ----------
-        graph : nx.DiGraph
-            The graph of migratable PRs
-
-        Returns
-        -------
-        graph : nx.DiGraph
-            The ordered graph.
-        """
-        return graph
-
-    def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
-        requirements = attrs.get("requirements", {})
-        rq = (
-            requirements.get("build", set())
-            | requirements.get("host", set())
-            | requirements.get("run", set())
-            | requirements.get("test", set())
-        )
-        return super().filter(attrs) or len(rq & self.packages) == 0
-
-    def migrate(
-        self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any
-    ) -> "MigrationUidTypedDict":
-        with open(os.path.join(recipe_dir, "meta.yaml")) as f:
-            raw = f.read()
-        lines = raw.splitlines()
-        n = False
-        for i, line in enumerate(lines):
-            m = self.pattern.match(line)
-            if m is not None:
-                lines[i] = lines[i].replace(m.group(1), self.new_pkg)
-                n = True
-        if not n:
-            return False
-        upd = "\n".join(lines) + "\n"
-        with open(os.path.join(recipe_dir, "meta.yaml"), "w") as f:
-            f.write(upd)
-        self.set_build_number(os.path.join(recipe_dir, "meta.yaml"))
-        return super().migrate(recipe_dir, attrs)
-
-    def pr_body(self, feedstock_ctx: FeedstockContext) -> str:
-        body = super().pr_body(feedstock_ctx)
-        body = body.format(
-            "I noticed that this recipe depends on `%s` instead of \n"
-            "`%s`. %s \n"
-            "This PR makes this change."
-            "\n"
-            "Notes and instructions for merging this PR:\n"
-            "1. Make sure that the recipe can indeed only depend on `%s`. \n"
-            "2. Please merge the PR only after the tests have passed. \n"
-            "3. Feel free to push to the bot's branch to update this PR if "
-            "needed. \n" % (self.old_pkg, self.new_pkg, self.rationale, self.new_pkg),
-        )
-        return body
-
-    def commit_message(self, feedstock_ctx: FeedstockContext) -> str:
-        return f"use {self.new_pkg} instead of {self.old_pkg}"
-
-    def pr_title(self, feedstock_ctx: FeedstockContext) -> str:
-        return f"Suggestion: depend on {self.new_pkg} instead of {self.old_pkg}"
-
-    def remote_branch(self, feedstock_ctx: FeedstockContext) -> str:
-        return f"{self.old_pkg}-to-{self.new_pkg}-migration-{self.migrator_version}"
 
     def migrator_uid(self, attrs: "AttrsTypedDict") -> "MigrationUidTypedDict":
         n = super().migrator_uid(attrs)

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -36,8 +36,11 @@ def _make_effective_graph(graph, migrator):
 
     # Prune graph to only things that need builds right now
     for node in list(gx2.nodes):
-        with graph.nodes[node]["payload"] as _attrs:
-            attrs = copy.deepcopy(_attrs.data)
+        if isinstance(graph.nodes[node]["payload"], LazyJson):
+            with graph.nodes[node]["payload"] as _attrs:
+                attrs = copy.deepcopy(_attrs.data)
+        else:
+            attrs = copy.deepcopy(graph.nodes[node]["payload"])
         base_branches = migrator.get_possible_feedstock_branches(attrs)
         filters = []
         for base_branch in base_branches:

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -608,6 +608,7 @@ class GraphMigrator(Migrator):
         piggy_back_migrations: Optional[Sequence[MiniMigrator]] = None,
         check_solvable=True,
         ignored_deps_per_node=None,
+        effective_graph: nx.DiGraph = None,
     ):
         if not hasattr(self, "_init_args"):
             self._init_args = []
@@ -623,6 +624,7 @@ class GraphMigrator(Migrator):
                 "piggy_back_migrations": piggy_back_migrations,
                 "check_solvable": check_solvable,
                 "ignored_deps_per_node": ignored_deps_per_node,
+                "effective_graph": effective_graph,
             }
 
         super().__init__(
@@ -631,6 +633,7 @@ class GraphMigrator(Migrator):
             piggy_back_migrations,
             check_solvable=check_solvable,
             graph=graph,
+            effective_graph=effective_graph,
         )
 
         # IDK if this will be there so I am going to make it if needed

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -242,14 +242,13 @@ class Migrator:
         self.pr_limit = pr_limit
         self.obj_version = obj_version
         self.check_solvable = check_solvable
+
         if graph is None:
             self.graph = nx.DiGraph()
         else:
             self.graph = graph
-        if effective_graph is None:
-            self.effective_graph = self.graph
-        else:
-            self.effective_graph = effective_graph
+
+        self.effective_graph = effective_graph
 
     def to_lazy_json_data(self):
         """Serialize the migrator to LazyJson-compatible data."""
@@ -274,11 +273,12 @@ class Migrator:
         data["name"] = _make_migrator_lazy_json_name(self, data)
         return data
 
-    def _reset_effective_graph(self):
+    def _reset_effective_graph(self, force=False):
         """This method is meant to be called by an non-abstract child class at the end
         of its __init__ method."""
-        self.effective_graph = _make_effective_graph(self.graph, self)
-        self._init_kwargs["effective_graph"] = self.effective_graph
+        if self.effective_graph is None or force:
+            self.effective_graph = _make_effective_graph(self.graph, self)
+            self._init_kwargs["effective_graph"] = self.effective_graph
 
     def downstream_children(
         self,

--- a/conda_forge_tick/migrators/matplotlib_base.py
+++ b/conda_forge_tick/migrators/matplotlib_base.py
@@ -3,7 +3,8 @@ import os
 import typing
 from typing import Any
 
-from conda_forge_tick.migrators.core import Replacement, _parse_bad_attr
+from conda_forge_tick.migrators.core import _parse_bad_attr
+from conda_forge_tick.migrators.replacement import Replacement
 from conda_forge_tick.utils import frozen_to_json_friendly
 
 if typing.TYPE_CHECKING:

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -482,7 +482,7 @@ class MigrationYamlCreator(Migrator):
             }
             self._init_kwargs.update(copy.deepcopy(kwargs))
 
-        super().__init__(pr_limit=pr_limit)
+        super().__init__(pr_limit=pr_limit, graph=graph)
         self.feedstock_name = feedstock_name
         self.pin_spec = pin_spec
         self.current_pin = current_pin
@@ -492,7 +492,6 @@ class MigrationYamlCreator(Migrator):
         self.package_name = package_name
         self.bump_number = bump_number
         self.name = package_name + " pinning"
-        self.graph = graph
 
     def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
         if (

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -135,6 +135,7 @@ class MigrationYaml(GraphMigrator):
         conda_forge_yml_patches=None,
         ignored_deps_per_node=None,
         max_solver_attempts=3,
+        effective_graph: nx.DiGraph = None,
         **kwargs: Any,
     ):
         if not hasattr(self, "_init_args"):
@@ -154,6 +155,7 @@ class MigrationYaml(GraphMigrator):
                 "conda_forge_yml_patches": conda_forge_yml_patches,
                 "ignored_deps_per_node": ignored_deps_per_node,
                 "max_solver_attempts": max_solver_attempts,
+                "effective_graph": effective_graph,
             }
             self._init_kwargs.update(copy.deepcopy(kwargs))
 
@@ -164,6 +166,7 @@ class MigrationYaml(GraphMigrator):
             piggy_back_migrations=piggy_back_migrations,
             check_solvable=check_solvable,
             ignored_deps_per_node=ignored_deps_per_node,
+            effective_graph=effective_graph,
         )
         self.yaml_contents = yaml_contents
         assert isinstance(name, str)
@@ -456,6 +459,7 @@ class MigrationYamlCreator(Migrator):
         full_graph: Optional[nx.DiGraph] = None,
         pr_limit: int = 1,
         bump_number: int = 1,
+        effective_graph: nx.DiGraph = None,
         **kwargs: Any,
     ):
         if pin_impact is None:
@@ -481,10 +485,13 @@ class MigrationYamlCreator(Migrator):
                 "bump_number": bump_number,
                 "pin_impact": pin_impact,
                 "full_graph": full_graph,
+                "effective_graph": effective_graph,
             }
             self._init_kwargs.update(copy.deepcopy(kwargs))
 
-        super().__init__(pr_limit=pr_limit, graph=graph)
+        super().__init__(
+            pr_limit=pr_limit, graph=graph, effective_graph=effective_graph
+        )
         self.feedstock_name = feedstock_name
         self.pin_spec = pin_spec
         self.current_pin = current_pin

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -196,6 +196,8 @@ class MigrationYaml(GraphMigrator):
         self.bump_number = bump_number
         self.max_solver_attempts = max_solver_attempts
 
+        self._reset_effective_graph()
+
     def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
         """
         Determine whether migrator needs to be filtered out.
@@ -492,6 +494,8 @@ class MigrationYamlCreator(Migrator):
         self.package_name = package_name
         self.bump_number = bump_number
         self.name = package_name + " pinning"
+
+        self._reset_effective_graph()
 
     def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
         if (

--- a/conda_forge_tick/migrators/replacement.py
+++ b/conda_forge_tick/migrators/replacement.py
@@ -1,0 +1,150 @@
+import logging
+import os
+import re
+import typing
+from typing import Any, Sequence
+
+import networkx as nx
+
+from conda_forge_tick.contexts import FeedstockContext
+from conda_forge_tick.migrators.core import Migrator
+
+if typing.TYPE_CHECKING:
+    from ..migrators_types import AttrsTypedDict, MigrationUidTypedDict, PackageName
+
+
+logger = logging.getLogger(__name__)
+
+
+class Replacement(Migrator):
+    """Migrator for replacing one package with another.
+
+    Parameters
+    ----------
+    old_pkg : str
+        The package to be replaced.
+    new_pkg : str
+        The package to replace the `old_pkg`.
+    rationale : str
+        The reason the for the migration. Should be a full statement.
+    graph : nx.DiGraph, optional
+        The graph of feedstocks.
+    pr_limit : int, optional
+        The maximum number of PRs made per run of the bot.
+    check_solvable : bool, optional
+        If True, uses mamba to check if the final recipe is solvable.
+    """
+
+    migrator_version = 0
+    rerender = True
+
+    def __init__(
+        self,
+        *,
+        old_pkg: "PackageName",
+        new_pkg: "PackageName",
+        rationale: str,
+        graph: nx.DiGraph = None,
+        pr_limit: int = 0,
+        check_solvable=True,
+    ):
+        if not hasattr(self, "_init_args"):
+            self._init_args = []
+
+        if not hasattr(self, "_init_kwargs"):
+            self._init_kwargs = {
+                "old_pkg": old_pkg,
+                "new_pkg": new_pkg,
+                "rationale": rationale,
+                "graph": graph,
+                "pr_limit": pr_limit,
+                "check_solvable": check_solvable,
+            }
+
+        super().__init__(pr_limit, check_solvable=check_solvable, graph=graph)
+        self.old_pkg = old_pkg
+        self.new_pkg = new_pkg
+        self.pattern = re.compile(r"\s*-\s*(%s)(\s+|$)" % old_pkg)
+        self.packages = {old_pkg}
+        self.rationale = rationale
+        self.name = f"{old_pkg}-to-{new_pkg}"
+
+        self._reset_effective_graph()
+
+    def order(
+        self,
+        graph: nx.DiGraph,
+        total_graph: nx.DiGraph,
+    ) -> Sequence["PackageName"]:
+        """Order to run migrations in
+
+        Parameters
+        ----------
+        graph : nx.DiGraph
+            The graph of migratable PRs
+
+        Returns
+        -------
+        graph : nx.DiGraph
+            The ordered graph.
+        """
+        return graph
+
+    def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
+        requirements = attrs.get("requirements", {})
+        rq = (
+            requirements.get("build", set())
+            | requirements.get("host", set())
+            | requirements.get("run", set())
+            | requirements.get("test", set())
+        )
+        return super().filter(attrs) or len(rq & self.packages) == 0
+
+    def migrate(
+        self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any
+    ) -> "MigrationUidTypedDict":
+        with open(os.path.join(recipe_dir, "meta.yaml")) as f:
+            raw = f.read()
+        lines = raw.splitlines()
+        n = False
+        for i, line in enumerate(lines):
+            m = self.pattern.match(line)
+            if m is not None:
+                lines[i] = lines[i].replace(m.group(1), self.new_pkg)
+                n = True
+        if not n:
+            return False
+        upd = "\n".join(lines) + "\n"
+        with open(os.path.join(recipe_dir, "meta.yaml"), "w") as f:
+            f.write(upd)
+        self.set_build_number(os.path.join(recipe_dir, "meta.yaml"))
+        return super().migrate(recipe_dir, attrs)
+
+    def pr_body(self, feedstock_ctx: FeedstockContext) -> str:
+        body = super().pr_body(feedstock_ctx)
+        body = body.format(
+            "I noticed that this recipe depends on `%s` instead of \n"
+            "`%s`. %s \n"
+            "This PR makes this change."
+            "\n"
+            "Notes and instructions for merging this PR:\n"
+            "1. Make sure that the recipe can indeed only depend on `%s`. \n"
+            "2. Please merge the PR only after the tests have passed. \n"
+            "3. Feel free to push to the bot's branch to update this PR if "
+            "needed. \n" % (self.old_pkg, self.new_pkg, self.rationale, self.new_pkg),
+        )
+        return body
+
+    def commit_message(self, feedstock_ctx: FeedstockContext) -> str:
+        return f"use {self.new_pkg} instead of {self.old_pkg}"
+
+    def pr_title(self, feedstock_ctx: FeedstockContext) -> str:
+        return f"Suggestion: depend on {self.new_pkg} instead of {self.old_pkg}"
+
+    def remote_branch(self, feedstock_ctx: FeedstockContext) -> str:
+        return f"{self.old_pkg}-to-{self.new_pkg}-migration-{self.migrator_version}"
+
+    def migrator_uid(self, attrs: "AttrsTypedDict") -> "MigrationUidTypedDict":
+        n = super().migrator_uid(attrs)
+        n["name"] = self.name
+        return n

--- a/conda_forge_tick/migrators/replacement.py
+++ b/conda_forge_tick/migrators/replacement.py
@@ -47,6 +47,7 @@ class Replacement(Migrator):
         graph: nx.DiGraph = None,
         pr_limit: int = 0,
         check_solvable=True,
+        effective_graph: nx.DiGraph = None,
     ):
         if not hasattr(self, "_init_args"):
             self._init_args = []
@@ -59,9 +60,15 @@ class Replacement(Migrator):
                 "graph": graph,
                 "pr_limit": pr_limit,
                 "check_solvable": check_solvable,
+                "effective_graph": effective_graph,
             }
 
-        super().__init__(pr_limit, check_solvable=check_solvable, graph=graph)
+        super().__init__(
+            pr_limit,
+            check_solvable=check_solvable,
+            graph=graph,
+            effective_graph=effective_graph,
+        )
         self.old_pkg = old_pkg
         self.new_pkg = new_pkg
         self.pattern = re.compile(r"\s*-\s*(%s)(\s+|$)" % old_pkg)

--- a/conda_forge_tick/migrators/version.py
+++ b/conda_forge_tick/migrators/version.py
@@ -220,12 +220,12 @@ class Version(Migrator):
         pred = [
             (
                 name,
-                self.ctx.effective_graph.nodes[name]["payload"]["version_pr_info"][
+                self.effective_graph.nodes[name]["payload"]["version_pr_info"][
                     "new_version"
                 ],
             )
             for name in list(
-                self.ctx.effective_graph.predecessors(feedstock_ctx.package_name),
+                self.effective_graph.predecessors(feedstock_ctx.package_name),
             )
         ]
         body = ""

--- a/conda_forge_tick/migrators/version.py
+++ b/conda_forge_tick/migrators/version.py
@@ -69,6 +69,8 @@ class Version(Migrator):
         super().__init__(*args, **kwargs, check_solvable=False)
         self._new_version = None
 
+        self._reset_effective_graph()
+
     def filter(
         self,
         attrs: "AttrsTypedDict",

--- a/tests/test_migration_yaml_migration.py
+++ b/tests/test_migration_yaml_migration.py
@@ -6,7 +6,6 @@ from unittest import mock
 import networkx as nx
 import pytest
 
-from conda_forge_tick.contexts import MigratorContext, MigratorSessionContext
 from conda_forge_tick.feedstock_parser import populate_feedstock_attributes
 from conda_forge_tick.migrators import MigrationYamlCreator, merge_migrator_cbc
 from conda_forge_tick.os_utils import eval_cmd, pushd
@@ -173,14 +172,6 @@ def run_test_migration(
     should_filter=False,
     tmpdir=None,
 ):
-    mm_ctx = MigratorSessionContext(
-        graph=G,
-        smithy_version="",
-        pinning_version="",
-    )
-    m_ctx = MigratorContext(mm_ctx, m)
-    m.bind_to_ctx(m_ctx)
-
     if mr_out:
         mr_out.update(bot_rerun=False)
     with open(os.path.join(tmpdir, "meta.yaml"), "w") as f:

--- a/tests/test_migrators.py
+++ b/tests/test_migrators.py
@@ -5,11 +5,7 @@ import tempfile
 
 import networkx as nx
 
-from conda_forge_tick.contexts import (
-    FeedstockContext,
-    MigratorContext,
-    MigratorSessionContext,
-)
+from conda_forge_tick.contexts import FeedstockContext
 from conda_forge_tick.feedstock_parser import populate_feedstock_attributes
 from conda_forge_tick.lazy_json_backends import LazyJson
 from conda_forge_tick.migrators import (
@@ -473,14 +469,6 @@ def run_test_migration(
     tmpdir=None,
     make_body=False,
 ):
-    mm_ctx = MigratorSessionContext(
-        graph=G,
-        smithy_version="",
-        pinning_version="",
-    )
-    m_ctx = MigratorContext(mm_ctx, m)
-    m.bind_to_ctx(m_ctx)
-
     if mr_out:
         mr_out.update(bot_rerun=False)
     with open(os.path.join(tmpdir, "meta.yaml"), "w") as f:
@@ -544,8 +532,8 @@ def run_test_migration(
                 attrs=pmy,
             )
             fctx.feedstock_dir = os.path.dirname(tmpdir)
-            m_ctx.effective_graph.add_node(name)
-            m_ctx.effective_graph.nodes[name]["payload"] = MockLazyJson({})
+            m.effective_graph.add_node(name)
+            m.effective_graph.nodes[name]["payload"] = MockLazyJson({})
             m.pr_body(fctx)
 
         assert mr_out == mr


### PR DESCRIPTION
This PR removes the migrator contexts to further isolate the migrators from graph state so that they have their full state serialized as json. This will allow them to be run on demand without access to the full graph, in isolated environments like containers, etc.