### PR TITLE
Readd git backend

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -30,8 +30,8 @@ from conda_forge_tick.feedstock_parser import BOOTSTRAP_MAPPINGS
 from conda_forge_tick.git_utils import (
     GIT_CLONE_DIR,
     comment_on_pr,
-    get_github_api_requests_left,
     get_repo,
+    github_backend,
     is_github_api_limit_reached,
     push_repo,
 )
@@ -194,13 +194,7 @@ def run(
 
     # TODO: run this in parallel
     feedstock_dir, repo = get_repo(
-        fctx=feedstock_ctx,
-        branch=branch_name,
-        feedstock=feedstock_ctx.feedstock_name,
-        protocol=protocol,
-        pull_request=pull_request,
-        fork=fork,
-        base_branch=base_branch,
+        fctx=feedstock_ctx, branch=branch_name, base_branch=base_branch
     )
     if not feedstock_dir or not repo:
         logger.critical(
@@ -617,7 +611,8 @@ def _run_migrator_on_feedstock_branch(
                 fctx.feedstock_name,
             )
 
-            if is_github_api_limit_reached(e):
+            if is_github_api_limit_reached():
+                logger.warning("GitHub API error", exc_info=e)
                 break_loop = True
 
     except VersionMigrationError as e:
@@ -692,7 +687,8 @@ def _run_migrator_on_feedstock_branch(
 
 def _is_migrator_done(_mg_start, good_prs, time_per, pr_limit):
     curr_time = time.time()
-    api_req = get_github_api_requests_left()
+    backend = github_backend()
+    api_req = backend.get_api_requests_left()
 
     if curr_time - START_TIME > TIMEOUT:
         logger.info(
@@ -1124,5 +1120,5 @@ def main(ctx: CliContext) -> None:
             #     ],
             # )
 
-    logger.info("API Calls Remaining: %d", get_github_api_requests_left())
+    logger.info("API Calls Remaining: %d", github_backend().get_api_requests_left())
     logger.info("Done")

--- a/conda_forge_tick/executors.py
+++ b/conda_forge_tick/executors.py
@@ -16,9 +16,21 @@ class DummyLock:
         pass
 
 
-TRLOCK = TRLock()
-PRLOCK = DummyLock()
-DRLOCK = DummyLock()
+GIT_LOCK_THREAD = TRLock()
+GIT_LOCK_PROCESS = DummyLock()
+GIT_LOCK_DASK = DummyLock()
+
+
+@contextlib.contextmanager
+def lock_git_operation():
+    """
+    A context manager to lock git operations - it can be acquired once per thread, once per process,
+    and once per dask worker.
+    Note that this is a reentrant lock, so it can be acquired multiple times by the same thread/process/worker.
+    """
+
+    with GIT_LOCK_THREAD, GIT_LOCK_PROCESS, GIT_LOCK_DASK:
+        yield
 
 
 logger = logging.getLogger(__name__)
@@ -27,10 +39,12 @@ logger = logging.getLogger(__name__)
 class DaskRLock(DaskLock):
     """A reentrant lock for dask that is always blocking and never times out."""
 
-    def acquire(self):
-        if not hasattr(self, "_rcount"):
-            self._rcount = 0
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._rcount = 0
+        self._rdata = None
 
+    def acquire(self, *args):
         self._rcount += 1
 
         if self._rcount == 1:
@@ -39,29 +53,29 @@ class DaskRLock(DaskLock):
         return self._rdata
 
     def release(self):
-        if not hasattr(self, "_rcount") or self._rcount == 0:
+        if self._rcount == 0:
             raise RuntimeError("Lock not acquired so cannot be released!")
 
         self._rcount -= 1
 
         if self._rcount == 0:
-            delattr(self, "_rdata")
+            self._rdata = None
             return super().release()
         else:
             return None
 
 
 def _init_process(lock):
-    global PRLOCK
-    PRLOCK = lock
+    global GIT_LOCK_PROCESS
+    GIT_LOCK_PROCESS = lock
 
 
 def _init_dask(lock):
-    global DRLOCK
-    # it appears we have to construct the locak by name instead
+    global GIT_LOCK_DASK
+    # it appears we have to construct the lock by name instead
     # of passing the object itself
     # otherwise dask uses a regular lock
-    DRLOCK = DaskRLock(name=lock)
+    GIT_LOCK_DASK = DaskRLock(name=lock)
 
 
 @contextlib.contextmanager
@@ -70,8 +84,8 @@ def executor(kind: str, max_workers: int, daemon=True) -> typing.Iterator[Execut
 
     This allows us to easily use other executors as needed.
     """
-    global DRLOCK
-    global PRLOCK
+    global GIT_LOCK_DASK
+    global GIT_LOCK_PROCESS
 
     if kind == "thread":
         with ThreadPoolExecutor(max_workers=max_workers) as pool_t:
@@ -85,7 +99,7 @@ def executor(kind: str, max_workers: int, daemon=True) -> typing.Iterator[Execut
             initargs=(lock,),
         ) as pool_p:
             yield pool_p
-        PRLOCK = DummyLock()
+        GIT_LOCK_PROCESS = DummyLock()
     elif kind in ["dask", "dask-process", "dask-thread"]:
         import dask
         import distributed
@@ -101,6 +115,6 @@ def executor(kind: str, max_workers: int, daemon=True) -> typing.Iterator[Execut
                 with distributed.Client(cluster) as client:
                     client.run(_init_dask, "cftick")
                     yield ClientExecutor(client)
-                DRLOCK = DummyLock()
+                GIT_LOCK_DASK = DummyLock()
     else:
         raise NotImplementedError("That kind is not implemented")

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -1,14 +1,17 @@
 """Utilities for managing github repos"""
 
 import copy
-import datetime
+import enum
 import logging
-import os
+import math
 import subprocess
-import sys
 import threading
 import time
-from typing import Dict, Optional, Tuple, Union
+from abc import ABC, abstractmethod
+from datetime import datetime
+from functools import cached_property
+from pathlib import Path
+from typing import Dict, Literal, Optional, Tuple, Union
 
 import backoff
 import github
@@ -26,6 +29,7 @@ from conda_forge_tick import sensitive_env
 from conda_forge_tick.lazy_json_backends import LazyJson
 
 from .contexts import FeedstockContext
+from .executors import lock_git_operation
 from .os_utils import pushd
 from .utils import get_bot_run_url, run_command_hiding_token
 
@@ -71,6 +75,9 @@ PR_KEYS_TO_KEEP = {
 
 
 def github3_client() -> github3.GitHub:
+    """
+    This will be removed in the future, use the GitHubBackend class instead.
+    """
     if not hasattr(GITHUB3_CLIENT, "client"):
         with sensitive_env() as env:
             GITHUB3_CLIENT.client = github3.login(token=env["BOT_TOKEN"])
@@ -78,6 +85,9 @@ def github3_client() -> github3.GitHub:
 
 
 def github_client() -> github.Github:
+    """
+    This will be removed in the future, use the GitHubBackend class instead.
+    """
     if not hasattr(GITHUB_CLIENT, "client"):
         with sensitive_env() as env:
             GITHUB_CLIENT.client = github.Github(
@@ -87,77 +97,584 @@ def github_client() -> github.Github:
     return GITHUB_CLIENT.client
 
 
-def get_default_branch(feedstock_name):
-    """Get the default branch for a feedstock
+class Bound(float, enum.Enum):
+    def __str__(self):
+        return str(self.value)
 
-    Parameters
-    ----------
-    feedstock_name : str
-        The feedstock without '-feedstock'.
-
-    Returns
-    -------
-    branch : str
-        The default branch (e.g., 'main').
+    INFINITY = math.inf
     """
-    return (
-        github_client()
-        .get_repo(f"conda-forge/{feedstock_name}-feedstock")
-        .default_branch
-    )
-
-
-def get_github_api_requests_left() -> Union[int, None]:
-    """Get the number of remaining GitHub API requests.
-
-    Returns
-    -------
-    left : int or None
-        The number of remaining requests, or None if there is an exception.
+    Python does not have support for a literal infinity type, so we use this enum for it.
     """
-    gh = github3_client()
-    try:
-        left = gh.rate_limit()["resources"]["core"]["remaining"]
-    except Exception:
-        left = None
-
-    return left
 
 
-def is_github_api_limit_reached(
-    e: Union[github3.GitHubError, github.GithubException],
-) -> bool:
-    """Prints diagnostic information about a github exception.
+class GitConnectionMode(enum.StrEnum):
+    SSH = "ssh"
+    HTTPS = "https"
 
-    Parameters
-    ----------
-    e
-        The exception to check.
 
-    Returns
-    -------
-    out_of_api_calls
-        A flag to indicate that the api call limit has been reached.
+class GitCliError(Exception):
+    pass
+
+
+class RepositoryNotFoundError(Exception):
     """
-    gh = github3_client()
+    Raised when a repository is not found.
+    """
 
-    logger.warning("GitHub API error:", exc_info=e)
+    pass
 
-    try:
-        c = gh.rate_limit()["resources"]["core"]
-    except Exception:
-        # if we can't connect to the rate limit API, let's assume it has been reached
-        return True
 
-    if c["remaining"] == 0:
-        ts = c["reset"]
-        logger.warning(
-            "GitHub API timeout, API returns at %s",
-            datetime.datetime.utcfromtimestamp(ts).strftime("%Y-%m-%dT%H:%M:%SZ"),
+class GitCli:
+    """
+    A simple wrapper around the git command line interface.
+
+    Git operations are locked (globally) to prevent operations from interfering with each other.
+    If this does impact performance too much, we can consider a per-repository locking strategy.
+    """
+
+    @staticmethod
+    @lock_git_operation()
+    def _run_git_command(
+        cmd: list[str | Path],
+        working_directory: Path | None = None,
+        check_error: bool = True,
+        capture_text: bool = False,
+    ) -> subprocess.CompletedProcess:
+        """
+        Run a git command.
+        :param cmd: The command to run, as a list of strings.
+        :param working_directory: The directory to run the command in. If None, the command will be run in the current
+        working directory.
+        :param check_error: If True, raise a GitCliError if the git command fails.
+        :param capture_text: If True, capture the output of the git command as text. The output will be in the
+        returned result object.
+        :return: The result of the git command.
+        :raises GitCliError: If the git command fails and check_error is True.
+        :raises FileNotFoundError: If the working directory does not exist.
+        """
+        git_command = ["git"] + cmd
+
+        logger.debug(f"Running git command: {git_command}")
+        capture_args = {"capture_output": True, "text": True} if capture_text else {}
+
+        try:
+            return subprocess.run(
+                git_command, check=check_error, cwd=working_directory, **capture_args
+            )
+        except subprocess.CalledProcessError as e:
+            raise GitCliError("Error running git command.") from e
+
+    @lock_git_operation()
+    def reset_hard(self, git_dir: Path, to_treeish: str = "HEAD"):
+        """
+        Reset the git index of a directory to the state of the last commit with `git reset --hard HEAD`.
+        :param git_dir: The directory to reset.
+        :param to_treeish: The treeish to reset to. Defaults to "HEAD".
+        :raises GitCliError: If the git command fails.
+        :raises FileNotFoundError: If the git_dir does not exist.
+        """
+        self._run_git_command(["reset", "--quiet", "--hard", to_treeish], git_dir)
+
+    @lock_git_operation()
+    def clone_repo(self, origin_url: str, target_dir: Path):
+        """
+        Clone a Git repository.
+        If target_dir exists and is non-empty, this method will fail with GitCliError.
+        If target_dir exists and is empty, it will work.
+        If target_dir does not exist, it will work.
+        :param target_dir: The directory to clone the repository into.
+        :param origin_url: The URL of the repository to clone.
+        :raises GitCliError: If the git command fails (e.g. because origin_url does not point to valid remote or
+        target_dir is not empty).
+        """
+        try:
+            self._run_git_command(["clone", "--quiet", origin_url, target_dir])
+        except GitCliError as e:
+            raise GitCliError(
+                f"Error cloning repository from {origin_url}. Does the repository exist? Is target_dir empty?"
+            ) from e
+
+    @lock_git_operation()
+    def add_remote(self, git_dir: Path, remote_name: str, remote_url: str):
+        """
+        Add a remote to a git repository.
+        :param remote_name: The name of the remote.
+        :param remote_url: The URL of the remote.
+        :param git_dir: The directory of the git repository.
+        :raises GitCliError: If the git command fails (e.g., the remote already exists).
+        :raises FileNotFoundError: If git_dir does not exist
+        """
+        self._run_git_command(["remote", "add", remote_name, remote_url], git_dir)
+
+    @lock_git_operation()
+    def fetch_all(self, git_dir: Path):
+        """
+        Fetch all changes from all remotes.
+        :param git_dir: The directory of the git repository.
+        :raises GitCliError: If the git command fails.
+        :raises FileNotFoundError: If git_dir does not exist
+        """
+        self._run_git_command(["fetch", "--all", "--quiet"], git_dir)
+
+    def does_branch_exist(self, git_dir: Path, branch_name: str):
+        """
+        Check if a branch exists in a git repository.
+        Note: If git_dir is not a git repository, this method will return False.
+        Note: This method is intentionally not locked with lock_git_operation, as it only reads the git repository and
+        does not modify it.
+        :param branch_name: The name of the branch.
+        :param git_dir: The directory of the git repository.
+        :return: True if the branch exists, False otherwise.
+        :raises GitCliError: If the git command fails.
+        :raises FileNotFoundError: If git_dir does not exist
+        """
+        ret = self._run_git_command(
+            ["show-ref", "--verify", "--quiet", f"refs/heads/{branch_name}"],
+            git_dir,
+            check_error=False,
         )
-        return True
 
-    return False
+        return ret.returncode == 0
+
+    def does_remote_exist(self, remote_url: str) -> bool:
+        """
+        Check if a remote exists.
+        Note: This method is intentionally not locked with lock_git_operation, as it only reads a remote and does not
+        modify a git repository.
+        :param remote_url: The URL of the remote.
+        :return: True if the remote exists, False otherwise.
+        """
+        ret = self._run_git_command(["ls-remote", remote_url], check_error=False)
+
+        return ret.returncode == 0
+
+    @lock_git_operation()
+    def checkout_branch(
+        self,
+        git_dir: Path,
+        branch: str,
+        track: bool = False,
+    ):
+        """
+        Checkout a branch in a git repository.
+        :param git_dir: The directory of the git repository.
+        :param branch: The branch to check out.
+        :param track: If True, set the branch to track the remote branch with the same name (sets the --track flag).
+        A new local branch will be created with the name inferred from branch.
+        For example, if branch is "upstream/main", the new branch will be "main".
+        :raises GitCliError: If the git command fails.
+        :raises FileNotFoundError: If git_dir does not exist
+        """
+        track_flag = ["--track"] if track else []
+        self._run_git_command(
+            ["checkout", "--quiet"] + track_flag + [branch],
+            git_dir,
+        )
+
+    @lock_git_operation()
+    def checkout_new_branch(
+        self, git_dir: Path, branch: str, start_point: str | None = None
+    ):
+        """
+        Checkout a new branch in a git repository.
+        :param git_dir: The directory of the git repository.
+        :param branch: The name of the new branch.
+        :param start_point: The name of the branch to branch from, or None to branch from the current branch.
+        :raises FileNotFoundError: If git_dir does not exist
+        """
+        start_point_option = [start_point] if start_point else []
+
+        self._run_git_command(
+            ["checkout", "--quiet", "-b", branch] + start_point_option, git_dir
+        )
+
+    @lock_git_operation()
+    def clone_fork_and_branch(
+        self,
+        origin_url: str,
+        target_dir: Path,
+        upstream_url: str,
+        new_branch: str,
+        base_branch: str = "main",
+    ):
+        """
+        Convenience method to do the following:
+        1. Clone the repository at origin_url into target_dir (resetting the directory if it already exists).
+        2. Add a remote named "upstream" with the URL upstream_url (ignoring if it already exists).
+        3. Fetch all changes from all remotes.
+        4. Checkout the base branch.
+        5. Create a new branch from the base branch with the name new_branch.
+
+        This is usually used to create a new branch for a pull request. In this case, origin_url is the URL of the
+        user's fork, and upstream_url is the URL of the upstream repository.
+
+        :param origin_url: The URL of the repository (fork) to clone.
+        :param target_dir: The directory to clone the repository into.
+        :param upstream_url: The URL of the upstream repository.
+        :param new_branch: The name of the branch to create.
+        :param base_branch: The name of the base branch to branch from.
+
+        :raises GitCliError: If a git command fails.
+        """
+        try:
+            self.clone_repo(origin_url, target_dir)
+        except GitCliError:
+            if not target_dir.exists():
+                raise GitCliError(
+                    f"Could not clone {origin_url} - does the remote exist?"
+                )
+            logger.debug(
+                f"Cloning {origin_url} into {target_dir} was not successful - "
+                f"trying to reset hard since the directory already exists. This will fail if the target directory is "
+                f"not a git repository."
+            )
+            self.reset_hard(target_dir)
+
+        try:
+            self.add_remote(target_dir, "upstream", upstream_url)
+        except GitCliError as e:
+            logger.debug(
+                "It looks like remote 'upstream' already exists. Ignoring.", exc_info=e
+            )
+            pass
+
+        self.fetch_all(target_dir)
+
+        if self.does_branch_exist(target_dir, base_branch):
+            self.checkout_branch(target_dir, base_branch)
+        else:
+            try:
+                self.checkout_branch(target_dir, f"upstream/{base_branch}", track=True)
+            except GitCliError as e:
+                logger.debug(
+                    "Could not check out with git checkout --track. Trying git checkout -b.",
+                    exc_info=e,
+                )
+
+                # not sure why this is needed, but it was in the original code
+                self.checkout_new_branch(
+                    target_dir,
+                    base_branch,
+                    start_point=f"upstream/{base_branch}",
+                )
+
+        # not sure why this is needed, but it was in the original code
+        self.reset_hard(target_dir, f"upstream/{base_branch}")
+
+        try:
+            logger.debug(
+                f"Trying to checkout branch {new_branch} without creating a new branch"
+            )
+            self.checkout_branch(target_dir, new_branch)
+        except GitCliError:
+            logger.debug(
+                f"It seems branch {new_branch} does not exist. Creating it.",
+            )
+            self.checkout_new_branch(target_dir, new_branch, start_point=base_branch)
+
+
+class GitPlatformBackend(ABC):
+    """
+    A backend for interacting with a git platform (e.g. GitHub).
+
+    Implementation Note: If you wonder what should be in this class vs. the GitCli class, the GitPlatformBackend class
+    should contain the logic for interacting with the platform (e.g. GitHub), while the GitCli class should contain the
+    logic for interacting with the git repository itself. If you need to know anything specific about the platform,
+    it should be in the GitPlatformBackend class.
+
+    Git operations are locked (globally) to prevent operations from interfering with each other.
+    If this does impact performance too much, we can consider a per-repository locking strategy.
+    """
+
+    def __init__(self, git_cli: GitCli):
+        """
+        Create a new GitPlatformBackend.
+        :param git_cli: The GitCli instance to use for interacting with git repositories.
+        """
+        self.cli = git_cli
+
+    @abstractmethod
+    def does_repository_exist(self, owner: str, repo_name: str) -> bool:
+        """
+        Check if a repository exists.
+        :param owner: The owner of the repository.
+        :param repo_name: The name of the repository.
+        """
+        pass
+
+    @staticmethod
+    def get_remote_url(
+        owner: str,
+        repo_name: str,
+        connection_mode: GitConnectionMode = GitConnectionMode.SSH,
+    ) -> str:
+        """
+        Get the URL of a remote repository.
+        :param owner: The owner of the repository.
+        :param repo_name: The name of the repository.
+        :param connection_mode: The connection mode to use (defaults to SSH).
+        :raises ValueError: If the connection mode is not supported.
+        """
+        # Currently we don't need any abstraction for other platforms than GitHub, so we don't build such abstractions.
+        match connection_mode:
+            case GitConnectionMode.HTTPS:
+                return f"https://github.com/{owner}/{repo_name}.git"
+            case GitConnectionMode.SSH:
+                return f"git@github.com:{owner}/{repo_name}.git"
+            case _:
+                raise ValueError(f"Unsupported connection mode: {connection_mode}")
+
+    @abstractmethod
+    def fork(self, owner: str, repo_name: str):
+        """
+        Fork a repository. If the fork already exists, do nothing except syncing the default branch name.
+        Forks are created under the current user's account (see `self.user`).
+        The name of the forked repository is the same as the original repository.
+        :param owner: The owner of the repository.
+        :param repo_name: The name of the repository.
+        :raises RepositoryNotFoundError: If the repository does not exist.
+        """
+        pass
+
+    @lock_git_operation()
+    def clone_fork_and_branch(
+        self,
+        upstream_owner: str,
+        repo_name: str,
+        target_dir: Path,
+        new_branch: str,
+        base_branch: str = "main",
+    ):
+        """
+        Identical to `GitCli::clone_fork_and_branch`, but generates the URLs from the repository name.
+
+        :param upstream_owner: The owner of the upstream repository.
+        :param repo_name: The name of the repository.
+        :param target_dir: The directory to clone the repository into.
+        :param new_branch: The name of the branch to create.
+        :param base_branch: The name of the base branch to branch from.
+
+        :raises GitCliError: If a git command fails.
+        """
+        self.cli.clone_fork_and_branch(
+            origin_url=self.get_remote_url(self.user, repo_name),
+            target_dir=target_dir,
+            upstream_url=self.get_remote_url(upstream_owner, repo_name),
+            new_branch=new_branch,
+            base_branch=base_branch,
+        )
+
+    @property
+    @abstractmethod
+    def user(self) -> str:
+        """
+        The username of the logged-in user, i.e. the owner of forked repositories.
+        """
+        pass
+
+    @abstractmethod
+    def _sync_default_branch(self, upstream_owner: str, upstream_repo: str):
+        """
+        Sync the default branch of the forked repository with the upstream repository.
+        :param upstream_owner: The owner of the upstream repository.
+        :param upstream_repo: The name of the upstream repository.
+        """
+        pass
+
+    @abstractmethod
+    def get_api_requests_left(self) -> int | Bound | None:
+        """
+        Get the number of remaining API requests for the backend.
+        Returns `Bound.INFINITY` if the backend does not have a rate limit.
+        Returns None if an exception occurred while getting the rate limit.
+
+        Implementations may print diagnostic information about the API limit.
+        """
+        pass
+
+    def is_api_limit_reached(self) -> bool:
+        """
+        Returns True if the API limit has been reached, False otherwise.
+
+        If an exception occurred while getting the rate limit, this method returns True, assuming the limit has
+        been reached.
+
+        Additionally, implementations may print diagnostic information about the API limit.
+        """
+        return self.get_api_requests_left() in (0, None)
+
+
+class GitHubBackend(GitPlatformBackend):
+    """
+    A git backend for GitHub, using both PyGithub and github3.py as clients.
+    Both clients are used for historical reasons. In the future, this should be refactored to use only one client.
+
+    Git operations are locked (globally) to prevent operations from interfering with each other.
+    If this does impact performance too much, we can consider a per-repository locking strategy.
+    """
+
+    _GITHUB_PER_PAGE = 100
+    """
+    The number of items to fetch per page from the GitHub API.
+    """
+
+    def __init__(self, github3_client: github3.GitHub, pygithub_client: github.Github):
+        super().__init__(GitCli())
+        self.github3_client = github3_client
+        self.pygithub_client = pygithub_client
+
+    @classmethod
+    def from_token(cls, token: str):
+        return cls(
+            github3.login(token=token),
+            github.Github(auth=github.Auth.Token(token), per_page=cls._GITHUB_PER_PAGE),
+        )
+
+    def does_repository_exist(self, owner: str, repo_name: str) -> bool:
+        repo = self.github3_client.repository(owner, repo_name)
+        return repo is not None
+
+    @lock_git_operation()
+    def fork(self, owner: str, repo_name: str):
+        if self.does_repository_exist(self.user, repo_name):
+            # The fork already exists, so we only sync the default branch.
+            self._sync_default_branch(owner, repo_name)
+            return
+
+        repo = self.github3_client.repository(owner, repo_name)
+        if repo is None:
+            raise RepositoryNotFoundError(
+                f"Repository {owner}/{repo_name} does not exist."
+            )
+
+        logger.debug(f"Forking {owner}/{repo_name}.")
+        repo.create_fork()
+
+        # Sleep to make sure the fork is created before we go after it
+        time.sleep(5)
+
+    @lock_git_operation()
+    def _sync_default_branch(self, upstream_owner: str, repo_name: str):
+        fork_owner = self.user
+
+        upstream_repo = self.pygithub_client.get_repo(f"{upstream_owner}/{repo_name}")
+        fork = self.pygithub_client.get_repo(f"{fork_owner}/{repo_name}")
+
+        if upstream_repo.default_branch == fork.default_branch:
+            return
+
+        logger.info(
+            f"Syncing default branch of {fork_owner}/{repo_name} with {upstream_owner}/{repo_name}..."
+        )
+
+        fork.rename_branch(fork.default_branch, upstream_repo.default_branch)
+
+        # Sleep to wait for branch name change
+        time.sleep(5)
+
+    @cached_property
+    def user(self) -> str:
+        return self.pygithub_client.get_user().login
+
+    def get_api_requests_left(self) -> int | None:
+        try:
+            limit_info = self.github3_client.rate_limit()
+        except github3.exceptions.GitHubException as e:
+            logger.warning("GitHub API error while fetching rate limit.", exc_info=e)
+            return None
+
+        try:
+            core_resource = limit_info["resources"]["core"]
+            remaining_limit = core_resource["remaining"]
+        except KeyError as e:
+            logger.warning("GitHub API error while parsing rate limit.", exc_info=e)
+            return None
+
+        if remaining_limit != 0:
+            return remaining_limit
+
+        # try to log when the limit will be reset
+        try:
+            reset_timestamp = core_resource["reset"]
+        except KeyError as e:
+            logger.warning(
+                "GitHub API error while fetching rate limit reset time.",
+                exc_info=e,
+            )
+            return remaining_limit
+
+        logger.info(
+            "GitHub API limit reached, will reset at "
+            f"{datetime.utcfromtimestamp(reset_timestamp).strftime('%Y-%m-%dT%H:%M:%SZ')}"
+        )
+
+        return remaining_limit
+
+
+class DryRunBackend(GitPlatformBackend):
+    """
+    A git backend that doesn't modify anything and only relies on public APIs that do not require authentication.
+    Useful for local testing with dry-run.
+
+    By default, the dry run backend assumes that the current user has not created any forks yet.
+    If forks are created, their names are stored in memory and can be checked with `does_repository_exist`.
+    """
+
+    _USER = "auto-tick-bot-dry-run"
+
+    def __init__(self):
+        super().__init__(GitCli())
+        self._repos: set[str] = set()
+
+    def get_api_requests_left(self) -> Bound:
+        return Bound.INFINITY
+
+    def does_repository_exist(self, owner: str, repo_name: str) -> bool:
+        if owner == self._USER:
+            return repo_name in self._repos
+
+        # We do not use the GitHub API because unauthenticated requests are quite strictly rate-limited.
+        return self.cli.does_remote_exist(
+            self.get_remote_url(owner, repo_name, GitConnectionMode.HTTPS)
+        )
+
+    @lock_git_operation()
+    def fork(self, owner: str, repo_name: str):
+        if repo_name in self._repos:
+            raise ValueError(f"Fork of {repo_name} already exists.")
+
+        logger.debug(
+            f"Dry Run: Creating fork of {owner}/{repo_name} for user {self._USER}."
+        )
+        self._repos.add(repo_name)
+
+    def _sync_default_branch(self, upstream_owner: str, upstream_repo: str):
+        logger.debug(
+            f"Dry Run: Syncing default branch of {upstream_owner}/{upstream_repo}."
+        )
+
+    @property
+    def user(self) -> str:
+        return self._USER
+
+
+def github_backend() -> GitHubBackend:
+    """
+    This helper method will be removed in the future, use the GitHubBackend class directly.
+    """
+    with sensitive_env() as env:
+        return GitHubBackend.from_token(env["BOT_TOKEN"])
+
+
+def is_github_api_limit_reached() -> bool:
+    """
+    Return True if the GitHub API limit has been reached, False otherwise.
+
+    This method will be removed in the future, use the GitHubBackend class directly.
+    """
+    backend = github_backend()
+
+    return backend.is_api_limit_reached()
 
 
 def feedstock_url(fctx: FeedstockContext, protocol: str = "ssh") -> str:
@@ -177,126 +694,30 @@ def feedstock_url(fctx: FeedstockContext, protocol: str = "ssh") -> str:
     elif protocol == "ssh":
         url = "git@github.com:conda-forge/" + feedstock + ".git"
     else:
-        msg = "Unrecognized github protocol {0!r}, must be ssh, http, or https."
-        raise ValueError(msg.format(protocol))
+        msg = f"Unrecognized github protocol {protocol}, must be ssh, http, or https."
+        raise ValueError(msg)
     return url
 
 
 def feedstock_repo(fctx: FeedstockContext) -> str:
     """Gets the name of the feedstock repository."""
-    repo = fctx.feedstock_name + "-feedstock"
-    if repo.endswith(".git"):
-        repo = repo[:-4]
-    return repo
+    return fctx.feedstock_name + "-feedstock"
 
 
-def fork_url(feedstock_url: str, username: str) -> str:
-    """Creates the URL of the user's fork."""
-    beg, end = feedstock_url.rsplit("/", 1)
-    beg = beg[:-11]  # chop off 'conda-forge'
-    url = beg + username + "/" + end
-    return url
-
-
-def fetch_repo(*, feedstock_dir, origin, upstream, branch, base_branch="main"):
-    """fetch a repo and make a PR branch
-
-    Parameters
-    ----------
-    feedstock_dir : str
-        The directory where you want to clone the feedstock.
-    origin : str
-        The origin to clone from.
-    upstream : str
-        The upstream repo to add as a remote named `upstream`.
-    branch : str
-        The branch to make and checkout.
-    base_branch : str, optional
-        The branch from which to branch from to make `branch`. Defaults to "main".
-
-    Returns
-    -------
-    success : bool
-        True if the fetch worked, False otherwise.
-    """
-    if not os.path.isdir(feedstock_dir):
-        p = subprocess.run(
-            ["git", "clone", "-q", origin, feedstock_dir],
-        )
-        if p.returncode != 0:
-            msg = "Could not clone " + origin
-            msg += ". Do you have a personal fork of the feedstock?"
-            print(msg, file=sys.stderr)
-            return False
-        reset_hard = False
-    else:
-        reset_hard = True
-
-    def _run_git_cmd(cmd, **kwargs):
-        return subprocess.run(["git"] + cmd, check=True, **kwargs)
-
-    quiet = "--quiet"
-    with pushd(feedstock_dir):
-        if reset_hard:
-            _run_git_cmd(["reset", "--hard", "HEAD"])
-
-        # doesn't work if the upstream already exists
-        try:
-            # always run upstream
-            _run_git_cmd(["remote", "add", "upstream", upstream])
-        except subprocess.CalledProcessError:
-            pass
-
-        # fetch remote changes
-        _run_git_cmd(["fetch", "--all", quiet])
-        if _run_git_cmd(
-            ["branch", "--list", base_branch],
-            capture_output=True,
-        ).stdout:
-            _run_git_cmd(["checkout", base_branch, quiet])
-        else:
-            try:
-                _run_git_cmd(["checkout", "--track", f"upstream/{base_branch}", quiet])
-            except subprocess.CalledProcessError:
-                _run_git_cmd(
-                    ["checkout", "-b", base_branch, f"upstream/{base_branch}", quiet],
-                )
-        _run_git_cmd(["reset", "--hard", f"upstream/{base_branch}", quiet])
-
-        # make and modify version branch
-        try:
-            _run_git_cmd(["checkout", branch, quiet])
-        except subprocess.CalledProcessError:
-            _run_git_cmd(["checkout", "-b", branch, base_branch, quiet])
-
-    return True
-
-
+@lock_git_operation()
 def get_repo(
     fctx: FeedstockContext,
     branch: str,
-    feedstock: Optional[str] = None,
-    protocol: str = "ssh",
-    pull_request: bool = True,
-    fork: bool = True,
     base_branch: str = "main",
-) -> Tuple[str, github3.repos.Repository]:
+) -> Tuple[str, github3.repos.Repository] | Tuple[Literal[False], Literal[False]]:
     """Get the feedstock repo
 
     Parameters
     ----------
-    fcts : FeedstockContext
+    fctx : FeedstockContext
         Feedstock context used for constructing feedstock urls, etc.
     branch : str
         The branch to be made.
-    feedstock : str, optional
-        The feedstock to clone if None use $FEEDSTOCK
-    protocol : str, optional
-        The git protocol to use, defaults to ``ssh``
-    pull_request : bool, optional
-        If true issue pull request, defaults to true
-    fork : bool
-        If true create a fork, defaults to true
     base_branch : str, optional
         The base branch from which to make the new branch.
 
@@ -307,65 +728,38 @@ def get_repo(
     repo : github3 repository
         The github3 repository object.
     """
-    gh = github3_client()
-    gh_username = gh.me().login
+    backend = github_backend()
+    feedstock_repo_name = feedstock_repo(fctx)
 
-    # first, let's grab the feedstock locally
-    upstream = feedstock_url(fctx=fctx, protocol=protocol)
-    origin = fork_url(upstream, gh_username)
-    feedstock_reponame = feedstock_repo(fctx=fctx)
-
-    if pull_request or fork:
-        repo = gh.repository("conda-forge", feedstock_reponame)
-        if repo is None:
-            print("could not fork conda-forge/%s!" % feedstock_reponame, flush=True)
-            with fctx.attrs["pr_info"] as pri:
-                pri["bad"] = f"{fctx.feedstock_name}: could not find feedstock\n"
-            return False, False
-
-    # Check if fork exists
-    if fork:
-        try:
-            fork_repo = gh.repository(gh_username, feedstock_reponame)
-        except github3.GitHubError:
-            fork_repo = None
-        if fork_repo is None or (hasattr(fork_repo, "is_null") and fork_repo.is_null()):
-            print("Fork doesn't exist creating feedstock fork...")
-            repo.create_fork()
-            # Sleep to make sure the fork is created before we go after it
-            time.sleep(5)
-
-        # sync the default branches if needed
-        _sync_default_branches(feedstock_reponame)
-
-    feedstock_dir = os.path.join(GIT_CLONE_DIR, fctx.feedstock_name + "-feedstock")
-
-    if fetch_repo(
-        feedstock_dir=feedstock_dir,
-        origin=origin,
-        upstream=upstream,
-        branch=branch,
-        base_branch=base_branch,
-    ):
-        return feedstock_dir, repo
-    else:
+    try:
+        backend.fork("conda-forge", feedstock_repo_name)
+    except RepositoryNotFoundError:
+        logger.warning(f"Could not fork conda-forge/{feedstock_repo_name}")
+        with fctx.attrs["pr_info"] as pri:
+            pri["bad"] = f"{fctx.feedstock_name}: Git repository not found.\n"
         return False, False
 
+    feedstock_dir = Path(GIT_CLONE_DIR) / (fctx.feedstock_name + "-feedstock")
 
-def _sync_default_branches(reponame):
-    gh = github_client()
-    forked_user = gh.get_user().login
-    default_branch = gh.get_repo(f"conda-forge/{reponame}").default_branch
-    forked_default_branch = gh.get_repo(f"{forked_user}/{reponame}").default_branch
-    if default_branch != forked_default_branch:
-        print("Fork's default branch doesn't match upstream, syncing...")
-        forked_repo = gh.get_repo(f"{forked_user}/{reponame}")
-        forked_repo.rename_branch(forked_default_branch, default_branch)
+    backend.clone_fork_and_branch(
+        upstream_owner="conda-forge",
+        repo_name=feedstock_repo_name,
+        target_dir=feedstock_dir,
+        new_branch=branch,
+        base_branch=base_branch,
+    )
 
-        # sleep to wait for branch name change
-        time.sleep(5)
+    # This is needed because we want to migrate to the new backend step-by-step
+    repo: github3.repos.Repository | None = github3_client().repository(
+        "conda-forge", feedstock_repo_name
+    )
+
+    assert repo is not None
+
+    return feedstock_repo_name, repo
 
 
+@lock_git_operation()
 def delete_branch(pr_json: LazyJson, dry_run: bool = False) -> None:
     ref = pr_json["head"]["ref"]
     if dry_run:
@@ -447,9 +841,6 @@ def lazy_update_pr_json(
     force : bool, optional
         If True, forcibly update the PR json even if it is not out of date
         according to the ETag. Default is False.
-    trim : bool, optional
-        If True, trim the PR json keys to ones in the global PR_KEYS_TO_KEEP.
-        Default is True.
 
     Returns
     -------
@@ -589,6 +980,7 @@ def close_out_labels(
     return None
 
 
+@lock_git_operation()
 def push_repo(
     fctx: FeedstockContext,
     feedstock_dir: str,
@@ -604,7 +996,7 @@ def push_repo(
 
     Parameters
     ----------
-    fcts : FeedstockContext
+    fctx : FeedstockContext
         Feedstock context used for constructing feedstock urls, etc.
     feedstock_dir : str
         The feedstock directory

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -406,7 +406,7 @@ class GitPlatformBackend(ABC):
     def get_remote_url(
         owner: str,
         repo_name: str,
-        connection_mode: GitConnectionMode = GitConnectionMode.SSH,
+        connection_mode: GitConnectionMode = GitConnectionMode.HTTPS,
     ) -> str:
         """
         Get the URL of a remote repository.

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -26,6 +26,7 @@ import rapidjson as json
 import requests
 
 from .cli_context import CliContext
+from .executors import lock_git_operation
 
 logger = logging.getLogger(__name__)
 
@@ -159,10 +160,8 @@ class FileLazyJsonBackend(LazyJsonBackend):
         }
 
     def hdel(self, name: str, keys: Iterable[str]) -> None:
-        from .executors import DRLOCK, PRLOCK, TRLOCK
-
         lzj_names = [get_sharded_path(f"{name}/{key}.json") for key in keys]
-        with PRLOCK, DRLOCK, TRLOCK:
+        with lock_git_operation():
             subprocess.run(
                 ["git", "rm", "--ignore-unmatch", "-f"] + lzj_names,
                 capture_output=True,

--- a/conda_forge_tick/update_prs.py
+++ b/conda_forge_tick/update_prs.py
@@ -89,7 +89,8 @@ def _update_pr(update_function, dry_run, gx, job, n_jobs):
             except (github3.GitHubError, github.GithubException) as e:
                 logger.error(f"GITHUB ERROR ON FEEDSTOCK: {name}")
                 failed_refresh += 1
-                if is_github_api_limit_reached(e):
+                if is_github_api_limit_reached():
+                    logger.warning("GitHub API error", exc_info=e)
                     break
             except (github3.exceptions.ConnectionError, github.GithubException):
                 logger.error(f"GITHUB ERROR ON FEEDSTOCK: {name}")

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -1,4 +1,903 @@
-from conda_forge_tick.git_utils import trim_pr_json_keys
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest import mock
+from unittest.mock import MagicMock
+
+import github3.exceptions
+import pytest
+
+from conda_forge_tick.git_utils import (
+    Bound,
+    DryRunBackend,
+    GitCli,
+    GitCliError,
+    GitConnectionMode,
+    GitHubBackend,
+    GitPlatformBackend,
+    RepositoryNotFoundError,
+    trim_pr_json_keys,
+)
+
+"""
+Note: You have to have git installed on your machine to run these tests.
+"""
+
+
+@mock.patch("subprocess.run")
+@pytest.mark.parametrize("check_error", [True, False])
+def test_git_cli_run_git_command_no_error(
+    subprocess_run_mock: MagicMock, check_error: bool
+):
+    cli = GitCli()
+
+    working_directory = Path("TEST_DIR")
+
+    cli._run_git_command(
+        ["GIT_COMMAND", "ARG1", "ARG2"], working_directory, check_error
+    )
+
+    subprocess_run_mock.assert_called_once_with(
+        ["git", "GIT_COMMAND", "ARG1", "ARG2"], check=check_error, cwd=working_directory
+    )
+
+
+@mock.patch("subprocess.run")
+def test_git_cli_run_git_command_error(subprocess_run_mock: MagicMock):
+    cli = GitCli()
+
+    working_directory = Path("TEST_DIR")
+
+    subprocess_run_mock.side_effect = subprocess.CalledProcessError(
+        returncode=1, cmd=""
+    )
+
+    with pytest.raises(GitCliError):
+        cli._run_git_command(["GIT_COMMAND"], working_directory)
+
+
+def test_git_cli_outside_repo():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir)
+
+        with dir_path.joinpath("test.txt").open("w") as f:
+            f.write("Hello, World!")
+
+        cli = GitCli()
+
+        with pytest.raises(GitCliError):
+            cli._run_git_command(["status"], working_directory=dir_path)
+
+        with pytest.raises(GitCliError):
+            cli.reset_hard(dir_path)
+
+        with pytest.raises(GitCliError):
+            cli.add_remote(dir_path, "origin", "https://github.com/torvalds/linux.git")
+
+        with pytest.raises(GitCliError):
+            cli.fetch_all(dir_path)
+
+        assert not cli.does_branch_exist(dir_path, "main")
+
+        with pytest.raises(GitCliError):
+            cli.checkout_branch(dir_path, "main")
+
+
+# noinspection PyProtectedMember
+def init_temp_git_repo(git_dir: Path):
+    cli = GitCli()
+    cli._run_git_command(["init"], working_directory=git_dir)
+    cli._run_git_command(
+        ["config", "user.name", "CI Test User"], working_directory=git_dir
+    )
+    cli._run_git_command(
+        ["config", "user.email", "ci-test-user-invalid@example.com"],
+        working_directory=git_dir,
+    )
+
+
+def test_git_cli_reset_hard_already_reset():
+    cli = GitCli()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir)
+
+        init_temp_git_repo(dir_path)
+        cli._run_git_command(
+            ["commit", "--allow-empty", "-m", "First commit"],
+            working_directory=dir_path,
+        )
+
+        cli._run_git_command(
+            ["commit", "--allow-empty", "-m", "Second commit"],
+            working_directory=dir_path,
+        )
+
+        cli.reset_hard(dir_path)
+
+        git_log = subprocess.run(
+            "git log", cwd=dir_path, shell=True, capture_output=True
+        ).stdout.decode()
+
+        assert "First commit" in git_log
+        assert "Second commit" in git_log
+
+
+@mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")
+def test_git_cli_reset_hard_mock(run_git_command_mock: MagicMock):
+    cli = GitCli()
+
+    git_dir = Path("TEST_DIR")
+
+    cli.reset_hard(git_dir)
+
+    run_git_command_mock.assert_called_once_with(
+        ["reset", "--quiet", "--hard", "HEAD"], git_dir
+    )
+
+
+def test_git_cli_reset_hard():
+    cli = GitCli()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir)
+
+        init_temp_git_repo(dir_path)
+        cli._run_git_command(
+            ["commit", "--allow-empty", "-m", "Initial commit"],
+            working_directory=dir_path,
+        )
+
+        with dir_path.joinpath("test.txt").open("w") as f:
+            f.write("Hello, World!")
+
+        cli._run_git_command(["add", "test.txt"], working_directory=dir_path)
+        cli._run_git_command(
+            ["commit", "-am", "Add test.txt"], working_directory=dir_path
+        )
+
+        with dir_path.joinpath("test.txt").open("w") as f:
+            f.write("Hello, World! Again!")
+
+        cli.reset_hard(dir_path)
+
+        with dir_path.joinpath("test.txt").open("r") as f:
+            assert f.read() == "Hello, World!"
+
+
+def test_git_cli_clone_repo_not_exists():
+    cli = GitCli()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir)
+
+        with pytest.raises(GitCliError):
+            cli.clone_repo(
+                "https://github.com/conda-forge/this-repo-does-not-exist.git", dir_path
+            )
+
+
+def test_git_cli_clone_repo_success():
+    cli = GitCli()
+
+    git_url = "https://github.com/conda-forge/duckdb-feedstock.git"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir) / "duckdb-feedstock"
+
+        # this is an archived feedstock that should not change
+        cli.clone_repo(git_url, dir_path)
+
+        readme_file = dir_path.joinpath("README.md")
+
+        assert readme_file.exists()
+
+
+def test_git_cli_clone_repo_existing_empty_dir():
+    cli = GitCli()
+
+    git_url = "https://github.com/conda-forge/duckdb-feedstock.git"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        target = Path(tmpdir) / "duckdb-feedstock"
+
+        target.mkdir()
+
+        cli.clone_repo(git_url, target)
+
+        readme_file = target.joinpath("README.md")
+
+        assert readme_file.exists()
+
+
+@mock.patch("conda_forge_tick.git_utils.GitCli.reset_hard")
+@mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")
+def test_git_cli_clone_repo_mock_success(
+    run_git_command_mock: MagicMock, reset_hard_mock: MagicMock
+):
+    cli = GitCli()
+
+    git_url = "https://git-repository.com/repo.git"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir) / "repo"
+
+        cli.clone_repo(git_url, dir_path)
+
+        run_git_command_mock.assert_called_once_with(
+            ["clone", "--quiet", git_url, dir_path]
+        )
+
+
+@mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")
+def test_git_cli_clone_repo_mock_error(run_git_command_mock: MagicMock):
+    cli = GitCli()
+
+    git_url = "https://git-repository.com/repo.git"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir) / "repo"
+
+        run_git_command_mock.side_effect = GitCliError("Error")
+
+        with pytest.raises(GitCliError, match="Error cloning repository"):
+            cli.clone_repo(git_url, dir_path)
+
+
+@mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")
+def test_git_cli_add_remote_mock(run_git_command_mock: MagicMock):
+    cli = GitCli()
+
+    git_dir = Path("TEST_DIR")
+    remote_name = "origin"
+    remote_url = "https://git-repository.com/repo.git"
+
+    cli.add_remote(git_dir, remote_name, remote_url)
+
+    run_git_command_mock.assert_called_once_with(
+        ["remote", "add", remote_name, remote_url], git_dir
+    )
+
+
+def test_git_cli_add_remote():
+    cli = GitCli()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir)
+
+        init_temp_git_repo(dir_path)
+
+        remote_name = "remote24"
+        remote_url = "https://git-repository.com/repo.git"
+
+        cli.add_remote(dir_path, remote_name, remote_url)
+
+        output = subprocess.run(
+            "git remote -v", cwd=dir_path, shell=True, capture_output=True
+        )
+
+        assert remote_name in output.stdout.decode()
+        assert remote_url in output.stdout.decode()
+
+
+@mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")
+def test_git_cli_fetch_all_mock(run_git_command_mock: MagicMock):
+    cli = GitCli()
+
+    git_dir = Path("TEST_DIR")
+
+    cli.fetch_all(git_dir)
+
+    run_git_command_mock.assert_called_once_with(["fetch", "--all", "--quiet"], git_dir)
+
+
+def test_git_cli_fetch_all():
+    cli = GitCli()
+
+    git_url = "https://github.com/conda-forge/duckdb-feedstock.git"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir) / "duckdb-feedstock"
+
+        cli.clone_repo(git_url, dir_path)
+        cli.fetch_all(dir_path)
+
+
+def test_git_cli_does_branch_exist():
+    cli = GitCli()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir)
+
+        init_temp_git_repo(dir_path)
+
+        assert not cli.does_branch_exist(dir_path, "main")
+
+        cli._run_git_command(["checkout", "-b", "main"], working_directory=dir_path)
+        cli._run_git_command(
+            ["commit", "--allow-empty", "-m", "Initial commit"],
+            working_directory=dir_path,
+        )
+
+        assert cli.does_branch_exist(dir_path, "main")
+
+
+@mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")
+@pytest.mark.parametrize("does_exist", [True, False])
+def test_git_cli_does_branch_exist_mock(
+    run_git_command_mock: MagicMock, does_exist: bool
+):
+    cli = GitCli()
+
+    git_dir = Path("TEST_DIR")
+    branch_name = "main"
+
+    run_git_command_mock.return_value = (
+        subprocess.CompletedProcess(args=[], returncode=0)
+        if does_exist
+        else subprocess.CompletedProcess(args=[], returncode=1)
+    )
+
+    assert cli.does_branch_exist(git_dir, branch_name) is does_exist
+
+    run_git_command_mock.assert_called_once_with(
+        ["show-ref", "--verify", "--quiet", f"refs/heads/{branch_name}"],
+        git_dir,
+        check_error=False,
+    )
+
+
+def test_git_cli_does_remote_exist_false():
+    cli = GitCli()
+
+    remote_url = "https://github.com/conda-forge/this-repo-does-not-exist.git"
+
+    assert not cli.does_remote_exist(remote_url)
+
+
+def test_git_cli_does_remote_exist_true():
+    cli = GitCli()
+
+    remote_url = "https://github.com/conda-forge/pytest-feedstock.git"
+
+    assert cli.does_remote_exist(remote_url)
+
+
+@mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")
+@pytest.mark.parametrize("does_exist", [True, False])
+def test_git_cli_does_remote_exist_mock(
+    run_git_command_mock: MagicMock, does_exist: bool
+):
+    cli = GitCli()
+
+    remote_url = "https://git-repository.com/repo.git"
+
+    run_git_command_mock.return_value = (
+        subprocess.CompletedProcess(args=[], returncode=0)
+        if does_exist
+        else subprocess.CompletedProcess(args=[], returncode=1)
+    )
+
+    assert cli.does_remote_exist(remote_url) is does_exist
+
+    run_git_command_mock.assert_called_once_with(
+        ["ls-remote", remote_url], check_error=False
+    )
+
+
+@mock.patch("conda_forge_tick.git_utils.GitCli._run_git_command")
+@pytest.mark.parametrize("track", [True, False])
+def test_git_cli_checkout_branch_mock(run_git_command_mock: MagicMock, track: bool):
+    branch_name = "BRANCH_NAME"
+
+    cli = GitCli()
+    git_dir = Path("TEST_DIR")
+
+    cli.checkout_branch(git_dir, branch_name, track=track)
+
+    track_flag = ["--track"] if track else []
+
+    run_git_command_mock.assert_called_once_with(
+        ["checkout", "--quiet", *track_flag, branch_name], git_dir
+    )
+
+
+def test_git_cli_checkout_branch_no_track():
+    cli = GitCli()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir)
+
+        init_temp_git_repo(dir_path)
+        cli._run_git_command(["checkout", "-b", "main"], working_directory=dir_path)
+        cli._run_git_command(
+            ["commit", "--allow-empty", "-m", "Initial commit"],
+            working_directory=dir_path,
+        )
+
+        assert (
+            "main"
+            in subprocess.run(
+                "git status", cwd=dir_path, shell=True, capture_output=True
+            ).stdout.decode()
+        )
+
+        branch_name = "new-branch-name"
+
+        cli._run_git_command(["branch", branch_name], working_directory=dir_path)
+
+        cli.checkout_branch(dir_path, branch_name)
+
+        assert (
+            branch_name
+            in subprocess.run(
+                "git status", cwd=dir_path, shell=True, capture_output=True
+            ).stdout.decode()
+        )
+
+
+def test_git_cli_clone_fork_and_branch_minimal():
+    fork_url = "https://github.com/regro-cf-autotick-bot/pytest-feedstock.git"
+    upstream_url = "https://github.com/conda-forge/pytest-feedstock.git"
+
+    cli = GitCli()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir) / "pytest-feedstock"
+
+        new_branch_name = "new_branch_name"
+
+        cli.clone_fork_and_branch(fork_url, dir_path, upstream_url, new_branch_name)
+
+        assert cli.does_branch_exist(dir_path, "main")
+        assert (
+            new_branch_name
+            in subprocess.run(
+                "git status", cwd=dir_path, shell=True, capture_output=True
+            ).stdout.decode()
+        )
+
+
+@pytest.mark.parametrize("remote_already_exists", [True, False])
+@pytest.mark.parametrize(
+    "base_branch_exists,git_checkout_track_error",
+    [(True, False), (False, False), (False, True)],
+)
+@pytest.mark.parametrize("new_branch_already_exists", [True, False])
+@pytest.mark.parametrize("target_repo_already_exists", [True, False])
+@mock.patch("conda_forge_tick.git_utils.GitCli.reset_hard")
+@mock.patch("conda_forge_tick.git_utils.GitCli.checkout_new_branch")
+@mock.patch("conda_forge_tick.git_utils.GitCli.checkout_branch")
+@mock.patch("conda_forge_tick.git_utils.GitCli.does_branch_exist")
+@mock.patch("conda_forge_tick.git_utils.GitCli.fetch_all")
+@mock.patch("conda_forge_tick.git_utils.GitCli.add_remote")
+@mock.patch("conda_forge_tick.git_utils.GitCli.clone_repo")
+def test_git_cli_clone_fork_and_branch_mock(
+    clone_repo_mock: MagicMock,
+    add_remote_mock: MagicMock,
+    fetch_all_mock: MagicMock,
+    does_branch_exist_mock: MagicMock,
+    checkout_branch_mock: MagicMock,
+    checkout_new_branch_mock: MagicMock,
+    reset_hard_mock: MagicMock,
+    remote_already_exists: bool,
+    base_branch_exists: bool,
+    git_checkout_track_error: bool,
+    new_branch_already_exists: bool,
+    target_repo_already_exists: bool,
+    caplog,
+):
+    fork_url = "https://github.com/regro-cf-autotick-bot/pytest-feedstock.git"
+    upstream_url = "https://github.com/conda-forge/pytest-feedstock.git"
+
+    caplog.set_level("DEBUG")
+
+    cli = GitCli()
+
+    if target_repo_already_exists:
+        clone_repo_mock.side_effect = GitCliError(
+            "target_dir is not an empty directory"
+        )
+
+    if remote_already_exists:
+        add_remote_mock.side_effect = GitCliError("Remote already exists")
+
+    does_branch_exist_mock.return_value = base_branch_exists
+
+    def checkout_branch_side_effect(_git_dir: Path, branch: str, track: bool = False):
+        if track and git_checkout_track_error:
+            raise GitCliError("Error checking out branch with --track")
+
+        if new_branch_already_exists and branch == "new_branch_name":
+            raise GitCliError("Branch new_branch_name already exists")
+
+    checkout_branch_mock.side_effect = checkout_branch_side_effect
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        git_dir = Path(tmpdir) / "pytest-feedstock"
+
+        if target_repo_already_exists:
+            git_dir.mkdir()
+
+        cli.clone_fork_and_branch(
+            fork_url, git_dir, upstream_url, "new_branch_name", "base_branch"
+        )
+
+    clone_repo_mock.assert_called_once_with(fork_url, git_dir)
+    if target_repo_already_exists:
+        reset_hard_mock.assert_any_call(git_dir)
+
+    add_remote_mock.assert_called_once_with(git_dir, "upstream", upstream_url)
+    if remote_already_exists:
+        assert "remote 'upstream' already exists" in caplog.text
+
+    fetch_all_mock.assert_called_once_with(git_dir)
+
+    if base_branch_exists:
+        checkout_branch_mock.assert_any_call(git_dir, "base_branch")
+    else:
+        checkout_branch_mock.assert_any_call(
+            git_dir, "upstream/base_branch", track=True
+        )
+
+        if git_checkout_track_error:
+            assert "Could not check out with git checkout --track" in caplog.text
+
+            checkout_new_branch_mock.assert_any_call(
+                git_dir, "base_branch", start_point="upstream/base_branch"
+            )
+
+    reset_hard_mock.assert_called_with(git_dir, "upstream/base_branch")
+    checkout_branch_mock.assert_any_call(git_dir, "new_branch_name")
+
+    if not new_branch_already_exists:
+        return
+
+    assert "branch new_branch_name does not exist" in caplog.text
+    checkout_new_branch_mock.assert_called_with(
+        git_dir, "new_branch_name", start_point="base_branch"
+    )
+
+
+def test_git_cli_clone_fork_and_branch_non_existing_remote():
+    origin_url = "https://github.com/conda-forge/this-repo-does-not-exist.git"
+    upstream_url = "https://github.com/conda-forge/duckdb-feedstock.git"
+    new_branch = "NEW_BRANCH"
+
+    cli = GitCli()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir) / "duckdb-feedstock"
+
+        with pytest.raises(GitCliError, match="does the remote exist?"):
+            cli.clone_fork_and_branch(origin_url, dir_path, upstream_url, new_branch)
+
+
+def test_git_cli_clone_fork_and_branch_non_existing_remote_existing_target_dir(caplog):
+    origin_url = "https://github.com/conda-forge/this-repo-does-not-exist.git"
+    upstream_url = "https://github.com/conda-forge/duckdb-feedstock.git"
+    new_branch = "NEW_BRANCH"
+
+    cli = GitCli()
+    caplog.set_level("DEBUG")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir) / "duckdb-feedstock"
+        dir_path.mkdir()
+
+        with pytest.raises(GitCliError):
+            cli.clone_fork_and_branch(origin_url, dir_path, upstream_url, new_branch)
+
+        assert "trying to reset hard" in caplog.text
+
+
+def test_git_platform_backend_get_remote_url_https():
+    owner = "OWNER"
+    repo = "REPO"
+
+    url = GitPlatformBackend.get_remote_url(owner, repo, GitConnectionMode.HTTPS)
+
+    assert url == f"https://github.com/{owner}/{repo}.git"
+
+
+def test_git_platform_backend_get_remote_url_ssh():
+    owner = "OWNER"
+    repo = "REPO"
+
+    url = GitPlatformBackend.get_remote_url(owner, repo, GitConnectionMode.SSH)
+
+    assert url == f"git@github.com:{owner}/{repo}.git"
+
+
+def test_github_backend_from_token():
+    token = "TOKEN"
+
+    backend = GitHubBackend.from_token(token)
+
+    assert backend.github3_client.session.auth.token == token
+    # we cannot verify the pygithub token trivially
+
+
+@pytest.mark.parametrize("does_exist", [True, False])
+def test_github_backend_does_repository_exist(does_exist: bool):
+    github3_client = MagicMock()
+
+    backend = GitHubBackend(github3_client, MagicMock())
+
+    github3_client.repository.return_value = MagicMock() if does_exist else None
+
+    assert backend.does_repository_exist("OWNER", "REPO") is does_exist
+    github3_client.repository.assert_called_once_with("OWNER", "REPO")
+
+
+@mock.patch("time.sleep", return_value=None)
+@mock.patch(
+    "conda_forge_tick.git_utils.GitHubBackend.user", new_callable=mock.PropertyMock
+)
+@mock.patch("conda_forge_tick.git_utils.GitHubBackend.does_repository_exist")
+def test_github_backend_fork_not_exists_repo_found(
+    exists_mock: MagicMock, user_mock: MagicMock, sleep_mock: MagicMock
+):
+    exists_mock.return_value = False
+
+    github3_client = MagicMock()
+    repository = MagicMock()
+    github3_client.repository.return_value = repository
+
+    backend = GitHubBackend(github3_client, MagicMock())
+    user_mock.return_value = "USER"
+    backend.fork("UPSTREAM-OWNER", "REPO")
+
+    exists_mock.assert_called_once_with("USER", "REPO")
+    github3_client.repository.assert_called_once_with("UPSTREAM-OWNER", "REPO")
+    repository.create_fork.assert_called_once()
+    sleep_mock.assert_called_once_with(5)
+
+
+@pytest.mark.parametrize("branch_already_synced", [True, False])
+@mock.patch("time.sleep", return_value=None)
+@mock.patch(
+    "conda_forge_tick.git_utils.GitHubBackend.user", new_callable=mock.PropertyMock
+)
+@mock.patch("conda_forge_tick.git_utils.GitHubBackend.does_repository_exist")
+def test_github_backend_fork_exists(
+    exists_mock: MagicMock,
+    user_mock: MagicMock,
+    sleep_mock: MagicMock,
+    branch_already_synced: bool,
+    caplog,
+):
+    caplog.set_level("DEBUG")
+
+    exists_mock.return_value = True
+    user_mock.return_value = "USER"
+
+    pygithub_client = MagicMock()
+    upstream_repo = MagicMock()
+    fork_repo = MagicMock()
+
+    def get_repo(full_name: str):
+        if full_name == "UPSTREAM-OWNER/REPO":
+            return upstream_repo
+        if full_name == "USER/REPO":
+            return fork_repo
+        assert False, f"Unexpected repo full name: {full_name}"
+
+    pygithub_client.get_repo.side_effect = get_repo
+
+    if branch_already_synced:
+        upstream_repo.default_branch = "BRANCH_NAME"
+        fork_repo.default_branch = "BRANCH_NAME"
+    else:
+        upstream_repo.default_branch = "UPSTREAM_BRANCH_NAME"
+        fork_repo.default_branch = "FORK_BRANCH_NAME"
+
+    backend = GitHubBackend(MagicMock(), pygithub_client)
+    backend.fork("UPSTREAM-OWNER", "REPO")
+
+    if not branch_already_synced:
+        pygithub_client.get_repo.assert_any_call("UPSTREAM-OWNER/REPO")
+        pygithub_client.get_repo.assert_any_call("USER/REPO")
+
+        assert "Syncing default branch" in caplog.text
+        sleep_mock.assert_called_once_with(5)
+
+
+@mock.patch(
+    "conda_forge_tick.git_utils.GitHubBackend.user", new_callable=mock.PropertyMock
+)
+@mock.patch("conda_forge_tick.git_utils.GitHubBackend.does_repository_exist")
+def test_github_backend_remote_does_not_exist(
+    exists_mock: MagicMock, user_mock: MagicMock
+):
+    exists_mock.return_value = False
+
+    github3_client = MagicMock()
+    github3_client.repository.return_value = None
+
+    backend = GitHubBackend(github3_client, MagicMock())
+
+    user_mock.return_value = "USER"
+
+    with pytest.raises(RepositoryNotFoundError):
+        backend.fork("UPSTREAM-OWNER", "REPO")
+
+    exists_mock.assert_called_once_with("USER", "REPO")
+    github3_client.repository.assert_called_once_with("UPSTREAM-OWNER", "REPO")
+
+
+def test_github_backend_user():
+    pygithub_client = MagicMock()
+    user = MagicMock()
+    user.login = "USER"
+    pygithub_client.get_user.return_value = user
+
+    backend = GitHubBackend(MagicMock(), pygithub_client)
+
+    for _ in range(4):
+        # cached property
+        assert backend.user == "USER"
+
+    pygithub_client.get_user.assert_called_once()
+
+
+def test_github_backend_get_api_requests_left_github_exception(caplog):
+    github3_client = MagicMock()
+    github3_client.rate_limit.side_effect = github3.exceptions.GitHubException(
+        "API Error"
+    )
+
+    backend = GitHubBackend(github3_client, MagicMock())
+
+    assert backend.get_api_requests_left() is None
+    assert "API error while fetching" in caplog.text
+
+    github3_client.rate_limit.assert_called_once()
+
+
+def test_github_backend_get_api_requests_left_unexpected_response_schema(caplog):
+    github3_client = MagicMock()
+    github3_client.rate_limit.return_value = {"some": "gibberish data"}
+
+    backend = GitHubBackend(github3_client, MagicMock())
+
+    assert backend.get_api_requests_left() is None
+    assert "API Error while parsing"
+
+    github3_client.rate_limit.assert_called_once()
+
+
+def test_github_backend_get_api_requests_left_nonzero():
+    github3_client = MagicMock()
+    github3_client.rate_limit.return_value = {"resources": {"core": {"remaining": 5}}}
+
+    backend = GitHubBackend(github3_client, MagicMock())
+
+    assert backend.get_api_requests_left() == 5
+
+    github3_client.rate_limit.assert_called_once()
+
+
+def test_github_backend_get_api_requests_left_zero_invalid_reset_time(caplog):
+    github3_client = MagicMock()
+
+    github3_client.rate_limit.return_value = {"resources": {"core": {"remaining": 0}}}
+
+    backend = GitHubBackend(github3_client, MagicMock())
+
+    assert backend.get_api_requests_left() == 0
+
+    github3_client.rate_limit.assert_called_once()
+    assert "GitHub API error while fetching rate limit reset time" in caplog.text
+
+
+def test_github_backend_get_api_requests_left_zero_valid_reset_time(caplog):
+    caplog.set_level("INFO")
+
+    github3_client = MagicMock()
+
+    reset_timestamp = 1716303697
+    reset_timestamp_str = "2024-05-21T15:01:37Z"
+
+    github3_client.rate_limit.return_value = {
+        "resources": {"core": {"remaining": 0, "reset": reset_timestamp}}
+    }
+
+    backend = GitHubBackend(github3_client, MagicMock())
+
+    assert backend.get_api_requests_left() == 0
+
+    github3_client.rate_limit.assert_called_once()
+    assert f"will reset at {reset_timestamp_str}" in caplog.text  #
+
+
+@pytest.mark.parametrize(
+    "backend", [GitHubBackend(MagicMock(), MagicMock()), DryRunBackend()]
+)
+@mock.patch(
+    "conda_forge_tick.git_utils.GitHubBackend.user", new_callable=mock.PropertyMock
+)
+@mock.patch("conda_forge_tick.git_utils.GitCli.clone_fork_and_branch")
+def test_git_platform_backend_clone_fork_and_branch(
+    convenience_method_mock: MagicMock,
+    user_mock: MagicMock,
+    backend: GitPlatformBackend,
+):
+    upstream_owner = "UPSTREAM-OWNER"
+    repo_name = "REPO"
+    target_dir = Path("TARGET_DIR")
+    new_branch = "NEW_BRANCH"
+    base_branch = "BASE_BRANCH"
+
+    user_mock.return_value = "USER"
+
+    backend = GitHubBackend(MagicMock(), MagicMock())
+    backend.clone_fork_and_branch(
+        upstream_owner, repo_name, target_dir, new_branch, base_branch
+    )
+
+    convenience_method_mock.assert_called_once_with(
+        origin_url=f"git@github.com:USER/{repo_name}.git",
+        target_dir=target_dir,
+        upstream_url=f"git@github.com:{upstream_owner}/{repo_name}.git",
+        new_branch=new_branch,
+        base_branch=base_branch,
+    )
+
+
+def test_dry_run_backend_get_api_requests_left():
+    backend = DryRunBackend()
+
+    assert backend.get_api_requests_left() is Bound.INFINITY
+
+
+def test_dry_run_backend_does_repository_exist_own_repo():
+    backend = DryRunBackend()
+
+    assert not backend.does_repository_exist("auto-tick-bot-dry-run", "REPO")
+    backend.fork("UPSTREAM_OWNER", "REPO")
+    assert backend.does_repository_exist("auto-tick-bot-dry-run", "REPO")
+
+
+def test_dry_run_backend_does_repository_exist_other_repo():
+    backend = DryRunBackend()
+
+    assert backend.does_repository_exist("conda-forge", "pytest-feedstock")
+    assert not backend.does_repository_exist(
+        "conda-forge", "this-repository-does-not-exist"
+    )
+
+
+def test_dry_run_backend_fork(caplog):
+    caplog.set_level("DEBUG")
+
+    backend = DryRunBackend()
+
+    backend.fork("UPSTREAM_OWNER", "REPO")
+    assert (
+        "Dry Run: Creating fork of UPSTREAM_OWNER/REPO for user auto-tick-bot-dry-run"
+        in caplog.text
+    )
+
+    with pytest.raises(ValueError, match="Fork of REPO already exists"):
+        backend.fork("UPSTREAM_OWNER", "REPO")
+
+    with pytest.raises(ValueError, match="Fork of REPO already exists"):
+        backend.fork("OTHER_OWNER", "REPO")
+
+
+def test_dry_run_backend_sync_default_branch(caplog):
+    caplog.set_level("DEBUG")
+
+    backend = DryRunBackend()
+
+    backend._sync_default_branch("UPSTREAM_OWNER", "REPO")
+
+    assert "Dry Run: Syncing default branch of UPSTREAM_OWNER/REPO" in caplog.text
+
+
+def test_dry_run_backend_user():
+    backend = DryRunBackend()
+
+    assert backend.user == "auto-tick-bot-dry-run"
 
 
 def test_trim_pr_json_keys():


### PR DESCRIPTION
<!-- Put your changes here -->
This reapplies #2643 after #2705 reverted the change. Turns out the default connection mode must be HTTPS, not SSH.
<!--
Thanks for contributing to cf-scripts!
We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

- [x] Pydantic model updated or no update needed
