### PR TITLE
Also try mangling sdist urls to match pep625

### DIFF
--- a/conda_forge_tick/url_transforms.py
+++ b/conda_forge_tick/url_transforms.py
@@ -1,6 +1,5 @@
 import os
 import re
-
 from itertools import permutations
 
 EXTS = [".tar.gz", ".zip", ".tar", ".tar.bz2", ".tar.xz", ".tgz"]

--- a/conda_forge_tick/url_transforms.py
+++ b/conda_forge_tick/url_transforms.py
@@ -61,9 +61,13 @@ def _pypi_name_munger(url):
     is_sdist = url.endswith(".tar.gz")
     is_pypi = any(url.startswith(pypi) for pypi in PYPI_URLS)
     has_version = re.search(r"\{\{\s*version", bn)
+    has_name = re.search(r"\{\{\s*name", bn)
 
     # try the original URL first, as a fallback (probably can't be removed?)
     yield url
+
+    if is_pypi and has_version and not has_name:
+        yield os.path.join(dn, "{{ name }}-{{ version }}.tar.gz")
 
     if not (is_sdist and is_pypi and has_version):
         return

--- a/conda_forge_tick/url_transforms.py
+++ b/conda_forge_tick/url_transforms.py
@@ -158,7 +158,7 @@ def gen_transformed_urls(url):
     url : str
         The URL to transform.
     """
-    yielded = []
+    yielded = set()
 
     for new_url in _gen_new_urls(
         url,
@@ -176,4 +176,4 @@ def gen_transformed_urls(url):
     ):
         if new_url not in yielded:
             yield new_url
-            yielded.append(new_url)
+            yielded.add(new_url)

--- a/tests/test_url_transforms.py
+++ b/tests/test_url_transforms.py
@@ -335,6 +335,78 @@ https://pypi.io/packages/source/p/packageurl-python/packageurl-python-v{{ versio
 https://pypi.io/packages/source/p/packageurl-python/packageurl-python-v{{ version }}.tar.xz
 https://pypi.io/packages/source/p/packageurl-python/packageurl-python-v{{ version }}.tgz
 https://pypi.io/packages/source/p/packageurl-python/packageurl-python-v{{ version }}.zip
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name }}-{{ version }}.tar
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name }}-{{ version }}.tar.bz2
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name }}-{{ version }}.tar.gz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name }}-{{ version }}.tar.xz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name }}-{{ version }}.tgz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name }}-{{ version }}.zip
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name }}-v{{ version }}.tar
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name }}-v{{ version }}.tar.bz2
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name }}-v{{ version }}.tar.gz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name }}-v{{ version }}.tar.xz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name }}-v{{ version }}.tgz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name }}-v{{ version }}.zip
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-{{ version }}.tar
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-{{ version }}.tar.bz2
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-{{ version }}.tar.gz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-{{ version }}.tar.xz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-{{ version }}.tgz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-{{ version }}.zip
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-v{{ version }}.tar
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-v{{ version }}.tar.bz2
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-v{{ version }}.tar.gz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-v{{ version }}.tar.xz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-v{{ version }}.tgz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-v{{ version }}.zip
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-{{ version }}.tar
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-{{ version }}.tar.bz2
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-{{ version }}.tar.xz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-{{ version }}.tgz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-{{ version }}.zip
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-v{{ version }}.tar
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-v{{ version }}.tar.bz2
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-v{{ version }}.tar.gz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-v{{ version }}.tar.xz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-v{{ version }}.tgz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-v{{ version }}.zip
+https://pypi.io/packages/source/p/packageurl-python/{{ name }}-{{ version }}.tar
+https://pypi.io/packages/source/p/packageurl-python/{{ name }}-{{ version }}.tar.bz2
+https://pypi.io/packages/source/p/packageurl-python/{{ name }}-{{ version }}.tar.gz
+https://pypi.io/packages/source/p/packageurl-python/{{ name }}-{{ version }}.tar.xz
+https://pypi.io/packages/source/p/packageurl-python/{{ name }}-{{ version }}.tgz
+https://pypi.io/packages/source/p/packageurl-python/{{ name }}-{{ version }}.zip
+https://pypi.io/packages/source/p/packageurl-python/{{ name }}-v{{ version }}.tar
+https://pypi.io/packages/source/p/packageurl-python/{{ name }}-v{{ version }}.tar.bz2
+https://pypi.io/packages/source/p/packageurl-python/{{ name }}-v{{ version }}.tar.gz
+https://pypi.io/packages/source/p/packageurl-python/{{ name }}-v{{ version }}.tar.xz
+https://pypi.io/packages/source/p/packageurl-python/{{ name }}-v{{ version }}.tgz
+https://pypi.io/packages/source/p/packageurl-python/{{ name }}-v{{ version }}.zip
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-{{ version }}.tar
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-{{ version }}.tar.bz2
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-{{ version }}.tar.gz
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-{{ version }}.tar.xz
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-{{ version }}.tgz
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-{{ version }}.zip
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-v{{ version }}.tar
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-v{{ version }}.tar.bz2
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-v{{ version }}.tar.gz
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-v{{ version }}.tar.xz
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-v{{ version }}.tgz
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('_', '-') }}-v{{ version }}.zip
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-{{ version }}.tar
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-{{ version }}.tar.bz2
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-{{ version }}.tar.xz
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-{{ version }}.tgz
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-{{ version }}.zip
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-v{{ version }}.tar
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-v{{ version }}.tar.bz2
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-v{{ version }}.tar.gz
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-v{{ version }}.tar.xz
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-v{{ version }}.tgz
+https://pypi.io/packages/source/p/packageurl-python/{{ name.replace('-', '_') }}-v{{ version }}.zip
 """,
     """
 https://pypi.io/packages/source/p/worst-case/Worst.-Case-{{ version }}.tar.gz
@@ -387,6 +459,78 @@ https://pypi.io/packages/source/p/worst-case/Worst.-Case-v{{ version }}.tar.gz
 https://pypi.io/packages/source/p/worst-case/Worst.-Case-v{{ version }}.tar.xz
 https://pypi.io/packages/source/p/worst-case/Worst.-Case-v{{ version }}.tgz
 https://pypi.io/packages/source/p/worst-case/Worst.-Case-v{{ version }}.zip
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name }}-{{ version }}.tar.bz2
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name }}-{{ version }}.tar.gz
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name }}-{{ version }}.tar.xz
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name }}-{{ version }}.tar
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name }}-{{ version }}.tgz
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name }}-{{ version }}.zip
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name }}-v{{ version }}.tar.bz2
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name }}-v{{ version }}.tar.gz
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name }}-v{{ version }}.tar.xz
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name }}-v{{ version }}.tar
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name }}-v{{ version }}.tgz
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name }}-v{{ version }}.zip
+https://pypi.io/packages/source/p/worst-case/{{ name }}-{{ version }}.tar.bz2
+https://pypi.io/packages/source/p/worst-case/{{ name }}-{{ version }}.tar.gz
+https://pypi.io/packages/source/p/worst-case/{{ name }}-{{ version }}.tar.xz
+https://pypi.io/packages/source/p/worst-case/{{ name }}-{{ version }}.tar
+https://pypi.io/packages/source/p/worst-case/{{ name }}-{{ version }}.tgz
+https://pypi.io/packages/source/p/worst-case/{{ name }}-{{ version }}.zip
+https://pypi.io/packages/source/p/worst-case/{{ name }}-v{{ version }}.tar.bz2
+https://pypi.io/packages/source/p/worst-case/{{ name }}-v{{ version }}.tar.gz
+https://pypi.io/packages/source/p/worst-case/{{ name }}-v{{ version }}.tar.xz
+https://pypi.io/packages/source/p/worst-case/{{ name }}-v{{ version }}.tar
+https://pypi.io/packages/source/p/worst-case/{{ name }}-v{{ version }}.tgz
+https://pypi.io/packages/source/p/worst-case/{{ name }}-v{{ version }}.zip
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('_', '-') }}-{{ version }}.tar.bz2
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('_', '-') }}-{{ version }}.tar.gz
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('_', '-') }}-{{ version }}.tar.xz
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('_', '-') }}-{{ version }}.tar
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('_', '-') }}-{{ version }}.tgz
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('_', '-') }}-{{ version }}.zip
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('_', '-') }}-v{{ version }}.tar.bz2
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('_', '-') }}-v{{ version }}.tar.gz
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('_', '-') }}-v{{ version }}.tar.xz
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('_', '-') }}-v{{ version }}.tar
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('_', '-') }}-v{{ version }}.tgz
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('_', '-') }}-v{{ version }}.zip
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('-', '_') }}-{{ version }}.tar.bz2
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('-', '_') }}-{{ version }}.tar.xz
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('-', '_') }}-{{ version }}.tar
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('-', '_') }}-{{ version }}.tgz
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('-', '_') }}-{{ version }}.zip
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('-', '_') }}-v{{ version }}.tar.bz2
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('-', '_') }}-v{{ version }}.tar.gz
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('-', '_') }}-v{{ version }}.tar.xz
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('-', '_') }}-v{{ version }}.tar
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('-', '_') }}-v{{ version }}.tgz
+https://files.pythonhosted.org/packages/source/p/worst-case/{{ name.replace('-', '_') }}-v{{ version }}.zip
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('_', '-') }}-{{ version }}.tar.bz2
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('_', '-') }}-{{ version }}.tar.gz
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('_', '-') }}-{{ version }}.tar.xz
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('_', '-') }}-{{ version }}.tar
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('_', '-') }}-{{ version }}.tgz
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('_', '-') }}-{{ version }}.zip
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('_', '-') }}-v{{ version }}.tar.bz2
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('_', '-') }}-v{{ version }}.tar.gz
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('_', '-') }}-v{{ version }}.tar.xz
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('_', '-') }}-v{{ version }}.tar
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('_', '-') }}-v{{ version }}.tgz
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('_', '-') }}-v{{ version }}.zip
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('-', '_') }}-{{ version }}.tar.bz2
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('-', '_') }}-{{ version }}.tar.xz
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('-', '_') }}-{{ version }}.tar
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('-', '_') }}-{{ version }}.tgz
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('-', '_') }}-{{ version }}.zip
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('-', '_') }}-v{{ version }}.tar.bz2
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('-', '_') }}-v{{ version }}.tar.gz
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('-', '_') }}-v{{ version }}.tar.xz
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('-', '_') }}-v{{ version }}.tar
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('-', '_') }}-v{{ version }}.tgz
+https://pypi.io/packages/source/p/worst-case/{{ name.replace('-', '_') }}-v{{ version }}.zip
 """,
 }
 

