### PR TITLE
fix: `HAVE_CONTAINERS` check

### DIFF
--- a/.github/workflows/bot-bot.yml
+++ b/.github/workflows/bot-bot.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch: null
   schedule:
     - cron: '15 * * * *'
-  
 
 concurrency: bot
 

--- a/tests/test_container_tasks.py
+++ b/tests/test_container_tasks.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import pprint
+import shutil
 import subprocess
 import tempfile
 
@@ -47,7 +48,8 @@ VERSION = Version(set())
 YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")
 
 HAVE_CONTAINERS = (
-    subprocess.run(["docker", "--version"], capture_output=True).returncode == 0
+    shutil.which("docker") is not None
+    and subprocess.run(["docker", "--version"], capture_output=True).returncode == 0
 )
 
 if HAVE_CONTAINERS:
@@ -571,6 +573,9 @@ yaml_rebuild = MigrationYaml(yaml_contents="{}", name="hi")
 yaml_rebuild.cycles = []
 
 
+@pytest.mark.skipif(
+    not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
+)
 def test_migration_runner_run_migration_containerized_yaml_rebuild(tmpdir):
     fs_dir = os.path.join(tmpdir, "scipy-feedstock")
     rp_dir = os.path.join(fs_dir, "recipe")
@@ -627,6 +632,9 @@ def test_migration_runner_run_migration_containerized_yaml_rebuild(tmpdir):
     assert saved_migration == yaml_rebuild.yaml_contents
 
 
+@pytest.mark.skipif(
+    not (HAVE_CONTAINERS and HAVE_TEST_IMAGE), reason="containers not available"
+)
 @pytest.mark.parametrize(
     "case,new_ver",
     [


### PR DESCRIPTION
- The original threw an exception if `docker` was missing.
- Not all tests using `docker` used `HAVE_CONTAINERS`

<!-- Put your changes here -->

<!--
Thanks for contributing to cf-scripts!
We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

- [x] Pydantic model updated or no update needed
