### PR TITLE
Begin Building on a modular Git Backend

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -192,13 +192,7 @@ def run(
 
     # TODO: run this in parallel
     feedstock_dir, repo = get_repo(
-        fctx=feedstock_ctx,
-        branch=branch_name,
-        feedstock=feedstock_ctx.feedstock_name,
-        protocol=protocol,
-        pull_request=pull_request,
-        fork=fork,
-        base_branch=base_branch,
+        fctx=feedstock_ctx, branch=branch_name, base_branch=base_branch
     )
     if not feedstock_dir or not repo:
         logger.critical(

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -29,8 +29,8 @@ from conda_forge_tick.feedstock_parser import BOOTSTRAP_MAPPINGS
 from conda_forge_tick.git_utils import (
     GIT_CLONE_DIR,
     comment_on_pr,
-    get_github_api_requests_left,
     get_repo,
+    github_backend,
     is_github_api_limit_reached,
     push_repo,
 )
@@ -680,7 +680,8 @@ def _run_migrator_on_feedstock_branch(
 
 def _is_migrator_done(_mg_start, good_prs, time_per, pr_limit):
     curr_time = time.time()
-    api_req = get_github_api_requests_left()
+    backend = github_backend()
+    api_req = backend.get_api_requests_left()
 
     if curr_time - START_TIME > TIMEOUT:
         logger.info(
@@ -1107,5 +1108,5 @@ def main(ctx: CliContext) -> None:
             #     ],
             # )
 
-    logger.info("API Calls Remaining: %d", get_github_api_requests_left())
+    logger.info("API Calls Remaining: %d", github_backend().get_api_requests_left())
     logger.info("Done")

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -604,7 +604,8 @@ def _run_migrator_on_feedstock_branch(
                 fctx.feedstock_name,
             )
 
-            if is_github_api_limit_reached(e):
+            if is_github_api_limit_reached():
+                logger.warning("GitHub API error", exc_info=e)
                 break_loop = True
 
     except VersionMigrationError as e:

--- a/conda_forge_tick/executors.py
+++ b/conda_forge_tick/executors.py
@@ -39,8 +39,8 @@ logger = logging.getLogger(__name__)
 class DaskRLock(DaskLock):
     """A reentrant lock for dask that is always blocking and never times out."""
 
-    def __init__(self, name: str):
-        super().__init__(name=name)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._rcount = 0
         self._rdata = None
 

--- a/conda_forge_tick/executors.py
+++ b/conda_forge_tick/executors.py
@@ -72,7 +72,7 @@ def _init_process(lock):
 
 def _init_dask(lock):
     global DRLOCK
-    # it appears we have to construct the locak by name instead
+    # it appears we have to construct the lock by name instead
     # of passing the object itself
     # otherwise dask uses a regular lock
     DRLOCK = DaskRLock(name=lock)

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -475,7 +475,7 @@ class GitPlatformBackend(ABC):
 class GitHubBackend(GitPlatformBackend):
     """
     A git backend for GitHub, using both PyGithub and github3.py as clients.
-    It is unclear why both clients are used, in the future, this should be refactored to use only one client.
+    Both clients are used for historical reasons. In the future, this should be refactored to use only one client.
     Note that this class is not thread-safe, you should create a new instance for each thread.
     """
 

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -584,7 +584,9 @@ class DryRunBackend(GitPlatformBackend):
             return repo_name in self._repos
 
         # We do not use the GitHub API because unauthenticated requests are quite strictly rate-limited.
-        return self.cli.does_remote_exist(self.get_remote_url(owner, repo_name))
+        return self.cli.does_remote_exist(
+            self.get_remote_url(owner, repo_name, GitConnectionMode.HTTPS)
+        )
 
     def fork(self, owner: str, repo_name: str):
         if repo_name in self._repos:

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -568,10 +568,9 @@ class DryRunBackend(GitPlatformBackend):
     """
     A git backend that doesn't modify anything and only relies on public APIs that do not require authentication.
     Useful for local testing with dry-run.
-    Note that this class is not thread-safe, you should create a new instance for each thread.
     """
 
-    _USER = "virtual-dry-run-user"
+    _USER = "auto-tick-bot-dry-run"
 
     def __init__(self):
         super().__init__(GitCli())

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -612,6 +612,17 @@ def github_backend() -> GitHubBackend:
         return GitHubBackend.from_token(env["BOT_TOKEN"])
 
 
+def is_github_api_limit_reached() -> bool:
+    """
+    Return True if the GitHub API limit has been reached, False otherwise.
+
+    This method will be removed in the future, use the GitHubBackend class directly.
+    """
+    backend = github_backend()
+
+    return backend.is_api_limit_reached()
+
+
 def feedstock_url(fctx: FeedstockContext, protocol: str = "ssh") -> str:
     """Returns the URL for a conda-forge feedstock."""
     feedstock = fctx.feedstock_name + "-feedstock"

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -653,14 +653,6 @@ def feedstock_repo(fctx: FeedstockContext) -> str:
     return fctx.feedstock_name + "-feedstock"
 
 
-def fork_url(feedstock_url: str, username: str) -> str:
-    """Creates the URL of the user's fork."""
-    beg, end = feedstock_url.rsplit("/", 1)
-    beg = beg[:-11]  # chop off 'conda-forge'
-    url = beg + username + "/" + end
-    return url
-
-
 def get_repo(
     fctx: FeedstockContext,
     branch: str,

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -616,6 +616,9 @@ class DryRunBackend(GitPlatformBackend):
     """
     A git backend that doesn't modify anything and only relies on public APIs that do not require authentication.
     Useful for local testing with dry-run.
+
+    By default, the dry run backend assumes that the current user has not created any forks yet.
+    If forks are created, their names are stored in memory and can be checked with `does_repository_exist`.
     """
 
     _USER = "auto-tick-bot-dry-run"

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -367,10 +367,10 @@ class GitPlatformBackend(ABC):
         connection_mode: GitConnectionMode = GitConnectionMode.SSH,
     ) -> str:
         """
-        Using SSH as the default protocol, get the URL of the remote repository.
+        Get the URL of a remote repository.
         :param owner: The owner of the repository.
         :param repo_name: The name of the repository.
-        :param connection_mode: The connection mode to use.
+        :param connection_mode: The connection mode to use (defaults to SSH).
         :raises ValueError: If the connection mode is not supported.
         """
         # Currently we don't need any abstraction for other platforms than GitHub, so we don't build such abstractions.

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -602,6 +602,7 @@ class DryRunBackend(GitPlatformBackend):
             f"Dry Run: Syncing default branch of {upstream_owner}/{upstream_repo}."
         )
 
+    @property
     def user(self) -> str:
         return self._USER
 

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -160,27 +160,6 @@ class GitCli:
         except subprocess.CalledProcessError as e:
             raise GitCliError("Error running git command.") from e
 
-    def _get_git_root(self, git_dir: Path) -> Path:
-        """
-        Get the root directory of a git repository.
-        :param git_dir: Any subdirectory of the local git repository in question
-        :return: The root directory of the git repository.
-        :raises RepositoryNotFoundError: if an error occurred while executing the git command.
-        If git is installed, this can only happen if git_dir does not point to a git repository.
-        :raises FileNotFoundError: If the git_dir does not exist.
-        """
-
-        try:
-            result = self._run_git_command(
-                ["rev-parse", "--show-toplevel"], git_dir, capture_text=True
-            )
-        except GitCliError as e:
-            raise RepositoryNotFoundError(
-                f"Error finding git root directory for {git_dir}"
-            ) from e
-
-        return Path(result.stdout.strip())
-
     def reset_hard(self, git_dir: Path, to_treeish: str = "HEAD"):
         """
         Reset the git index of a directory to the state of the last commit with `git reset --hard HEAD`.

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -610,7 +610,7 @@ def feedstock_url(fctx: FeedstockContext, protocol: str = "ssh") -> str:
         url = "git@github.com:conda-forge/" + feedstock + ".git"
     else:
         msg = f"Unrecognized github protocol {protocol}, must be ssh, http, or https."
-        raise ValueError(msg.format(protocol))
+        raise ValueError(msg)
     return url
 
 

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -737,7 +737,7 @@ def get_repo(
     except RepositoryNotFoundError:
         logger.warning(f"Could not fork conda-forge/{feedstock_repo_name}")
         with fctx.attrs["pr_info"] as pri:
-            pri["bad"] = f"{fctx.package_name}: does not match feedstock name\n"
+            pri["bad"] = f"{fctx.feedstock_name}: Git repository not found.\n"
         return False, False
 
     feedstock_dir = Path(GIT_CLONE_DIR) / (fctx.feedstock_name + "-feedstock")

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -26,6 +26,7 @@ import rapidjson as json
 import requests
 
 from .cli_context import CliContext
+from .executors import lock_git_operation
 
 logger = logging.getLogger(__name__)
 
@@ -159,10 +160,8 @@ class FileLazyJsonBackend(LazyJsonBackend):
         }
 
     def hdel(self, name: str, keys: Iterable[str]) -> None:
-        from .executors import DRLOCK, PRLOCK, TRLOCK
-
         lzj_names = [get_sharded_path(f"{name}/{key}.json") for key in keys]
-        with PRLOCK, DRLOCK, TRLOCK:
+        with lock_git_operation():
             subprocess.run(
                 ["git", "rm", "--ignore-unmatch", "-f"] + lzj_names,
                 capture_output=True,

--- a/conda_forge_tick/update_prs.py
+++ b/conda_forge_tick/update_prs.py
@@ -89,7 +89,8 @@ def _update_pr(update_function, dry_run, gx, job, n_jobs):
             except (github3.GitHubError, github.GithubException) as e:
                 logger.error(f"GITHUB ERROR ON FEEDSTOCK: {name}")
                 failed_refresh += 1
-                if is_github_api_limit_reached(e):
+                if is_github_api_limit_reached():
+                    logger.warning("GitHub API error", exc_info=e)
                     break
             except (github3.exceptions.ConnectionError, github.GithubException):
                 logger.error(f"GITHUB ERROR ON FEEDSTOCK: {name}")

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -8,10 +8,14 @@ from conda_forge_tick.executors import executor
 
 
 def _square_with_lock(x):
-    from conda_forge_tick.executors import DRLOCK, PRLOCK, TRLOCK
+    from conda_forge_tick.executors import (
+        GIT_LOCK_DASK,
+        GIT_LOCK_PROCESS,
+        GIT_LOCK_THREAD,
+    )
 
-    with TRLOCK, PRLOCK, DRLOCK:
-        with TRLOCK, PRLOCK, DRLOCK:
+    with GIT_LOCK_THREAD, GIT_LOCK_PROCESS, GIT_LOCK_DASK:
+        with GIT_LOCK_THREAD, GIT_LOCK_PROCESS, GIT_LOCK_DASK:
             time.sleep(0.01)
             return x * x
 

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -687,7 +687,7 @@ def test_github_backend_get_api_requests_left_github_exception(caplog):
     backend = GitHubBackend(github3_client, MagicMock())
 
     assert backend.get_api_requests_left() is None
-    assert "API Error while fetching" in caplog.text
+    assert "API error while fetching" in caplog.text
 
     github3_client.rate_limit.assert_called_once()
 

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -710,7 +710,7 @@ def test_github_backend_get_api_requests_left_nonzero():
 
     backend = GitHubBackend(github3_client, MagicMock())
 
-    assert backend.get_api_requests_left() == 0
+    assert backend.get_api_requests_left() == 5
 
     github3_client.rate_limit.assert_called_once()
 

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -226,13 +226,6 @@ def test_git_cli_clone_repo_mock_success(
             ["clone", "--quiet", git_url, dir_path]
         )
 
-        # now we simulate that the repo already exists
-        dir_path.mkdir()
-
-        cli.clone_repo(git_url, dir_path)
-
-        reset_hard_mock.assert_called_once_with(dir_path)
-
 
 @mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")
 def test_git_cli_clone_repo_mock_error(run_git_command_mock: MagicMock):

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -1,4 +1,507 @@
-from conda_forge_tick.git_utils import trim_pr_json_keys
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest import mock
+from unittest.mock import MagicMock
+
+import pytest
+
+from conda_forge_tick.git_utils import GitCli, GitCliError, trim_pr_json_keys
+
+"""
+Note: You have to have git installed on your machine to run these tests.
+"""
+
+
+@mock.patch("subprocess.run")
+@pytest.mark.parametrize("check_error", [True, False])
+def test_git_cli_run_git_command_no_error(
+    subprocess_run_mock: MagicMock, check_error: bool
+):
+    cli = GitCli()
+
+    working_directory = Path("TEST_DIR")
+
+    cli._run_git_command(
+        ["GIT_COMMAND", "ARG1", "ARG2"], working_directory, check_error
+    )
+
+    subprocess_run_mock.assert_called_once_with(
+        ["git", "GIT_COMMAND", "ARG1", "ARG2"], check=check_error, cwd=working_directory
+    )
+
+
+@mock.patch("subprocess.run")
+def test_git_cli_run_git_command_error(subprocess_run_mock: MagicMock):
+    cli = GitCli()
+
+    working_directory = Path("TEST_DIR")
+
+    subprocess_run_mock.side_effect = subprocess.CalledProcessError(
+        returncode=1, cmd=""
+    )
+
+    with pytest.raises(GitCliError):
+        cli._run_git_command(["GIT_COMMAND"], working_directory)
+
+
+def test_git_cli_outside_repo():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir)
+
+        with dir_path.joinpath("test.txt").open("w") as f:
+            f.write("Hello, World!")
+
+        cli = GitCli()
+
+        with pytest.raises(GitCliError):
+            cli._run_git_command(["status"], working_directory=dir_path)
+
+        with pytest.raises(GitCliError):
+            cli.reset_hard(dir_path)
+
+        with pytest.raises(GitCliError):
+            cli.add_remote(dir_path, "origin", "https://github.com/torvalds/linux.git")
+
+        with pytest.raises(GitCliError):
+            cli.fetch_all(dir_path)
+
+        assert not cli.does_branch_exist(dir_path, "main")
+
+        with pytest.raises(GitCliError):
+            cli.checkout_branch(dir_path, "main")
+
+
+def test_git_cli_reset_hard_already_reset():
+    cli = GitCli()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir)
+
+        cli._run_git_command(["init"], working_directory=dir_path)
+        cli._run_git_command(
+            ["commit", "--allow-empty", "-m", "Initial commit"],
+            working_directory=dir_path,
+        )
+
+        cli.reset_hard(dir_path)
+
+
+@mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")
+def test_git_cli_reset_hard_mock(run_git_command_mock: MagicMock):
+    cli = GitCli()
+
+    git_dir = Path("TEST_DIR")
+
+    cli.reset_hard(git_dir)
+
+    run_git_command_mock.assert_called_once_with(
+        ["reset", "--quiet", "--hard", "HEAD"], git_dir
+    )
+
+
+def test_git_cli_reset_hard():
+    cli = GitCli()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir)
+
+        cli._run_git_command(["init"], working_directory=dir_path)
+        cli._run_git_command(
+            ["commit", "--allow-empty", "-m", "Initial commit"],
+            working_directory=dir_path,
+        )
+
+        with dir_path.joinpath("test.txt").open("w") as f:
+            f.write("Hello, World!")
+
+        cli._run_git_command(["add", "test.txt"], working_directory=dir_path)
+        cli._run_git_command(
+            ["commit", "-am", "Add test.txt"], working_directory=dir_path
+        )
+
+        with dir_path.joinpath("test.txt").open("w") as f:
+            f.write("Hello, World! Again!")
+
+        cli.reset_hard(dir_path)
+
+        with dir_path.joinpath("test.txt").open("r") as f:
+            assert f.read() == "Hello, World!"
+
+
+def test_git_cli_clone_repo_not_exists():
+    cli = GitCli()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir)
+
+        with pytest.raises(GitCliError):
+            cli.clone_repo(
+                "https://github.com/conda-forge/this-repo-does-not-exist.git", dir_path
+            )
+
+
+def test_git_cli_clone_repo_success():
+    cli = GitCli()
+
+    git_url = "https://github.com/conda-forge/duckdb-feedstock.git"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir) / "duckdb-feedstock"
+
+        # this is an archived feedstock that should not change
+        cli.clone_repo(git_url, dir_path)
+
+        readme_file = dir_path.joinpath("README.md")
+
+        # delete the README.md file
+        readme_file.unlink()
+
+        assert not readme_file.exists()
+
+        # clone the repo again (in the same directory!) - this should reset the repo
+        cli.clone_repo(git_url, dir_path)
+
+        assert readme_file.exists()
+
+
+@mock.patch("conda_forge_tick.git_utils.GitCli.reset_hard")
+@mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")
+def test_git_cli_clone_repo_mock_success(
+    run_git_command_mock: MagicMock, reset_hard_mock: MagicMock
+):
+    cli = GitCli()
+
+    git_url = "https://git-repository.com/repo.git"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir) / "repo"
+
+        cli.clone_repo(git_url, dir_path)
+
+        run_git_command_mock.assert_called_once_with(
+            ["clone", "--quiet", git_url, dir_path]
+        )
+
+        # now we simulate that the repo already exists
+        dir_path.mkdir()
+
+        cli.clone_repo(git_url, dir_path)
+
+        reset_hard_mock.assert_called_once_with(dir_path)
+
+
+@mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")
+def test_git_cli_clone_repo_mock_error(run_git_command_mock: MagicMock):
+    cli = GitCli()
+
+    git_url = "https://git-repository.com/repo.git"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir) / "repo"
+
+        run_git_command_mock.side_effect = GitCliError("Error")
+
+        with pytest.raises(GitCliError, match="Error cloning repository"):
+            cli.clone_repo(git_url, dir_path)
+
+
+@mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")
+def test_git_cli_add_remote_mock(run_git_command_mock: MagicMock):
+    cli = GitCli()
+
+    git_dir = Path("TEST_DIR")
+    remote_name = "origin"
+    remote_url = "https://git-repository.com/repo.git"
+
+    cli.add_remote(git_dir, remote_name, remote_url)
+
+    run_git_command_mock.assert_called_once_with(
+        ["remote", "add", remote_name, remote_url], git_dir
+    )
+
+
+def test_git_cli_add_remote():
+    cli = GitCli()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir)
+
+        cli._run_git_command(["init"], working_directory=dir_path)
+
+        remote_name = "remote24"
+        remote_url = "https://git-repository.com/repo.git"
+
+        cli.add_remote(dir_path, remote_name, remote_url)
+
+        output = subprocess.run(
+            "git remote -v", cwd=dir_path, shell=True, capture_output=True
+        )
+
+        assert remote_name in output.stdout.decode()
+        assert remote_url in output.stdout.decode()
+
+
+@mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")
+def test_git_cli_fetch_all_mock(run_git_command_mock: MagicMock):
+    cli = GitCli()
+
+    git_dir = Path("TEST_DIR")
+
+    cli.fetch_all(git_dir)
+
+    run_git_command_mock.assert_called_once_with(["fetch", "--all", "--quiet"], git_dir)
+
+
+def test_git_cli_fetch_all():
+    cli = GitCli()
+
+    git_url = "https://github.com/conda-forge/duckdb-feedstock.git"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir) / "duckdb-feedstock"
+
+        cli.clone_repo(git_url, dir_path)
+        cli.fetch_all(dir_path)
+
+
+def test_git_cli_does_branch_exist():
+    cli = GitCli()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir)
+
+        cli._run_git_command(["init"], working_directory=dir_path)
+
+        assert not cli.does_branch_exist(dir_path, "main")
+
+        cli._run_git_command(["checkout", "-b", "main"], working_directory=dir_path)
+        cli._run_git_command(
+            ["commit", "--allow-empty", "-m", "Initial commit"],
+            working_directory=dir_path,
+        )
+
+        assert cli.does_branch_exist(dir_path, "main")
+
+
+@mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")
+@pytest.mark.parametrize("does_exist", [True, False])
+def test_git_cli_does_branch_exist_mock(
+    run_git_command_mock: MagicMock, does_exist: bool
+):
+    cli = GitCli()
+
+    git_dir = Path("TEST_DIR")
+    branch_name = "main"
+
+    run_git_command_mock.return_value = (
+        subprocess.CompletedProcess(args=[], returncode=0)
+        if does_exist
+        else subprocess.CompletedProcess(args=[], returncode=1)
+    )
+
+    assert cli.does_branch_exist(git_dir, branch_name) is does_exist
+
+    run_git_command_mock.assert_called_once_with(
+        ["show-ref", "--verify", "--quiet", f"refs/heads/{branch_name}"],
+        git_dir,
+        check_error=False,
+    )
+
+
+def test_git_cli_does_remote_exist_false():
+    cli = GitCli()
+
+    remote_url = "https://github.com/conda-forge/this-repo-does-not-exist.git"
+
+    assert not cli.does_remote_exist(remote_url)
+
+
+def test_git_cli_does_remote_exist_true():
+    cli = GitCli()
+
+    remote_url = "https://github.com/conda-forge/pytest-feedstock.git"
+
+    assert cli.does_remote_exist(remote_url)
+
+
+@mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")
+@pytest.mark.parametrize("does_exist", [True, False])
+def test_git_cli_does_remote_exist_mock(
+    run_git_command_mock: MagicMock, does_exist: bool
+):
+    cli = GitCli()
+
+    remote_url = "https://git-repository.com/repo.git"
+
+    run_git_command_mock.return_value = (
+        subprocess.CompletedProcess(args=[], returncode=0)
+        if does_exist
+        else subprocess.CompletedProcess(args=[], returncode=1)
+    )
+
+    assert cli.does_remote_exist(remote_url) is does_exist
+
+    run_git_command_mock.assert_called_once_with(
+        ["ls-remote", remote_url], check_error=False
+    )
+
+
+@mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")
+@pytest.mark.parametrize("track", [True, False])
+def test_git_cli_checkout_branch_mock(run_git_command_mock: MagicMock, track: bool):
+    branch_name = "BRANCH_NAME"
+
+    cli = GitCli()
+    git_dir = Path("TEST_DIR")
+
+    cli.checkout_branch(git_dir, branch_name, track=track)
+
+    track_flag = ["--track"] if track else []
+
+    run_git_command_mock.assert_called_once_with(
+        ["checkout", "--quiet", *track_flag, branch_name], git_dir
+    )
+
+
+def test_git_cli_checkout_branch_no_track():
+    cli = GitCli()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir)
+
+        cli._run_git_command(["init"], working_directory=dir_path)
+        cli._run_git_command(["checkout", "-b", "main"], working_directory=dir_path)
+        cli._run_git_command(
+            ["commit", "--allow-empty", "-m", "Initial commit"],
+            working_directory=dir_path,
+        )
+
+        assert (
+            "main"
+            in subprocess.run(
+                "git status", cwd=dir_path, shell=True, capture_output=True
+            ).stdout.decode()
+        )
+
+        branch_name = "new-branch-name"
+
+        cli._run_git_command(["branch", branch_name], working_directory=dir_path)
+
+        cli.checkout_branch(dir_path, branch_name)
+
+        assert (
+            branch_name
+            in subprocess.run(
+                "git status", cwd=dir_path, shell=True, capture_output=True
+            ).stdout.decode()
+        )
+
+
+def test_git_cli_clone_fork_and_branch_minimal():
+    fork_url = "https://github.com/regro-cf-autotick-bot/pytest-feedstock.git"
+    upstream_url = "https://github.com/conda-forge/pytest-feedstock.git"
+
+    cli = GitCli()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir) / "pytest-feedstock"
+
+        new_branch_name = "new_branch_name"
+
+        cli.clone_fork_and_branch(fork_url, dir_path, upstream_url, new_branch_name)
+
+        assert cli.does_branch_exist(dir_path, "main")
+        assert (
+            new_branch_name
+            in subprocess.run(
+                "git status", cwd=dir_path, shell=True, capture_output=True
+            ).stdout.decode()
+        )
+
+
+@pytest.mark.parametrize("remote_already_exists", [True, False])
+@pytest.mark.parametrize(
+    "base_branch_exists,git_checkout_track_error",
+    [(True, False), (False, False), (False, True)],
+)
+@pytest.mark.parametrize("new_branch_already_exists", [True, False])
+@mock.patch("conda_forge_tick.git_utils.GitCli.reset_hard")
+@mock.patch("conda_forge_tick.git_utils.GitCli.checkout_new_branch")
+@mock.patch("conda_forge_tick.git_utils.GitCli.checkout_branch")
+@mock.patch("conda_forge_tick.git_utils.GitCli.does_branch_exist")
+@mock.patch("conda_forge_tick.git_utils.GitCli.fetch_all")
+@mock.patch("conda_forge_tick.git_utils.GitCli.add_remote")
+@mock.patch("conda_forge_tick.git_utils.GitCli.clone_repo")
+def test_git_cli_clone_fork_and_branch_mock(
+    clone_repo_mock: MagicMock,
+    add_remote_mock: MagicMock,
+    fetch_all_mock: MagicMock,
+    does_branch_exist_mock: MagicMock,
+    checkout_branch_mock: MagicMock,
+    checkout_new_branch_mock: MagicMock,
+    reset_hard_mock: MagicMock,
+    remote_already_exists: bool,
+    base_branch_exists: bool,
+    git_checkout_track_error: bool,
+    new_branch_already_exists: bool,
+    caplog,
+):
+    fork_url = "https://github.com/regro-cf-autotick-bot/pytest-feedstock.git"
+    upstream_url = "https://github.com/conda-forge/pytest-feedstock.git"
+    git_dir = Path("TEST_DIR")
+
+    caplog.set_level("DEBUG")
+
+    cli = GitCli()
+
+    if remote_already_exists:
+        add_remote_mock.side_effect = GitCliError("Remote already exists")
+
+    does_branch_exist_mock.return_value = base_branch_exists
+
+    def checkout_branch_side_effect(_git_dir: Path, branch: str, track: bool = False):
+        if track and git_checkout_track_error:
+            raise GitCliError("Error checking out branch with --track")
+
+        if new_branch_already_exists and branch == "new_branch_name":
+            raise GitCliError("Branch new_branch_name already exists")
+
+    checkout_branch_mock.side_effect = checkout_branch_side_effect
+
+    cli.clone_fork_and_branch(
+        fork_url, git_dir, upstream_url, "new_branch_name", "base_branch"
+    )
+
+    clone_repo_mock.assert_called_once_with(fork_url, git_dir)
+    add_remote_mock.assert_called_once_with(git_dir, "upstream", upstream_url)
+    if remote_already_exists:
+        assert "remote 'upstream' already exists" in caplog.text
+
+    fetch_all_mock.assert_called_once_with(git_dir)
+
+    if base_branch_exists:
+        checkout_branch_mock.assert_any_call(git_dir, "base_branch")
+    else:
+        checkout_branch_mock.assert_any_call(
+            git_dir, "upstream/base_branch", track=True
+        )
+
+        if git_checkout_track_error:
+            assert "Could not check out with git checkout --track" in caplog.text
+
+            checkout_new_branch_mock.assert_any_call(
+                git_dir, "base_branch", start_point="upstream/base_branch"
+            )
+
+    reset_hard_mock.assert_called_once_with(git_dir, "upstream/base_branch")
+    checkout_branch_mock.assert_any_call(git_dir, "new_branch_name")
+
+    if not new_branch_already_exists:
+        return
+
+    assert "branch new_branch_name does not exist" in caplog.text
+    checkout_new_branch_mock.assert_called_with(
+        git_dir, "new_branch_name", start_point="base_branch"
+    )
 
 
 def test_trim_pr_json_keys():

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -494,7 +494,6 @@ def test_git_cli_clone_fork_and_branch_mock(
 ):
     fork_url = "https://github.com/regro-cf-autotick-bot/pytest-feedstock.git"
     upstream_url = "https://github.com/conda-forge/pytest-feedstock.git"
-    git_dir = Path("TEST_DIR")
 
     caplog.set_level("DEBUG")
 
@@ -519,9 +518,15 @@ def test_git_cli_clone_fork_and_branch_mock(
 
     checkout_branch_mock.side_effect = checkout_branch_side_effect
 
-    cli.clone_fork_and_branch(
-        fork_url, git_dir, upstream_url, "new_branch_name", "base_branch"
-    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        git_dir = Path(tmpdir) / "pytest-feedstock"
+
+        if target_repo_already_exists:
+            git_dir.mkdir()
+
+        cli.clone_fork_and_branch(
+            fork_url, git_dir, upstream_url, "new_branch_name", "base_branch"
+        )
 
     clone_repo_mock.assert_called_once_with(fork_url, git_dir)
     if target_repo_already_exists:

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -83,12 +83,25 @@ def test_git_cli_outside_repo():
             cli.checkout_branch(dir_path, "main")
 
 
+# noinspection PyProtectedMember
+def init_temp_git_repo(git_dir: Path):
+    cli = GitCli()
+    cli._run_git_command(["init"], working_directory=git_dir)
+    cli._run_git_command(
+        ["config", "user.name", "CI Test User"], working_directory=git_dir
+    )
+    cli._run_git_command(
+        ["config", "user.email", "ci-test-user-invalid@example.com"],
+        working_directory=git_dir,
+    )
+
+
 def test_git_cli_reset_hard_already_reset():
     cli = GitCli()
     with tempfile.TemporaryDirectory() as tmpdir:
         dir_path = Path(tmpdir)
 
-        cli._run_git_command(["init"], working_directory=dir_path)
+        init_temp_git_repo(dir_path)
         cli._run_git_command(
             ["commit", "--allow-empty", "-m", "Initial commit"],
             working_directory=dir_path,
@@ -115,7 +128,7 @@ def test_git_cli_reset_hard():
     with tempfile.TemporaryDirectory() as tmpdir:
         dir_path = Path(tmpdir)
 
-        cli._run_git_command(["init"], working_directory=dir_path)
+        init_temp_git_repo(dir_path)
         cli._run_git_command(
             ["commit", "--allow-empty", "-m", "Initial commit"],
             working_directory=dir_path,
@@ -236,7 +249,7 @@ def test_git_cli_add_remote():
     with tempfile.TemporaryDirectory() as tmpdir:
         dir_path = Path(tmpdir)
 
-        cli._run_git_command(["init"], working_directory=dir_path)
+        init_temp_git_repo(dir_path)
 
         remote_name = "remote24"
         remote_url = "https://git-repository.com/repo.git"
@@ -280,7 +293,7 @@ def test_git_cli_does_branch_exist():
     with tempfile.TemporaryDirectory() as tmpdir:
         dir_path = Path(tmpdir)
 
-        cli._run_git_command(["init"], working_directory=dir_path)
+        init_temp_git_repo(dir_path)
 
         assert not cli.does_branch_exist(dir_path, "main")
 
@@ -379,7 +392,7 @@ def test_git_cli_checkout_branch_no_track():
     with tempfile.TemporaryDirectory() as tmpdir:
         dir_path = Path(tmpdir)
 
-        cli._run_git_command(["init"], working_directory=dir_path)
+        init_temp_git_repo(dir_path)
         cli._run_git_command(["checkout", "-b", "main"], working_directory=dir_path)
         cli._run_git_command(
             ["commit", "--allow-empty", "-m", "Initial commit"],

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -56,59 +56,6 @@ def test_git_cli_run_git_command_error(subprocess_run_mock: MagicMock):
         cli._run_git_command(["GIT_COMMAND"], working_directory)
 
 
-def test_git_cli_get_git_root():
-    cli = GitCli()
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        dir_path = Path(tmpdir)
-
-        init_temp_git_repo(dir_path)
-
-        assert cli._get_git_root(dir_path).resolve() == dir_path.resolve()
-
-        subdir = dir_path / "subdir"
-        subdir.mkdir()
-
-        assert cli._get_git_root(subdir).resolve() == dir_path.resolve()
-
-        with pytest.raises(FileNotFoundError):
-            cli._get_git_root(dir_path / "non_existent_dir")
-
-        sub_subdir = subdir / "sub_subdir"
-        sub_subdir.mkdir()
-
-        assert cli._get_git_root(sub_subdir).resolve() == dir_path.resolve()
-
-
-@mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")
-def test_git_cli_get_git_root_mock(run_git_command_mock: MagicMock):
-    run_git_command_mock.return_value = subprocess.CompletedProcess(
-        [], returncode=0, stdout="GIT_ROOT_PATH"
-    )
-
-    cli = GitCli()
-    git_root = cli._get_git_root(Path("TEST_DIR"))
-
-    assert git_root == Path("GIT_ROOT_PATH")
-    run_git_command_mock.assert_called_once_with(
-        ["rev-parse", "--show-toplevel"], Path("TEST_DIR"), capture_text=True
-    )
-
-
-@mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")
-def test_git_cli_get_git_root_mock_error(run_git_command_mock: MagicMock):
-    run_git_command_mock.side_effect = GitCliError("Error")
-
-    cli = GitCli()
-
-    with pytest.raises(RepositoryNotFoundError):
-        cli._get_git_root(Path("TEST_DIR"))
-
-    run_git_command_mock.assert_called_once_with(
-        ["rev-parse", "--show-toplevel"], Path("TEST_DIR"), capture_text=True
-    )
-
-
 def test_git_cli_outside_repo():
     with tempfile.TemporaryDirectory() as tmpdir:
         dir_path = Path(tmpdir)

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -56,6 +56,59 @@ def test_git_cli_run_git_command_error(subprocess_run_mock: MagicMock):
         cli._run_git_command(["GIT_COMMAND"], working_directory)
 
 
+def test_git_cli_get_git_root():
+    cli = GitCli()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir)
+
+        init_temp_git_repo(dir_path)
+
+        assert cli._get_git_root(dir_path).resolve() == dir_path.resolve()
+
+        subdir = dir_path / "subdir"
+        subdir.mkdir()
+
+        assert cli._get_git_root(subdir).resolve() == dir_path.resolve()
+
+        with pytest.raises(FileNotFoundError):
+            cli._get_git_root(dir_path / "non_existent_dir")
+
+        sub_subdir = subdir / "sub_subdir"
+        sub_subdir.mkdir()
+
+        assert cli._get_git_root(sub_subdir).resolve() == dir_path.resolve()
+
+
+@mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")
+def test_git_cli_get_git_root_mock(run_git_command_mock: MagicMock):
+    run_git_command_mock.return_value = subprocess.CompletedProcess(
+        [], returncode=0, stdout="GIT_ROOT_PATH"
+    )
+
+    cli = GitCli()
+    git_root = cli._get_git_root(Path("TEST_DIR"))
+
+    assert git_root == Path("GIT_ROOT_PATH")
+    run_git_command_mock.assert_called_once_with(
+        ["rev-parse", "--show-toplevel"], Path("TEST_DIR"), capture_text=True
+    )
+
+
+@mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")
+def test_git_cli_get_git_root_mock_error(run_git_command_mock: MagicMock):
+    run_git_command_mock.side_effect = GitCliError("Error")
+
+    cli = GitCli()
+
+    with pytest.raises(RepositoryNotFoundError):
+        cli._get_git_root(Path("TEST_DIR"))
+
+    run_git_command_mock.assert_called_once_with(
+        ["rev-parse", "--show-toplevel"], Path("TEST_DIR"), capture_text=True
+    )
+
+
 def test_git_cli_outside_repo():
     with tempfile.TemporaryDirectory() as tmpdir:
         dir_path = Path(tmpdir)

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -103,11 +103,23 @@ def test_git_cli_reset_hard_already_reset():
 
         init_temp_git_repo(dir_path)
         cli._run_git_command(
-            ["commit", "--allow-empty", "-m", "Initial commit"],
+            ["commit", "--allow-empty", "-m", "First commit"],
+            working_directory=dir_path,
+        )
+
+        cli._run_git_command(
+            ["commit", "--allow-empty", "-m", "Second commit"],
             working_directory=dir_path,
         )
 
         cli.reset_hard(dir_path)
+
+        git_log = subprocess.run(
+            "git log", cwd=dir_path, shell=True, capture_output=True
+        ).stdout.decode()
+
+        assert "First commit" in git_log
+        assert "Second commit" in git_log
 
 
 @mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")


### PR DESCRIPTION
<!-- Put your changes here -->
In my efforts about adding easier local debugging for the bot, we need a way to let the bot run without the need of having a conda-forge GitHub token available. Accomplishing this is not easy with the current codebase because the git and token logic is baked into it.

With this PR, I begin to decouple the git logic and make everything interfacing with GitHub replaceable by a dry run backend (that is currently still unused). To keep the PR small, not all git operations but only some now use the new object-oriented git approach. Further PRs will follow that replace more of the logic.

<!--
Thanks for contributing to cf-scripts!
We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

- [x] Pydantic model updated or no update needed
