### PR TITLE
Replace doctr_run with our own token-preserving function

### DIFF
--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -3085,51 +3085,6 @@ package:
     version: 2.6.1
   - category: main
     dependencies:
-      cryptography: ''
-      python: '>=3.5'
-      pyyaml: ''
-      requests: ''
-    hash:
-      md5: f57b656502db0e45cc996ddbef2a9d25
-      sha256: 41ea80bd2b50180e074632152c3364ac92d75546af46db10a724a07eb1ff06d4
-    manager: conda
-    name: doctr
-    optional: false
-    platform: linux-64
-    url: https://conda.anaconda.org/conda-forge/noarch/doctr-1.9.0-pyhd8ed1ab_0.tar.bz2
-    version: 1.9.0
-  - category: main
-    dependencies:
-      cryptography: ''
-      python: '>=3.5'
-      pyyaml: ''
-      requests: ''
-    hash:
-      md5: f57b656502db0e45cc996ddbef2a9d25
-      sha256: 41ea80bd2b50180e074632152c3364ac92d75546af46db10a724a07eb1ff06d4
-    manager: conda
-    name: doctr
-    optional: false
-    platform: osx-64
-    url: https://conda.anaconda.org/conda-forge/noarch/doctr-1.9.0-pyhd8ed1ab_0.tar.bz2
-    version: 1.9.0
-  - category: main
-    dependencies:
-      cryptography: ''
-      python: '>=3.5'
-      pyyaml: ''
-      requests: ''
-    hash:
-      md5: f57b656502db0e45cc996ddbef2a9d25
-      sha256: 41ea80bd2b50180e074632152c3364ac92d75546af46db10a724a07eb1ff06d4
-    manager: conda
-    name: doctr
-    optional: false
-    platform: osx-arm64
-    url: https://conda.anaconda.org/conda-forge/noarch/doctr-1.9.0-pyhd8ed1ab_0.tar.bz2
-    version: 1.9.0
-  - category: main
-    dependencies:
       python: '>=3.7'
     hash:
       md5: 9873878e2a069bc358b69e9a29c1ecd5

--- a/conda_forge_tick/deploy.py
+++ b/conda_forge_tick/deploy.py
@@ -1,12 +1,10 @@
 import os
 import subprocess
 
-from doctr.travis import run_command_hiding_token as doctr_run
-
 from . import sensitive_env
 from .cli_context import CliContext
 from .lazy_json_backends import CF_TICK_GRAPH_DATA_HASHMAPS, get_lazy_json_backends
-from .utils import get_bot_run_url, load_existing_graph
+from .utils import get_bot_run_url, load_existing_graph, run_command_hiding_token
 
 
 def _run_git_cmd(cmd, **kwargs):
@@ -63,7 +61,7 @@ def _deploy_batch(*, files_to_add, batch, n_added, max_per_batch=200):
                 pass
             print("\n\n>>>>>>>>>>>> git push try %d\n\n" % num_try, flush=True)
             with sensitive_env() as env:
-                status = doctr_run(
+                status = run_command_hiding_token(
                     [
                         "git",
                         "push",
@@ -73,7 +71,7 @@ def _deploy_batch(*, files_to_add, batch, n_added, max_per_batch=200):
                         ),
                         "master",
                     ],
-                    token=env.get("BOT_TOKEN", "").encode("utf-8"),
+                    token=env.get("BOT_TOKEN", ""),
                 )
             num_try += 1
 

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -17,7 +17,6 @@ import github3.exceptions
 import github3.pulls
 import github3.repos
 import requests
-from doctr.travis import run_command_hiding_token as doctr_run
 from requests.exceptions import RequestException, Timeout
 
 from conda_forge_tick import sensitive_env
@@ -28,7 +27,7 @@ from conda_forge_tick.lazy_json_backends import LazyJson
 
 from .contexts import FeedstockContext
 from .os_utils import pushd
-from .utils import get_bot_run_url
+from .utils import get_bot_run_url, run_command_hiding_token
 
 logger = logging.getLogger(__name__)
 
@@ -378,7 +377,7 @@ def delete_branch(pr_json: LazyJson, dry_run: bool = False) -> None:
     deploy_repo = gh.me().login + "/" + name
 
     with sensitive_env() as env:
-        doctr_run(
+        run_command_hiding_token(
             [
                 "git",
                 "push",
@@ -386,7 +385,7 @@ def delete_branch(pr_json: LazyJson, dry_run: bool = False) -> None:
                 "--delete",
                 ref,
             ],
-            token=env["BOT_TOKEN"].encode("utf-8"),
+            token=env["BOT_TOKEN"],
         )
     # Replace ref so we know not to try again
     pr_json["head"]["ref"] = "this_is_not_a_branch"
@@ -629,7 +628,6 @@ def push_repo(
         to create a PR instance.
     """
     with sensitive_env() as env, pushd(feedstock_dir):
-        # Setup push from doctr
         # Copyright (c) 2016 Aaron Meurer, Gil Forsyth
         token = env["BOT_TOKEN"]
         gh_username = github3_client().me().login
@@ -642,7 +640,7 @@ def push_repo(
             repo_url = f"https://github.com/{deploy_repo}.git"
             print(f"dry run: adding remote and pushing up branch for {repo_url}")
         else:
-            ecode = doctr_run(
+            ecode = run_command_hiding_token(
                 [
                     "git",
                     "remote",
@@ -650,15 +648,15 @@ def push_repo(
                     "regro_remote",
                     f"https://{token}@github.com/{deploy_repo}.git",
                 ],
-                token=token.encode("utf-8"),
+                token=token,
             )
             if ecode != 0:
                 print("Failed to add git remote!")
                 return False
 
-            ecode = doctr_run(
+            ecode = run_command_hiding_token(
                 ["git", "push", "--set-upstream", "regro_remote", branch],
-                token=token.encode("utf-8"),
+                token=token,
             )
             if ecode != 0:
                 print("Failed to push to remote!")

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -966,3 +966,58 @@ def change_log_level(logger, new_level):
         yield
     finally:
         logger.setLevel(saved_logger_level)
+
+
+def print_subprocess_output_strip_token(
+    completed_process: subprocess.CompletedProcess, token: str
+) -> None:
+    """
+    Use this function to print the outputs (stdout and stderr) of a subprocess.CompletedProcess object
+    that may contain sensitive information. The token will be replaced with a string
+    of asterisks of the same length.
+
+    This function assumes that you have called subprocess.run() with the arguments text=True, stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE.
+
+    If stdout or stderr is None, it will not be printed.
+
+    See run_command_hiding_token() for a convenience method that combines running a command and printing the output.
+
+    :param completed_process: The subprocess.CompletedProcess object to print the outputs of. You have probably
+        obtained this object by calling subprocess.run().
+    :param token: The token to replace with asterisks.
+
+    :raises ValueError: If the completed_process object does not contain str in stdout or stderr.
+    """
+    out, err = completed_process.stdout, completed_process.stderr
+
+    for captured, out_dev in [(out, sys.stdout), (err, sys.stderr)]:
+        if captured is None:
+            continue
+
+        if not isinstance(captured, str):
+            raise ValueError(
+                f"Expected stdout and stderr to be str, but got {type(captured)}. Run subprocess.run() with "
+                "text=True."
+            )
+
+        captured = captured.replace(token, "*" * len(token))
+        print(captured, file=out_dev, end="")
+        out_dev.flush()
+
+
+def run_command_hiding_token(args: list[str], token: str) -> int:
+    """
+    Run a command and hide the token in the output.
+
+    This is a convenience method for print_subprocess_output_strip_token() if you don't need full control
+    over subprocess.run().
+
+    :param args: The command to run.
+    :param token: The token to hide in the output.
+    :return: The return code of the command.
+    """
+    p = subprocess.run(args, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    print_subprocess_output_strip_token(p, token)
+
+    return p.returncode

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,6 @@ dependencies:
   - curl
   - depfinder
   - distributed
-  - doctr
   - feedparser
   - frozendict
   - git
@@ -63,7 +62,6 @@ dependencies:
   - pytest<8.1.0
   - codecov
   - requests-mock
-  - doctr
   - pre-commit
   - flaky
   - pytest-xdist

--- a/mypy.ini
+++ b/mypy.ini
@@ -38,9 +38,6 @@ ignore_missing_imports = True
 [mypy-pytest.*]
 ignore_missing_imports = True
 
-[mypy-doctr.*]
-ignore_missing_imports = True
-
 [mypy-backoff.*]
 ignore_missing_imports = True
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,6 @@
+import contextlib
+from io import StringIO
+from subprocess import CompletedProcess
 from unittest import mock
 from unittest.mock import MagicMock, mock_open
 
@@ -10,6 +13,8 @@ from conda_forge_tick.utils import (
     load_existing_graph,
     load_graph,
     parse_munged_run_export,
+    print_subprocess_output_strip_token,
+    run_command_hiding_token,
 )
 
 EMPTY_JSON = "{}"
@@ -148,3 +153,127 @@ def test_munge_dict_repr():
     d = {"a": 1, "b": 2, "weak": [1, 2, 3], "strong": {"a": 1, "b": 2}}
     print(_munge_dict_repr(d))
     assert parse_munged_run_export(_munge_dict_repr(d)) == d
+
+
+def test_print_subprocess_output_strip_token_all_none():
+    stdout = StringIO()
+    stderr = StringIO()
+
+    p = CompletedProcess(args=[], returncode=0, stdout=None, stderr=None)
+
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        print_subprocess_output_strip_token(p, "TOKEN")
+
+    assert stdout.getvalue() == ""
+    assert stderr.getvalue() == ""
+
+
+def test_print_subprocess_output_strip_token_stdout_only():
+    stdout = StringIO()
+    stderr = StringIO()
+
+    p = CompletedProcess(args=[], returncode=0, stdout="stdout", stderr=None)
+
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        print_subprocess_output_strip_token(p, "TOKEN")
+
+    assert stdout.getvalue() == "stdout"
+    assert stderr.getvalue() == ""
+
+
+def test_print_subprocess_output_strip_token_stderr_only():
+    stdout = StringIO()
+    stderr = StringIO()
+
+    p = CompletedProcess(args=[], returncode=0, stdout=None, stderr="stderr")
+
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        print_subprocess_output_strip_token(p, "TOKEN")
+
+    assert stdout.getvalue() == ""
+    assert stderr.getvalue() == "stderr"
+
+
+def test_print_subprocess_output_strip_token_both():
+    stdout = StringIO()
+    stderr = StringIO()
+
+    p = CompletedProcess(
+        args=[], returncode=0, stdout="stdTOKEN.out", stderr="stdTOKEN.err"
+    )
+
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        print_subprocess_output_strip_token(p, "TOKEN")
+
+    assert stdout.getvalue() == "std****.out"
+    assert stderr.getvalue() == "std****.err"
+
+
+def test_print_subprocess_output_strip_token_no_token():
+    stdout = StringIO()
+    stderr = StringIO()
+
+    p = CompletedProcess(args=[], returncode=0, stdout="stdout", stderr="stderr")
+
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        print_subprocess_output_strip_token(p, "TOKEN")
+
+    assert stdout.getvalue() == "stdout"
+    assert stderr.getvalue() == "stderr"
+
+
+def test_print_subprocess_output_strip_token_multiple_occurrences():
+    stdout = StringIO()
+    stderr = StringIO()
+
+    p = CompletedProcess(
+        args=[], returncode=1, stdout="stdTOKEN-TOKEN.out", stderr="stdTOKEN-TOKEN.err"
+    )
+
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        print_subprocess_output_strip_token(p, "TOKEN")
+
+    assert stdout.getvalue() == "std****-******.out"
+    assert stderr.getvalue() == "std****-******.err"
+
+
+def test_print_subprocess_output_strip_token_bytes_in_stdout():
+    stdout = StringIO()
+    stderr = StringIO()
+
+    p = CompletedProcess(
+        args=[], returncode=1, stdout=b"stdTOKEN-TOKEN.out", stderr=b""
+    )
+
+    with pytest.raises(ValueError, match="Expected stdout and stderr to be str"):
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            print_subprocess_output_strip_token(p, "TOKEN")
+
+    assert stdout.getvalue() == ""
+    assert stderr.getvalue() == ""
+
+
+def test_run_command_hiding_token():
+    cmd = ["python", "-c", "print('stdTOKEN.out')"]
+
+    stdout = StringIO()
+    stderr = StringIO()
+
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        run_command_hiding_token(cmd, "TOKEN")
+
+    assert stdout.getvalue() == "std*****.out\n"
+    assert stderr.getvalue() == ""
+
+
+def test_run_command_hiding_token_stderr():
+    cmd = ["python", "-c", "import sys; sys.stderr.write('stdTOKEN.err')"]
+
+    stdout = StringIO()
+    stderr = StringIO()
+
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        run_command_hiding_token(cmd, "TOKEN")
+
+    assert stdout.getvalue() == ""
+    assert stderr.getvalue() == "std*****.err"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -205,8 +205,8 @@ def test_print_subprocess_output_strip_token_both():
     with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
         print_subprocess_output_strip_token(p, "TOKEN")
 
-    assert stdout.getvalue() == "std****.out"
-    assert stderr.getvalue() == "std****.err"
+    assert stdout.getvalue() == "std*****.out"
+    assert stderr.getvalue() == "std*****.err"
 
 
 def test_print_subprocess_output_strip_token_no_token():
@@ -233,8 +233,8 @@ def test_print_subprocess_output_strip_token_multiple_occurrences():
     with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
         print_subprocess_output_strip_token(p, "TOKEN")
 
-    assert stdout.getvalue() == "std****-******.out"
-    assert stderr.getvalue() == "std****-******.err"
+    assert stdout.getvalue() == "std*****-*****.out"
+    assert stderr.getvalue() == "std*****-*****.err"
 
 
 def test_print_subprocess_output_strip_token_bytes_in_stdout():


### PR DESCRIPTION
<!-- Put your changes here -->
This PR removed `doctr_run` and the corresponding dependency from our repo.

Why?
- In the very near future, `GitCli` should be able to run commands that require token hiding in outputs. However, I cannot easily use `doctr_run` for it because I need more control over the subprocess `CompletedProcess` return object. 
- With this change, I have `run_command_hiding_token` which is equivalent to `doctr_run` as well as `print_subprocess_output_strip_token`, allowing me to run the subprocess with token hiding logic manually.
- doctr is quite a big dependency just to get a 10-line function, so probably it's a good idea to remove it anyway.

<!--
Thanks for contributing to cf-scripts!
We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

- [x] Pydantic model updated or no update needed
