### PR TITLE
Add xfail tests for #2833 (support sources that depend on conda build config variants)

### DIFF
--- a/tests/test_version_migrator.py
+++ b/tests/test_version_migrator.py
@@ -50,6 +50,10 @@ YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")
         ("libevent", "2.1.12"),
         ("boost", "1.74.0"),
         ("boostcpp", "1.74.0"),
+        # these contains sources that depend on conda build config variants
+        ("polars_mixed_selectors", "1.1.0"),
+        ("polars_name_selectors", "1.1.0"),
+        ("polars_variant_selectors", "1.1.0"),
         # upstream is not available
         # ("mumps", "5.2.1"),
         # ("cb3multi", "6.0.0"),

--- a/tests/test_version_migrator.py
+++ b/tests/test_version_migrator.py
@@ -13,6 +13,10 @@ VERSION = Version(set())
 
 YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")
 
+VARIANT_SOURCES_NOT_IMPLEMENTED = (
+    "Sources that depend on conda build config variants are not supported yet."
+)
+
 
 @pytest.mark.parametrize(
     "case,new_ver",
@@ -50,10 +54,22 @@ YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")
         ("libevent", "2.1.12"),
         ("boost", "1.74.0"),
         ("boostcpp", "1.74.0"),
-        # these contains sources that depend on conda build config variants
-        ("polars_mixed_selectors", "1.1.0"),
-        ("polars_name_selectors", "1.1.0"),
-        ("polars_variant_selectors", "1.1.0"),
+        # these contain sources that depend on conda build config variants
+        pytest.param(
+            "polars_mixed_selectors",
+            "1.1.0",
+            marks=pytest.mark.xfail(reason=VARIANT_SOURCES_NOT_IMPLEMENTED),
+        ),
+        pytest.param(
+            "polars_name_selectors",
+            "1.1.0",
+            marks=pytest.mark.xfail(reason=VARIANT_SOURCES_NOT_IMPLEMENTED),
+        ),
+        pytest.param(
+            "polars_variant_selectors",
+            "1.1.0",
+            marks=pytest.mark.xfail(reason=VARIANT_SOURCES_NOT_IMPLEMENTED),
+        ),
         # upstream is not available
         # ("mumps", "5.2.1"),
         # ("cb3multi", "6.0.0"),

--- a/tests/test_yaml/version_polars_mixed_selectors.yaml
+++ b/tests/test_yaml/version_polars_mixed_selectors.yaml
@@ -1,0 +1,83 @@
+{% if polars_variant == "polars-lts-cpu" %}
+  {% set name = "polars-lts-cpu" %}
+{% elif polars_variant == "polars-u64-idx" %}
+  {% set name = "polars-u64-idx" %}
+{% else %}
+  {% set name = "polars" %}
+{% endif %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name | replace("-", "_") }}-{{ version }}.tar.gz
+    sha256: 144a63d6d61dc5d675304673c4261ceccf4cfc75277431389d4afe9a5be0f70b  # [polars_variant == "polars"]
+    sha256: e4c3d203d398bd2914fe191544385950a0cd559051af6b2f6b431b837e357d8e  # [polars_variant == "polars-lts-cpu"]
+    sha256: e2fd9758a4381aef4f3bee0ba62b80c7125983445751579b0d95288e39c94d9f  # [polars_variant == "polars-u64-idx"]
+
+
+build:
+  number: 0
+  skip: true  # [win and python_impl=="pypy"]
+
+requirements:
+  build:
+    - python                              # [build_platform != target_platform]
+    # there is no cross-python for linux-64 -> win-64
+    - cross-python_{{ target_platform }}  # [build_platform != target_platform and not target_platform == "win-64"]
+    - crossenv                            # [build_platform != target_platform]
+    - maturin >=1.3.2,<2                  # [build_platform != target_platform]
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}               # [win]
+    # clang_win-64 already adds all required run_exports for the windows build
+    - {{ stdlib("c") }}  # [not (build_platform == "linux-64" and target_platform == "win-64")]
+    - {{ compiler('rust') }}
+    - posix                               # [build_platform == "win-64"]
+    - cmake
+    - make                                # [unix]
+    - cargo-feature                       # [build_platform != target_platform and target_platform == "win-64"]
+    - cargo-bundle-licenses
+  host:
+    - python
+    - pip
+    - maturin >=1.3.2,<2
+  run:
+    - python
+    - numpy >=1.16.0,<2
+    - backports.zoneinfo                   # [py<39]
+    - typing_extensions >=4.0.0            # [py<311]
+    - packaging                            # [py>=310]
+
+test:
+  imports:
+    - polars
+  commands:
+    - pip check
+    - python -c "from polars import DataFrame"
+  requires:
+    - pip
+
+about:
+  home: https://github.com/pola-rs/polars
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: Polars is a blazingly fast DataFrames library implemented in Rust using Apache Arrow(2) as memory model.
+  doc_url: https://pola-rs.github.io/polars-book/user-guide/index.html
+  dev_url: https://github.com/pola-rs/polars
+
+extra:
+  recipe-maintainers:
+    - borchero
+    - Maxyme
+    - timkpaine
+    - ritchie46
+    - sugatoray
+    - xhochy
+    - dhirschfeld
+    - pavelzw
+    - '0xbe7a'

