### PR TITLE
consistently ensure trailing newline in recipe conda_build_config.yaml

### DIFF
--- a/conda_forge_tick/migrators/cstdlib.py
+++ b/conda_forge_tick/migrators/cstdlib.py
@@ -245,9 +245,12 @@ class StdlibMigrator(MiniMigrator):
             # that in the conda_build_config, and remove all `__osx` constraints in
             # the meta.yaml (see further up).
             # this line almost always has a selector, keep the alignment
-            cbc_lines = _replacer(
+            new_cbc_lines = _replacer(
                 cbc_lines, r"^MACOSX_DEPLOYMENT_TARGET:", "c_stdlib_version:        "
             )
-
-            with open(fname, "w") as fp:
-                fp.write("".join(cbc_lines) + "\n")
+            if new_cbc_lines != cbc_lines:
+                with open(fname, "w") as fp:
+                    fp.write("".join(new_cbc_lines))
+                    if new_cbc_lines and not new_cbc_lines[-1].endswith("\n"):
+                        # ensure trailing newline
+                        fp.write("\n")

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -108,6 +108,9 @@ def merge_migrator_cbc(migrator_yaml: str, conda_build_config_yaml: str):
         # if this is in a key we didn't migrate, add the line (or it is a space)
         elif current_cbc_key not in migrator_keys or line.isspace() or not line:
             outbound_cbc.append(line)
+    if outbound_cbc and outbound_cbc[-1]:
+        # ensure trailing newline
+        outbound_cbc.append("")
     return "\n".join(outbound_cbc)
 
 

--- a/conda_forge_tick/migrators/mpi_pin_run_as_build.py
+++ b/conda_forge_tick/migrators/mpi_pin_run_as_build.py
@@ -92,6 +92,9 @@ class MPIPinRunAsBuildCleanup(MiniMigrator):
             if len(new_lines) > 0:
                 with open(fname, "w") as fp:
                     fp.write("\n".join(new_lines))
+                    if new_lines[-1]:
+                        # ensure trailing newline
+                        fp.write("\n")
             else:
                 with pushd(recipe_dir):
                     subprocess.run(["rm", "-f", "conda_build_config.yaml"])


### PR DESCRIPTION
#2698 didn't fix #2696, as seen [here](https://github.com/conda-forge/petsc-feedstock/pull/204/files#diff-ff61408cdc05bc9667deeadb55e4aaceb1371972076b6bf6934f9008920f2bd2). It also adds an _additional_ trailing newline, even if there is one.

I found 3 places where trailing newlines could be mishandled:

- yaml migrator (only affects conda-forge-pinning, I think)
- cstdlib (#2698 adds an _additional_ trailing newline rather than ensuring one exists)
- mpi_pin_run_as_build - I'm pretty sure this is actually the one that was affecting the petsc feedstock, which prompted #2696 . I was able to run the migrator on petsc and it re-stripped the trailing newline.

reissue and extend #2696. GitHub didn't give me a reopen button, perhaps because the branch had been deleted.