--- a/tests/test_url_transforms.py
+++ b/tests/test_url_transforms.py
@@ -335,7 +335,59 @@ https://pypi.io/packages/source/p/packageurl-python/packageurl-python-v{{ versio
 https://pypi.io/packages/source/p/packageurl-python/packageurl-python-v{{ version }}.tar.xz
 https://pypi.io/packages/source/p/packageurl-python/packageurl-python-v{{ version }}.tgz
 https://pypi.io/packages/source/p/packageurl-python/packageurl-python-v{{ version }}.zip
-"""
+""",
+    """
+https://pypi.io/packages/source/p/worst-case/Worst.-Case-{{ version }}.tar.gz
+""".strip(): r"""
+https://files.pythonhosted.org/packages/source/p/worst-case/worst_case-{{ version }}.tar
+https://files.pythonhosted.org/packages/source/p/worst-case/worst_case-{{ version }}.tar.bz2
+https://files.pythonhosted.org/packages/source/p/worst-case/worst_case-{{ version }}.tar.gz
+https://files.pythonhosted.org/packages/source/p/worst-case/worst_case-{{ version }}.tar.xz
+https://files.pythonhosted.org/packages/source/p/worst-case/worst_case-{{ version }}.tgz
+https://files.pythonhosted.org/packages/source/p/worst-case/worst_case-{{ version }}.zip
+https://files.pythonhosted.org/packages/source/p/worst-case/worst_case-v{{ version }}.tar
+https://files.pythonhosted.org/packages/source/p/worst-case/worst_case-v{{ version }}.tar.bz2
+https://files.pythonhosted.org/packages/source/p/worst-case/worst_case-v{{ version }}.tar.gz
+https://files.pythonhosted.org/packages/source/p/worst-case/worst_case-v{{ version }}.tar.xz
+https://files.pythonhosted.org/packages/source/p/worst-case/worst_case-v{{ version }}.tgz
+https://files.pythonhosted.org/packages/source/p/worst-case/worst_case-v{{ version }}.zip
+https://files.pythonhosted.org/packages/source/p/worst-case/Worst.-Case-{{ version }}.tar
+https://files.pythonhosted.org/packages/source/p/worst-case/Worst.-Case-{{ version }}.tar.bz2
+https://files.pythonhosted.org/packages/source/p/worst-case/Worst.-Case-{{ version }}.tar.gz
+https://files.pythonhosted.org/packages/source/p/worst-case/Worst.-Case-{{ version }}.tar.xz
+https://files.pythonhosted.org/packages/source/p/worst-case/Worst.-Case-{{ version }}.tgz
+https://files.pythonhosted.org/packages/source/p/worst-case/Worst.-Case-{{ version }}.zip
+https://files.pythonhosted.org/packages/source/p/worst-case/Worst.-Case-v{{ version }}.tar
+https://files.pythonhosted.org/packages/source/p/worst-case/Worst.-Case-v{{ version }}.tar.bz2
+https://files.pythonhosted.org/packages/source/p/worst-case/Worst.-Case-v{{ version }}.tar.gz
+https://files.pythonhosted.org/packages/source/p/worst-case/Worst.-Case-v{{ version }}.tar.xz
+https://files.pythonhosted.org/packages/source/p/worst-case/Worst.-Case-v{{ version }}.tgz
+https://files.pythonhosted.org/packages/source/p/worst-case/Worst.-Case-v{{ version }}.zip
+https://pypi.io/packages/source/p/worst-case/worst_case-{{ version }}.tar
+https://pypi.io/packages/source/p/worst-case/worst_case-{{ version }}.tar.bz2
+https://pypi.io/packages/source/p/worst-case/worst_case-{{ version }}.tar.gz
+https://pypi.io/packages/source/p/worst-case/worst_case-{{ version }}.tar.xz
+https://pypi.io/packages/source/p/worst-case/worst_case-{{ version }}.tgz
+https://pypi.io/packages/source/p/worst-case/worst_case-{{ version }}.zip
+https://pypi.io/packages/source/p/worst-case/worst_case-v{{ version }}.tar
+https://pypi.io/packages/source/p/worst-case/worst_case-v{{ version }}.tar.bz2
+https://pypi.io/packages/source/p/worst-case/worst_case-v{{ version }}.tar.gz
+https://pypi.io/packages/source/p/worst-case/worst_case-v{{ version }}.tar.xz
+https://pypi.io/packages/source/p/worst-case/worst_case-v{{ version }}.tgz
+https://pypi.io/packages/source/p/worst-case/worst_case-v{{ version }}.zip
+https://pypi.io/packages/source/p/worst-case/Worst.-Case-{{ version }}.tar
+https://pypi.io/packages/source/p/worst-case/Worst.-Case-{{ version }}.tar.bz2
+https://pypi.io/packages/source/p/worst-case/Worst.-Case-{{ version }}.tar.gz
+https://pypi.io/packages/source/p/worst-case/Worst.-Case-{{ version }}.tar.xz
+https://pypi.io/packages/source/p/worst-case/Worst.-Case-{{ version }}.tgz
+https://pypi.io/packages/source/p/worst-case/Worst.-Case-{{ version }}.zip
+https://pypi.io/packages/source/p/worst-case/Worst.-Case-v{{ version }}.tar
+https://pypi.io/packages/source/p/worst-case/Worst.-Case-v{{ version }}.tar.bz2
+https://pypi.io/packages/source/p/worst-case/Worst.-Case-v{{ version }}.tar.gz
+https://pypi.io/packages/source/p/worst-case/Worst.-Case-v{{ version }}.tar.xz
+https://pypi.io/packages/source/p/worst-case/Worst.-Case-v{{ version }}.tgz
+https://pypi.io/packages/source/p/worst-case/Worst.-Case-v{{ version }}.zip
+""",
 }
 
 

