### PR TITLE
fix: signature of migration util functions

### DIFF
--- a/tests/test_migrators.py
+++ b/tests/test_migrators.py
@@ -463,9 +463,9 @@ def run_test_migration(
     kwargs: dict,
     prb: dict,
     mr_out: dict,
-    should_filter=False,
-    tmpdir=None,
-    make_body=False,
+    tmpdir: str,
+    should_filter: bool = False,
+    make_body: bool = False,
 ):
     if mr_out:
         mr_out.update(bot_rerun=False)
@@ -561,8 +561,8 @@ def run_minimigrator(
     inp: str,
     output: str,
     mr_out: dict,
+    tmpdir: str,
     should_filter: bool = False,
-    tmpdir=None,
 ):
     if mr_out:
         mr_out.update(bot_rerun=False)


### PR DESCRIPTION
- `tmpdir` is required, both functions will fail if it will not be set
- add type hints

<!-- Put your changes here -->

<!--
Thanks for contributing to cf-scripts!
We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

- [x] Pydantic model updated or no update needed