--- a/tests/test_yaml/version_polars_mixed_selectors_correct.yaml
+++ b/tests/test_yaml/version_polars_mixed_selectors_correct.yaml
@@ -1,0 +1,83 @@
+{% if polars_variant == "polars-lts-cpu" %}
+  {% set name = "polars-lts-cpu" %}
+{% elif polars_variant == "polars-u64-idx" %}
+  {% set name = "polars-u64-idx" %}
+{% else %}
+  {% set name = "polars" %}
+{% endif %}
+{% set version = "1.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name | replace("-", "_") }}-{{ version }}.tar.gz
+    sha256: 75fe824243006ada0f2dd30c8aba0ec03595d9087b29c3ca8f106ef1a975b9cb  # [polars_variant == "polars"]
+    sha256: a9add68d6cf992f8d8bb79c5b8bd73549af504108b8774c5e5d2fc6c751ea48c  # [polars_variant == "polars-lts-cpu"]
+    sha256: ecbfe1bab9367270399490780dd1700d824a9255fd509d22497095029c19ae6b  # [polars_variant == "polars-u64-idx"]
+
+
+build:
+  number: 0
+  skip: true  # [win and python_impl=="pypy"]
+
+requirements:
+  build:
+    - python                              # [build_platform != target_platform]
+    # there is no cross-python for linux-64 -> win-64
+    - cross-python_{{ target_platform }}  # [build_platform != target_platform and not target_platform == "win-64"]
+    - crossenv                            # [build_platform != target_platform]
+    - maturin >=1.3.2,<2                  # [build_platform != target_platform]
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}               # [win]
+    # clang_win-64 already adds all required run_exports for the windows build
+    - {{ stdlib("c") }}  # [not (build_platform == "linux-64" and target_platform == "win-64")]
+    - {{ compiler('rust') }}
+    - posix                               # [build_platform == "win-64"]
+    - cmake
+    - make                                # [unix]
+    - cargo-feature                       # [build_platform != target_platform and target_platform == "win-64"]
+    - cargo-bundle-licenses
+  host:
+    - python
+    - pip
+    - maturin >=1.3.2,<2
+  run:
+    - python
+    - numpy >=1.16.0
+    - backports.zoneinfo                   # [py<39]
+    - typing_extensions >=4.0.0            # [py<311]
+    - packaging                            # [py>=310]
+
+test:
+  imports:
+    - polars
+  commands:
+    - pip check
+    - python -c "from polars import DataFrame"
+  requires:
+    - pip
+
+about:
+  home: https://github.com/pola-rs/polars
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: Polars is a blazingly fast DataFrames library implemented in Rust using Apache Arrow(2) as memory model.
+  doc_url: https://pola-rs.github.io/polars-book/user-guide/index.html
+  dev_url: https://github.com/pola-rs/polars
+
+extra:
+  recipe-maintainers:
+    - borchero
+    - Maxyme
+    - timkpaine
+    - ritchie46
+    - sugatoray
+    - xhochy
+    - dhirschfeld
+    - pavelzw
+    - '0xbe7a'

