### PR TITLE
ENH ramp PRs better

### DIFF
--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -310,7 +310,7 @@ def add_rebuild_migration_yaml(
         **config,
     )
 
-    # adaptivewl set PR limits based on the number of PRs made so far
+    # adaptively set PR limits based on the number of PRs made so far
     number_pred = len(
         [
             k

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -242,7 +242,7 @@ class Migrator:
             }
 
         self.piggy_back_migrations = piggy_back_migrations or []
-        self.pr_limit = pr_limit
+        self._pr_limit = pr_limit
         self.obj_version = obj_version
         self.check_solvable = check_solvable
 
@@ -282,6 +282,16 @@ class Migrator:
         if self.effective_graph is None or force:
             self.effective_graph = _make_effective_graph(self.graph, self)
             self._init_kwargs["effective_graph"] = self.effective_graph
+
+    @property
+    def pr_limit(self):
+        return self._pr_limit
+
+    @pr_limit.setter
+    def pr_limit(self, value):
+        self._pr_limit = value
+        if hasattr(self, "_init_kwargs"):
+            self._init_kwargs["pr_limit"] = value
 
     def downstream_children(
         self,

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -178,26 +178,6 @@ class MigrationYaml(GraphMigrator):
         self.automerge = automerge
         self.conda_forge_yml_patches = conda_forge_yml_patches
         self.loaded_yaml = yaml_safe_load(self.yaml_contents)
-
-        # auto set the pr_limit for initial things
-        if self.pr_limit > 2:
-            number_pred = len(
-                [
-                    k
-                    for k, v in self.graph.nodes.items()
-                    if self.migrator_uid(v.get("payload", {}))
-                    in [
-                        vv.get("data", {})
-                        for vv in v.get("payload", {})
-                        .get("pr_info", {})
-                        .get("PRed", [])
-                    ]
-                ],
-            )
-            if number_pred == 0:
-                self.pr_limit = 2
-            elif number_pred < 7:
-                self.pr_limit = 5
         self.bump_number = bump_number
         self.max_solver_attempts = max_solver_attempts
         self.longterm = longterm


### PR DESCRIPTION
This PR should ramp PRs for migrators better. It starts them slow, then bumps them up in rate for a while and then back down. Hopefully, this will emphasize newly merged migrators a bit over older ones that have gone through most of their work.