### PR TITLE
BUG need to set pin_impact attribute

### DIFF
--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -487,6 +487,7 @@ class MigrationYamlCreator(Migrator):
         self.package_name = package_name
         self.bump_number = bump_number
         self.name = package_name + " pinning"
+        self.pin_impact = pin_impact
 
         self._reset_effective_graph()
 


### PR DESCRIPTION
This bug is preventing pinning PRs from being made. This is the cause of why the bot never made the proper orc PR. 

cc @h-vetinari 