--- a/tests/test_yaml/version_polars_name_selectors.yaml
+++ b/tests/test_yaml/version_polars_name_selectors.yaml
@@ -1,0 +1,83 @@
+{% if polars_variant == "polars-lts-cpu" %}
+  {% set name = "polars-lts-cpu" %}
+{% elif polars_variant == "polars-u64-idx" %}
+  {% set name = "polars-u64-idx" %}
+{% else %}
+  {% set name = "polars" %}
+{% endif %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name | replace("-", "_") }}-{{ version }}.tar.gz
+    sha256: 144a63d6d61dc5d675304673c4261ceccf4cfc75277431389d4afe9a5be0f70b  # [name == "polars"]
+    sha256: e4c3d203d398bd2914fe191544385950a0cd559051af6b2f6b431b837e357d8e  # [name == "polars-lts-cpu"]
+    sha256: e2fd9758a4381aef4f3bee0ba62b80c7125983445751579b0d95288e39c94d9f  # [name == "polars-u64-idx"]
+
+
+build:
+  number: 0
+  skip: true  # [win and python_impl=="pypy"]
+
+requirements:
+  build:
+    - python                              # [build_platform != target_platform]
+    # there is no cross-python for linux-64 -> win-64
+    - cross-python_{{ target_platform }}  # [build_platform != target_platform and not target_platform == "win-64"]
+    - crossenv                            # [build_platform != target_platform]
+    - maturin >=1.3.2,<2                  # [build_platform != target_platform]
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}               # [win]
+    # clang_win-64 already adds all required run_exports for the windows build
+    - {{ stdlib("c") }}  # [not (build_platform == "linux-64" and target_platform == "win-64")]
+    - {{ compiler('rust') }}
+    - posix                               # [build_platform == "win-64"]
+    - cmake
+    - make                                # [unix]
+    - cargo-feature                       # [build_platform != target_platform and target_platform == "win-64"]
+    - cargo-bundle-licenses
+  host:
+    - python
+    - pip
+    - maturin >=1.3.2,<2
+  run:
+    - python
+    - numpy >=1.16.0,<2
+    - backports.zoneinfo                   # [py<39]
+    - typing_extensions >=4.0.0            # [py<311]
+    - packaging                            # [py>=310]
+
+test:
+  imports:
+    - polars
+  commands:
+    - pip check
+    - python -c "from polars import DataFrame"
+  requires:
+    - pip
+
+about:
+  home: https://github.com/pola-rs/polars
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: Polars is a blazingly fast DataFrames library implemented in Rust using Apache Arrow(2) as memory model.
+  doc_url: https://pola-rs.github.io/polars-book/user-guide/index.html
+  dev_url: https://github.com/pola-rs/polars
+
+extra:
+  recipe-maintainers:
+    - borchero
+    - Maxyme
+    - timkpaine
+    - ritchie46
+    - sugatoray
+    - xhochy
+    - dhirschfeld
+    - pavelzw
+    - '0xbe7a'

