### PR TITLE
Remove Black Formatter, replace isort by ruff rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,6 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
-    hooks:
-      - id: black
-        language_version: python3.11
-
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.15.2
     hooks:
@@ -37,14 +31,8 @@ repos:
           - --exclude-file=.codespellignorelines
           - --ignore-words=.codespellignorewords
 
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        name: isort (python)
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.7
+    rev: v0.5.0
     hooks:
       - id: ruff
         args: [ --fix ]

--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -16,8 +16,10 @@ from requests.models import Response
 
 if typing.TYPE_CHECKING:
     from mypy_extensions import TestTypedDict
-    from .migrators_types import PackageName, RequirementsTypedDict
+
     from conda_forge_tick.migrators_types import MetaYamlTypedDict
+
+    from .migrators_types import PackageName, RequirementsTypedDict
 
 from conda_forge_tick.lazy_json_backends import LazyJson, dumps, loads
 from conda_forge_tick.utils import run_container_task

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,17 +37,11 @@ write_to_template = "__version__ = '{version}'\n"
 [tool.pytest_env]
 CF_TICK_PYTEST = "true"
 
-[tool.black]
-line-length = 88
-
-[tool.isort]
-profile = "black"
-
 [tool.ruff]
 extend-exclude = ["conda_forge_tick/migrators/disabled/legacy.py"]
 
 [tool.ruff.lint]
-select = ["E", "F", "W"]
+select = ["E", "F", "I", "W"]
 preview = true
 
 [tool.ruff.lint.pycodestyle]


### PR DESCRIPTION
black is [not intended to be used next to ruff-format](https://docs.astral.sh/ruff/faq/#is-the-ruff-linter-compatible-with-black):

> Ruff is designed to be used alongside a formatter (like Ruff's own formatter, or Black) and, as such, will defer implementing stylistic rules that are obviated by automated formatting.

In fact, the current pre-commit setup actively prevents me from committing a file where black and ruff format conflict with each other.

This is why I propose to remove `black` from this project, since we already have `ruff-format`.

Also, `ruff` has support for [`I` rules that are comparable with `isort`](https://docs.astral.sh/ruff/rules/#isort-i). Since `isort` has no profile for `ruff-format` (only for `black`) we should also switch over to using these rules instead of using isort separately.

I would appreciate if we can handle this PR with rather high priority, as it's currently blocking commits (see above). Thank you.

<!-- Put your changes here -->

<!--
Thanks for contributing to cf-scripts!
We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

- [x] Pydantic model updated or no update needed
