### PR TITLE
Use version prefix from github URL

### DIFF
--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -563,10 +563,14 @@ class Github(VersionFromFeed):
         self.ver_prefix_remove = [self.version_prefix] + self.ver_prefix_remove
 
     def get_version_prefix(self, version: str, split_url: list[str]):
+        """Returns prefix for the first split that contains version. If prefix
+        is empty - returns None."""
         r = re.compile(rf"^(.*){version}")
         for split in split_url:
             match = r.match(split)
-            if match is not None and match.group(1) != "":
+            if match is not None:
+                if match.group(1) == "":
+                    return None
                 return match.group(1)
 
         return None

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -553,13 +553,14 @@ class IncrementAlphaRawURL(BaseRawURL):
 
 class Github(VersionFromFeed):
     name = "Github"
+    version_prefix = None
 
     def set_version_prefix(self, version: str, split_url: list[str]):
-        version_prefix = self.get_version_prefix(version, split_url)
-        if version_prefix is None:
+        self.version_prefix = self.get_version_prefix(version, split_url)
+        if self.version_prefix is None:
             return
-        logger.debug(f"Found version prefix from url: {version_prefix}")
-        self.ver_prefix_remove = [version_prefix] + self.ver_prefix_remove
+        logger.debug(f"Found version prefix from url: {self.version_prefix}")
+        self.ver_prefix_remove = [self.version_prefix] + self.ver_prefix_remove
 
     def get_version_prefix(self, version: str, split_url: list[str]):
         r = re.compile(rf"^(.*){version}")

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -555,7 +555,6 @@ class Github(VersionFromFeed):
     name = "Github"
 
     def set_version_prefix(self, version: str, split_url: list[str]):
-        logger.debug(f"dbg: {split_url}")
         version_prefix = self.get_version_prefix(version, split_url)
         if version_prefix is None:
             return
@@ -566,7 +565,7 @@ class Github(VersionFromFeed):
         r = re.compile(rf"^(.*){version}")
         for split in split_url:
             match = r.match(split)
-            if match is not None:
+            if match is not None and match.group(1) != "":
                 return match.group(1)
 
         return None

--- a/tests/test_upstream_versions.py
+++ b/tests/test_upstream_versions.py
@@ -1661,6 +1661,19 @@ def test_main(
             "1.2.3",
             "example-",
         ),
+        (
+            "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.6/llvm-18.1.6.src.tar.xz",
+            "18.1.6",
+            "llvmorg-",
+        ),
+        (
+            "https://github.com/simplejson/simplejson/releases/download/1.2.3/simplejson-1.2.3.tar.gz",
+            "1.2.3",
+            None,
+        ),
+        # Test URLs without source version (if any)
+        ("https://example.com/archs/sources.tar.gz", "1.2.3", None),
+        ("https://github.com/archs/sources.tar.gz", "1.2.3", None),
     ],
 )
 @flaky


### PR DESCRIPTION
<!-- Put your changes here -->

<!--
Thanks for contributing to cf-scripts!
We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

Pick up release prefix from the archive URL.

After this changes version at is picked up properly:
```
> CF_TICK_IN_CONTAINER=true python -m conda_forge_tick.cli --debug --online update-upstream-versions --job=1 --n-jobs=1 spirv-headers

2024-05-22 15:26:16,058 DEBUG    conda_forge_tick.update_upstream_versions || Fetching latest version for spirv-headers from Github...
2024-05-22 15:26:16,058 DEBUG    conda_forge_tick.update_sources || Found version prefix from url: vulkan-sdk-
2024-05-22 15:26:16,058 DEBUG    conda_forge_tick.update_upstream_versions || Using URL https://github.com/khronosgroup/spirv-headers/releases.atom
2024-05-22 15:26:16,801 DEBUG    conda_forge_tick.update_upstream_versions || Found version 1.3.283.0 on Github
2024-05-22 15:26:16,801 INFO     conda_forge_tick.update_upstream_versions || # 0     - spirv-headers - 1.3.268.0 - 1.3.283.0
```



- [x] Pydantic model updated or no update needed

Fixes: #2648