--- a/tests/test_yaml/version_polars_name_selectors_correct.yaml
+++ b/tests/test_yaml/version_polars_name_selectors_correct.yaml
@@ -1,0 +1,83 @@
+{% if polars_variant == "polars-lts-cpu" %}
+  {% set name = "polars-lts-cpu" %}
+{% elif polars_variant == "polars-u64-idx" %}
+  {% set name = "polars-u64-idx" %}
+{% else %}
+  {% set name = "polars" %}
+{% endif %}
+{% set version = "1.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name | replace("-", "_") }}-{{ version }}.tar.gz
+    sha256: 75fe824243006ada0f2dd30c8aba0ec03595d9087b29c3ca8f106ef1a975b9cb  # [name == "polars"]
+    sha256: a9add68d6cf992f8d8bb79c5b8bd73549af504108b8774c5e5d2fc6c751ea48c  # [name == "polars-lts-cpu"]
+    sha256: ecbfe1bab9367270399490780dd1700d824a9255fd509d22497095029c19ae6b  # [name == "polars-u64-idx"]
+
+
+build:
+  number: 0
+  skip: true  # [win and python_impl=="pypy"]
+
+requirements:
+  build:
+    - python                              # [build_platform != target_platform]
+    # there is no cross-python for linux-64 -> win-64
+    - cross-python_{{ target_platform }}  # [build_platform != target_platform and not target_platform == "win-64"]
+    - crossenv                            # [build_platform != target_platform]
+    - maturin >=1.3.2,<2                  # [build_platform != target_platform]
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}               # [win]
+    # clang_win-64 already adds all required run_exports for the windows build
+    - {{ stdlib("c") }}  # [not (build_platform == "linux-64" and target_platform == "win-64")]
+    - {{ compiler('rust') }}
+    - posix                               # [build_platform == "win-64"]
+    - cmake
+    - make                                # [unix]
+    - cargo-feature                       # [build_platform != target_platform and target_platform == "win-64"]
+    - cargo-bundle-licenses
+  host:
+    - python
+    - pip
+    - maturin >=1.3.2,<2
+  run:
+    - python
+    - numpy >=1.16.0
+    - backports.zoneinfo                   # [py<39]
+    - typing_extensions >=4.0.0            # [py<311]
+    - packaging                            # [py>=310]
+
+test:
+  imports:
+    - polars
+  commands:
+    - pip check
+    - python -c "from polars import DataFrame"
+  requires:
+    - pip
+
+about:
+  home: https://github.com/pola-rs/polars
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: Polars is a blazingly fast DataFrames library implemented in Rust using Apache Arrow(2) as memory model.
+  doc_url: https://pola-rs.github.io/polars-book/user-guide/index.html
+  dev_url: https://github.com/pola-rs/polars
+
+extra:
+  recipe-maintainers:
+    - borchero
+    - Maxyme
+    - timkpaine
+    - ritchie46
+    - sugatoray
+    - xhochy
+    - dhirschfeld
+    - pavelzw
+    - '0xbe7a'

--- a/tests/test_yaml/version_polars_variant_selectors.yaml
+++ b/tests/test_yaml/version_polars_variant_selectors.yaml
@@ -1,0 +1,83 @@
+{% if polars_variant == "polars-lts-cpu" %}
+  {% set name = "polars-lts-cpu" %}
+{% elif polars_variant == "polars-u64-idx" %}
+  {% set name = "polars-u64-idx" %}
+{% else %}
+  {% set name = "polars" %}
+{% endif %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://pypi.io/packages/source/{{ polars_variant[0] }}/{{ polars_variant }}/{{ polars_variant | replace("-", "_") }}-{{ version }}.tar.gz
+    sha256: 144a63d6d61dc5d675304673c4261ceccf4cfc75277431389d4afe9a5be0f70b  # [polars_variant == "polars"]
+    sha256: e4c3d203d398bd2914fe191544385950a0cd559051af6b2f6b431b837e357d8e  # [polars_variant == "polars-lts-cpu"]
+    sha256: e2fd9758a4381aef4f3bee0ba62b80c7125983445751579b0d95288e39c94d9f  # [polars_variant == "polars-u64-idx"]
+
+
+build:
+  number: 0
+  skip: true  # [win and python_impl=="pypy"]
+
+requirements:
+  build:
+    - python                              # [build_platform != target_platform]
+    # there is no cross-python for linux-64 -> win-64
+    - cross-python_{{ target_platform }}  # [build_platform != target_platform and not target_platform == "win-64"]
+    - crossenv                            # [build_platform != target_platform]
+    - maturin >=1.3.2,<2                  # [build_platform != target_platform]
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}               # [win]
+    # clang_win-64 already adds all required run_exports for the windows build
+    - {{ stdlib("c") }}  # [not (build_platform == "linux-64" and target_platform == "win-64")]
+    - {{ compiler('rust') }}
+    - posix                               # [build_platform == "win-64"]
+    - cmake
+    - make                                # [unix]
+    - cargo-feature                       # [build_platform != target_platform and target_platform == "win-64"]
+    - cargo-bundle-licenses
+  host:
+    - python
+    - pip
+    - maturin >=1.3.2,<2
+  run:
+    - python
+    - numpy >=1.16.0,<2
+    - backports.zoneinfo                   # [py<39]
+    - typing_extensions >=4.0.0            # [py<311]
+    - packaging                            # [py>=310]
+
+test:
+  imports:
+    - polars
+  commands:
+    - pip check
+    - python -c "from polars import DataFrame"
+  requires:
+    - pip
+
+about:
+  home: https://github.com/pola-rs/polars
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: Polars is a blazingly fast DataFrames library implemented in Rust using Apache Arrow(2) as memory model.
+  doc_url: https://pola-rs.github.io/polars-book/user-guide/index.html
+  dev_url: https://github.com/pola-rs/polars
+
+extra:
+  recipe-maintainers:
+    - borchero
+    - Maxyme
+    - timkpaine
+    - ritchie46
+    - sugatoray
+    - xhochy
+    - dhirschfeld
+    - pavelzw
+    - '0xbe7a'

