### PR TITLE
BUG redirect right at the source for getting source code

### DIFF
--- a/conda_forge_tick/provide_source_code.py
+++ b/conda_forge_tick/provide_source_code.py
@@ -112,7 +112,7 @@ def provide_source_code_local(recipe_dir):
             )
 
     try:
-        with wurlitzer.pipes(stderr=wurlitzer.STDOU) as (out):
+        with wurlitzer.pipes(stderr=wurlitzer.STDOUT) as (out, _):
             from conda_build.api import render
             from conda_build.config import Config
             from conda_build.source import provide

--- a/conda_forge_tick/provide_source_code.py
+++ b/conda_forge_tick/provide_source_code.py
@@ -103,6 +103,17 @@ def provide_source_code_local(recipe_dir):
     out = None
     err = None
 
+    def _print_out_err():
+        try:
+            if out:
+                sys.stdout.write(out.read())
+            if err:
+                sys.stderr.write(err.read())
+        except Exception as e:
+            logger.error(
+                "Error printing out/err in getting conda build src!", exc_info=e
+            )
+
     try:
         with wurlitzer.pipes() as (out, err):
             from conda_build.api import render
@@ -123,14 +134,7 @@ def provide_source_code_local(recipe_dir):
             # provide source dir
             yield provide(md)
     except (SystemExit, Exception) as e:
-        if out:
-            sys.stdout.write(out.getvalue())
-        if err:
-            sys.stderr.write(err.getvalue())
-
+        _print_out_err()
         raise RuntimeError("conda build src exception: " + str(e))
 
-    if out:
-        sys.stdout.write(out.getvalue())
-    if err:
-        sys.stderr.write(err.getvalue())
+    _print_out_err()

--- a/conda_forge_tick/provide_source_code.py
+++ b/conda_forge_tick/provide_source_code.py
@@ -1,8 +1,11 @@
 import logging
 import os
 import shutil
+import sys
 import tempfile
 from contextlib import contextmanager
+
+import wurlitzer
 
 from conda_forge_tick.os_utils import chmod_plus_rwX, sync_dirs
 from conda_forge_tick.utils import CB_CONFIG, run_container_task
@@ -97,23 +100,37 @@ def provide_source_code_local(recipe_dir):
     str
         The path to the source code directory.
     """
+    out = None
+    err = None
+
     try:
-        from conda_build.api import render
-        from conda_build.config import Config
-        from conda_build.source import provide
+        with wurlitzer.pipes() as (out, err):
+            from conda_build.api import render
+            from conda_build.config import Config
+            from conda_build.source import provide
 
-        # Use conda build to do all the downloading/extracting bits
-        md = render(
-            recipe_dir,
-            config=Config(**CB_CONFIG),
-            finalize=False,
-            bypass_env_check=True,
-        )
-        if not md:
-            return None
-        md = md[0][0]
+            # Use conda build to do all the downloading/extracting bits
+            md = render(
+                recipe_dir,
+                config=Config(**CB_CONFIG),
+                finalize=False,
+                bypass_env_check=True,
+            )
+            if not md:
+                return None
+            md = md[0][0]
 
-        # provide source dir
-        yield provide(md)
+            # provide source dir
+            yield provide(md)
     except (SystemExit, Exception) as e:
-        raise RuntimeError("conda build src exception:" + str(e))
+        if out:
+            sys.stdout.write(out.getvalue())
+        if err:
+            sys.stderr.write(err.getvalue())
+
+        raise RuntimeError("conda build src exception: " + str(e))
+
+    if out:
+        sys.stdout.write(out.getvalue())
+    if err:
+        sys.stderr.write(err.getvalue())

--- a/conda_forge_tick/provide_source_code.py
+++ b/conda_forge_tick/provide_source_code.py
@@ -101,21 +101,18 @@ def provide_source_code_local(recipe_dir):
         The path to the source code directory.
     """
     out = None
-    err = None
 
-    def _print_out_err():
+    def _print_out():
         try:
             if out:
                 sys.stdout.write(out.read())
-            if err:
-                sys.stderr.write(err.read())
         except Exception as e:
             logger.error(
                 "Error printing out/err in getting conda build src!", exc_info=e
             )
 
     try:
-        with wurlitzer.pipes() as (out, err):
+        with wurlitzer.pipes(stderr=wurlitzer.STDOU) as (out):
             from conda_build.api import render
             from conda_build.config import Config
             from conda_build.source import provide
@@ -134,7 +131,7 @@ def provide_source_code_local(recipe_dir):
             # provide source dir
             yield provide(md)
     except (SystemExit, Exception) as e:
-        _print_out_err()
+        _print_out()
         raise RuntimeError("conda build src exception: " + str(e))
 
-    _print_out_err()
+    _print_out()

--- a/docker/run_bot_task.py
+++ b/docker/run_bot_task.py
@@ -25,7 +25,6 @@ import traceback
 from contextlib import contextmanager, redirect_stdout
 
 import click
-import wurlitzer
 
 existing_feedstock_node_attrs_option = click.option(
     "--existing-feedstock-node-attrs",
@@ -154,18 +153,12 @@ def _provide_source_code():
         output_source_code = "/cf_tick_dir/source_dir"
         os.makedirs(output_source_code, exist_ok=True)
 
-        with (
-            wurlitzer.pipes(stderr=wurlitzer.STDOUT) as (out, _),
-            provide_source_code_local(recipe_dir) as cb_work_dir,
-        ):
+        with provide_source_code_local(recipe_dir) as cb_work_dir:
             chmod_plus_rwX(cb_work_dir, recursive=True, skip_on_error=True)
             sync_dirs(
                 cb_work_dir, output_source_code, ignore_dot_git=True, update_git=False
             )
             chmod_plus_rwX(output_source_code, recursive=True, skip_on_error=True)
-
-        # report even if not live
-        sys.stderr.write(out.read())
 
         return dict()
 


### PR DESCRIPTION
This PR puts the i/o capture right over the conda-build call that seems to escape the higher level i/o redirect.