--- a/tests/test_url_transforms.py
+++ b/tests/test_url_transforms.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 from conda_forge_tick.url_transforms import gen_transformed_urls
 
 
@@ -278,3 +280,67 @@ def test_url_transform_complicated_github():
         "https://github.com/releases/download/{{ version }}/{{ name }}/{{ name }}-{{ version }}.tar.bz2",  # noqa
         "https://github.com/releases/download/{{ version }}/{{ name }}/{{ name }}-{{ version }}.tar.xz",  # noqa
     }
+
+
+TRANFORM_URLS = {
+    # a la https://github.com/conda-forge/packageurl-python-feedstock/pull/22
+    """
+https://pypi.io/packages/source/p/packageurl-python/packageurl-python-{{ version }}.tar.gz
+""".strip(): r"""
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl_python-{{ version }}.tar
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl_python-{{ version }}.tar.bz2
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl_python-{{ version }}.tar.gz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl_python-{{ version }}.tar.xz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl_python-{{ version }}.tgz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl_python-{{ version }}.zip
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl_python-v{{ version }}.tar
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl_python-v{{ version }}.tar.bz2
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl_python-v{{ version }}.tar.gz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl_python-v{{ version }}.tar.xz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl_python-v{{ version }}.tgz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl_python-v{{ version }}.zip
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl-python-{{ version }}.tar
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl-python-{{ version }}.tar.bz2
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl-python-{{ version }}.tar.gz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl-python-{{ version }}.tar.xz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl-python-{{ version }}.tgz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl-python-{{ version }}.zip
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl-python-v{{ version }}.tar
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl-python-v{{ version }}.tar.bz2
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl-python-v{{ version }}.tar.gz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl-python-v{{ version }}.tar.xz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl-python-v{{ version }}.tgz
+https://files.pythonhosted.org/packages/source/p/packageurl-python/packageurl-python-v{{ version }}.zip
+https://pypi.io/packages/source/p/packageurl-python/packageurl_python-{{ version }}.tar
+https://pypi.io/packages/source/p/packageurl-python/packageurl_python-{{ version }}.tar.bz2
+https://pypi.io/packages/source/p/packageurl-python/packageurl_python-{{ version }}.tar.gz
+https://pypi.io/packages/source/p/packageurl-python/packageurl_python-{{ version }}.tar.xz
+https://pypi.io/packages/source/p/packageurl-python/packageurl_python-{{ version }}.tgz
+https://pypi.io/packages/source/p/packageurl-python/packageurl_python-{{ version }}.zip
+https://pypi.io/packages/source/p/packageurl-python/packageurl_python-v{{ version }}.tar
+https://pypi.io/packages/source/p/packageurl-python/packageurl_python-v{{ version }}.tar.bz2
+https://pypi.io/packages/source/p/packageurl-python/packageurl_python-v{{ version }}.tar.gz
+https://pypi.io/packages/source/p/packageurl-python/packageurl_python-v{{ version }}.tar.xz
+https://pypi.io/packages/source/p/packageurl-python/packageurl_python-v{{ version }}.tgz
+https://pypi.io/packages/source/p/packageurl-python/packageurl_python-v{{ version }}.zip
+https://pypi.io/packages/source/p/packageurl-python/packageurl-python-{{ version }}.tar
+https://pypi.io/packages/source/p/packageurl-python/packageurl-python-{{ version }}.tar.bz2
+https://pypi.io/packages/source/p/packageurl-python/packageurl-python-{{ version }}.tar.gz
+https://pypi.io/packages/source/p/packageurl-python/packageurl-python-{{ version }}.tar.xz
+https://pypi.io/packages/source/p/packageurl-python/packageurl-python-{{ version }}.tgz
+https://pypi.io/packages/source/p/packageurl-python/packageurl-python-{{ version }}.zip
+https://pypi.io/packages/source/p/packageurl-python/packageurl-python-v{{ version }}.tar
+https://pypi.io/packages/source/p/packageurl-python/packageurl-python-v{{ version }}.tar.bz2
+https://pypi.io/packages/source/p/packageurl-python/packageurl-python-v{{ version }}.tar.gz
+https://pypi.io/packages/source/p/packageurl-python/packageurl-python-v{{ version }}.tar.xz
+https://pypi.io/packages/source/p/packageurl-python/packageurl-python-v{{ version }}.tgz
+https://pypi.io/packages/source/p/packageurl-python/packageurl-python-v{{ version }}.zip
+"""
+}
+
+
+@pytest.mark.parametrize("url", TRANFORM_URLS)
+def test_url_transform(url):
+    urls = {*gen_transformed_urls(url.strip())}
+    expected = {line.strip() for line in TRANFORM_URLS[url].strip().splitlines()}
+    assert urls == expected


### PR DESCRIPTION
- [x] Pydantic model updated or no update needed

This adds _yet another_ URL to try, namely the basically-now-ubiquitous [PEP625](https://peps.python.org/pep-0625/) form:

```
old    package-name-0.0.0.tar.gz
              V
new    package_name-0.0.1.tar.gz
```