### PR TITLE
ensure trailing newline when rewriting conda_build_config.yaml

### DIFF
--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -108,6 +108,9 @@ def merge_migrator_cbc(migrator_yaml: str, conda_build_config_yaml: str):
         # if this is in a key we didn't migrate, add the line (or it is a space)
         elif current_cbc_key not in migrator_keys or line.isspace() or not line:
             outbound_cbc.append(line)
+    if outbound_cbc and outbound_cbc[-1]:
+        # ensure trailing newline
+        outbound_cbc.append("")
     return "\n".join(outbound_cbc)
 
 


### PR DESCRIPTION
migrators keep rewriting conda_build_config.yaml with the only change being stripping trailing newlines, like [this one](https://github.com/conda-forge/petsc-feedstock/pull/199/commits/84c7c0813b8d865aeebdd8b90fd0733c08de2b50)

I'm not 100% sure if this is the relevant bit, but I _think_ it is. It is at least clear that this code would produce a file without a trailing newline.

<!--
Thanks for contributing to cf-scripts!
We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

- [x] Pydantic model updated or no update needed
