### PR TITLE
ENH force issue PRs after many many solver attempts

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -270,6 +270,8 @@ def run(
     if (
         feedstock_ctx.feedstock_name != "conda-forge-pinning"
         and (base_branch == "master" or base_branch == "main")
+        # feedstocks that have problematic bootstrapping will not always be solvable
+        and feedstock_ctx.feedstock_name not in BOOTSTRAP_MAPPINGS
         and (
             (
                 migrator.check_solvable
@@ -286,13 +288,13 @@ def run(
                 {},
                 False,
             )
+            # we try up to MAX_SOLVER_ATTEMPTS times and then we just skip
+            # the solver check and issue the PR
+            or (
+                _get_pre_pr_migrator_attempts(feedstock_ctx.attrs, migrator_name)
+                < migrator.force_pr_after_solver_attempts
+            )
         )
-        # feedstocks that have problematic bootstrapping will not always be solvable
-        and feedstock_ctx.feedstock_name not in BOOTSTRAP_MAPPINGS
-        # we try up to MAX_SOLVER_ATTEMPTS times and then we just skip
-        # the solver check and issue the PR
-        and _get_pre_pr_migrator_attempts(feedstock_ctx.attrs, migrator_name)
-        < migrator.force_pr_after_solver_attempts
     ):
         solvable, errors, _ = is_recipe_solvable(
             feedstock_dir,

--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -216,7 +216,7 @@ def add_rebuild_migration_yaml(
     migration_name: str,
     nominal_pr_limit: int = PR_LIMIT,
     max_solver_attempts: int = 3,
-    force_pr_after_solver_attempts: int = MAX_SOLVER_ATTEMPTS,
+    force_pr_after_solver_attempts: int = MAX_SOLVER_ATTEMPTS * 2,
 ) -> None:
     """Adds rebuild migrator.
 
@@ -243,7 +243,7 @@ def add_rebuild_migration_yaml(
     nominal_pr_limit : int, optional
         The number of PRs per hour, defaults to 5
     force_pr_after_solver_attempts : int, optional
-        The number of solver attempts after which to force a PR, defaults to 50.
+        The number of solver attempts after which to force a PR, defaults to 100.
     """
 
     total_graph = create_rebuild_graph(
@@ -423,8 +423,10 @@ def migration_factory(
                 MAX_SOLVER_ATTEMPTS,
             )
             force_pr_after_solver_attempts = min(
-                migrator_config.pop("force_pr_after_solver_attempts", 50),
-                MAX_SOLVER_ATTEMPTS,
+                migrator_config.pop(
+                    "force_pr_after_solver_attempts", MAX_SOLVER_ATTEMPTS * 2
+                ),
+                MAX_SOLVER_ATTEMPTS * 2,
             )
 
             if "override_cbc_keys" in migrator_config:

--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -216,6 +216,7 @@ def add_rebuild_migration_yaml(
     migration_name: str,
     nominal_pr_limit: int = PR_LIMIT,
     max_solver_attempts: int = 3,
+    force_pr_after_solver_attempts: int = MAX_SOLVER_ATTEMPTS,
 ) -> None:
     """Adds rebuild migrator.
 
@@ -241,6 +242,8 @@ def add_rebuild_migration_yaml(
         Name of the migration
     nominal_pr_limit : int, optional
         The number of PRs per hour, defaults to 5
+    force_pr_after_solver_attempts : int, optional
+        The number of solver attempts after which to force a PR, defaults to 50.
     """
 
     total_graph = create_rebuild_graph(
@@ -307,6 +310,7 @@ def add_rebuild_migration_yaml(
         cycles=cycles,
         piggy_back_migrations=piggy_back_migrations,
         max_solver_attempts=max_solver_attempts,
+        force_pr_after_solver_attempts=force_pr_after_solver_attempts,
         **config,
     )
 
@@ -418,6 +422,10 @@ def migration_factory(
                 migrator_config.pop("max_solver_attempts", 3),
                 MAX_SOLVER_ATTEMPTS,
             )
+            force_pr_after_solver_attempts = min(
+                migrator_config.pop("force_pr_after_solver_attempts", 50),
+                MAX_SOLVER_ATTEMPTS,
+            )
 
             if "override_cbc_keys" in migrator_config:
                 package_names = set(migrator_config.get("override_cbc_keys"))
@@ -466,6 +474,7 @@ def migration_factory(
                     config=migrator_config,
                     nominal_pr_limit=_pr_limit,
                     max_solver_attempts=max_solver_attempts,
+                    force_pr_after_solver_attempts=force_pr_after_solver_attempts,
                 )
                 if skip_solver_checks:
                     assert not migrators[-1].check_solvable

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -136,6 +136,7 @@ class MigrationYaml(GraphMigrator):
         ignored_deps_per_node=None,
         max_solver_attempts=3,
         effective_graph: nx.DiGraph = None,
+        force_pr_after_solver_attempts=50,
         longterm=False,
         **kwargs: Any,
     ):
@@ -158,6 +159,7 @@ class MigrationYaml(GraphMigrator):
                 "max_solver_attempts": max_solver_attempts,
                 "effective_graph": effective_graph,
                 "longterm": longterm,
+                "force_pr_after_solver_attempts": force_pr_after_solver_attempts,
             }
             self._init_kwargs.update(copy.deepcopy(kwargs))
 
@@ -181,6 +183,7 @@ class MigrationYaml(GraphMigrator):
         self.bump_number = bump_number
         self.max_solver_attempts = max_solver_attempts
         self.longterm = longterm
+        self.force_pr_after_solver_attempts = force_pr_after_solver_attempts
 
         self._reset_effective_graph()
 

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -136,7 +136,7 @@ class MigrationYaml(GraphMigrator):
         ignored_deps_per_node=None,
         max_solver_attempts=3,
         effective_graph: nx.DiGraph = None,
-        force_pr_after_solver_attempts=50,
+        force_pr_after_solver_attempts=100,
         longterm=False,
         **kwargs: Any,
     ):


### PR DESCRIPTION
OK @h-vetinari here is an initial attempt at issuing PRs after many failed solver attempts per feedstock. Right now I set this to 100 attempts. A bot job takes ~2 hours, so the bot will try a PR for about a week before issuing it. This matches the other timescales we give maintainers to fix things up. We don't actually notify folks of failed solver attempts, but if we did, the week would be the right timescale. 