--- a/tests/test_yaml/version_polars_variant_selectors_correct.yaml
+++ b/tests/test_yaml/version_polars_variant_selectors_correct.yaml
@@ -1,0 +1,83 @@
+{% if polars_variant == "polars-lts-cpu" %}
+  {% set name = "polars-lts-cpu" %}
+{% elif polars_variant == "polars-u64-idx" %}
+  {% set name = "polars-u64-idx" %}
+{% else %}
+  {% set name = "polars" %}
+{% endif %}
+{% set version = "1.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://pypi.io/packages/source/{{ polars_variant[0] }}/{{ polars_variant }}/{{ polars_variant | replace("-", "_") }}-{{ version }}.tar.gz
+    sha256: 75fe824243006ada0f2dd30c8aba0ec03595d9087b29c3ca8f106ef1a975b9cb  # [polars_variant == "polars"]
+    sha256: a9add68d6cf992f8d8bb79c5b8bd73549af504108b8774c5e5d2fc6c751ea48c  # [polars_variant == "polars-lts-cpu"]
+    sha256: ecbfe1bab9367270399490780dd1700d824a9255fd509d22497095029c19ae6b  # [polars_variant == "polars-u64-idx"]
+
+
+build:
+  number: 0
+  skip: true  # [win and python_impl=="pypy"]
+
+requirements:
+  build:
+    - python                              # [build_platform != target_platform]
+    # there is no cross-python for linux-64 -> win-64
+    - cross-python_{{ target_platform }}  # [build_platform != target_platform and not target_platform == "win-64"]
+    - crossenv                            # [build_platform != target_platform]
+    - maturin >=1.3.2,<2                  # [build_platform != target_platform]
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}               # [win]
+    # clang_win-64 already adds all required run_exports for the windows build
+    - {{ stdlib("c") }}  # [not (build_platform == "linux-64" and target_platform == "win-64")]
+    - {{ compiler('rust') }}
+    - posix                               # [build_platform == "win-64"]
+    - cmake
+    - make                                # [unix]
+    - cargo-feature                       # [build_platform != target_platform and target_platform == "win-64"]
+    - cargo-bundle-licenses
+  host:
+    - python
+    - pip
+    - maturin >=1.3.2,<2
+  run:
+    - python
+    - numpy >=1.16.0
+    - backports.zoneinfo                   # [py<39]
+    - typing_extensions >=4.0.0            # [py<311]
+    - packaging                            # [py>=310]
+
+test:
+  imports:
+    - polars
+  commands:
+    - pip check
+    - python -c "from polars import DataFrame"
+  requires:
+    - pip
+
+about:
+  home: https://github.com/pola-rs/polars
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: Polars is a blazingly fast DataFrames library implemented in Rust using Apache Arrow(2) as memory model.
+  doc_url: https://pola-rs.github.io/polars-book/user-guide/index.html
+  dev_url: https://github.com/pola-rs/polars
+
+extra:
+  recipe-maintainers:
+    - borchero
+    - Maxyme
+    - timkpaine
+    - ritchie46
+    - sugatoray
+    - xhochy
+    - dhirschfeld
+    - pavelzw
+    - '0xbe7a'


### PR DESCRIPTION
<!-- Put your changes here -->
This PR add xfail tests for the feature requested in #2833. The current [polars-feedstock](https://github.com/conda-forge/polars-feedstock) uses name selectors but also the two other scenarios should be supported.

<!--
Thanks for contributing to cf-scripts!
We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

- [x] Pydantic model updated or no update needed
