### PR TITLE
PROD end migrators faster

### DIFF
--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -92,7 +92,7 @@ logger = logging.getLogger(__name__)
 PR_LIMIT = 5
 MAX_PR_LIMIT = 50
 MAX_SOLVER_ATTEMPTS = 50
-CHECK_SOLVABLE_TIMEOUT = 90  # 90 days
+CHECK_SOLVABLE_TIMEOUT = 30  # 30 days
 
 
 def add_replacement_migrator(


### PR DESCRIPTION
This will end migrations faster by turning off solver checks after 30 days instead of 90. 