### PR TITLE
feat: Extend feedstock functions to allow for `recipe_yaml`

### DIFF
--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -224,6 +224,9 @@ def populate_feedstock_attributes(
 
     from conda_forge_tick.chaindb import ChainDB, _convert_to_dict
 
+    if meta_yaml is None and recipe_yaml is None:
+        raise ValueError("Either `meta_yaml` or  `recipe_yaml` needs to be given.")
+
     sub_graph.update({"feedstock_name": name, "parsing_error": False, "branch": "main"})
 
     if mark_not_archived:

--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -530,8 +530,9 @@ def load_feedstock_local(
 def load_feedstock_containerized(
     name: str,
     sub_graph: typing.MutableMapping,
-    meta_yaml: Optional[str] = None,
-    conda_forge_yaml: Optional[str] = None,
+    meta_yaml: str | None = None,
+    recipe_yaml: str | None = None,
+    conda_forge_yaml: str | None = None,
     mark_not_archived: bool = False,
 ):
     """Load a feedstock into subgraph based on its name. If meta_yaml and/or
@@ -545,9 +546,11 @@ def load_feedstock_containerized(
         Name of the feedstock
     sub_graph : MutableMapping
         The existing metadata if any
-    meta_yaml : Optional[str]
+    meta_yaml : str | None
         The string meta.yaml, overrides the file in the feedstock if provided
-    conda_forge_yaml : Optional[str]
+    recipe_yaml : str | None
+        The string recipe.yaml, overrides the file in the feedstock if provided
+    conda_forge_yaml : str | None
         The string conda-forge.yaml, overrides the file in the feedstock if provided
     mark_not_archived : bool
         If True, forcibly mark the feedstock as not archived in the node attrs.
@@ -564,6 +567,9 @@ def load_feedstock_containerized(
 
     if meta_yaml is not None:
         args += ["--meta-yaml", meta_yaml]
+
+    if recipe_yaml is not None:
+        args += ["--recipe-yaml", recipe_yaml]
 
     if conda_forge_yaml is not None:
         args += ["--conda-forge-yaml", conda_forge_yaml]
@@ -592,10 +598,11 @@ def load_feedstock_containerized(
 def load_feedstock(
     name: str,
     sub_graph: typing.MutableMapping,
-    meta_yaml: Optional[str] = None,
-    conda_forge_yaml: Optional[str] = None,
+    meta_yaml: str | None = None,
+    recipe_yaml: str | None = None,
+    conda_forge_yaml: str | None = None,
     mark_not_archived: bool = False,
-    use_container: bool = True,
+    use_container: bool | None = None,
 ):
     """Load a feedstock into subgraph based on its name. If meta_yaml and/or
     conda_forge_yaml are not provided, they will be fetched from the feedstock.
@@ -606,9 +613,11 @@ def load_feedstock(
         Name of the feedstock
     sub_graph : MutableMapping
         The existing metadata if any
-    meta_yaml : Optional[str]
+    meta_yaml : str | None
         The string meta.yaml, overrides the file in the feedstock if provided
-    conda_forge_yaml : Optional[str]
+    recipe_yaml : str | None
+        The string recipe.yaml, overrides the file in the feedstock if provided
+    conda_forge_yaml : str | None
         The string conda-forge.yaml, overrides the file in the feedstock if provided
     mark_not_archived : bool
         If True, forcibly mark the feedstock as not archived in the node attrs.
@@ -632,6 +641,7 @@ def load_feedstock(
             name,
             sub_graph,
             meta_yaml=meta_yaml,
+            recipe_yaml=recipe_yaml,
             conda_forge_yaml=conda_forge_yaml,
             mark_not_archived=mark_not_archived,
         )
@@ -640,6 +650,7 @@ def load_feedstock(
             name,
             sub_graph,
             meta_yaml=meta_yaml,
+            recipe_yaml=recipe_yaml,
             conda_forge_yaml=conda_forge_yaml,
             mark_not_archived=mark_not_archived,
         )

--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -8,6 +8,7 @@ import tempfile
 import typing
 import zipfile
 from collections import defaultdict
+from pathlib import Path
 from typing import Optional, Set, Union
 
 import requests
@@ -213,18 +214,14 @@ def _clean_req_nones(reqs):
 def populate_feedstock_attributes(
     name: str,
     sub_graph: typing.MutableMapping,
-    meta_yaml: typing.Union[str, Response] = "",
-    conda_forge_yaml: typing.Union[str, Response] = "",
+    meta_yaml: str | None = None,
+    recipe_yaml: str | None = None,
+    conda_forge_yaml: str | None = None,
     mark_not_archived=False,
     feedstock_dir=None,
 ) -> typing.MutableMapping:
-    """Parse the various configuration information into something usable
+    """Parse the various configuration information into something usable"""
 
-    Notes
-    -----
-    If the return is bad hand the response itself in so that it can be parsed
-    for meaning.
-    """
     from conda_forge_tick.chaindb import ChainDB, _convert_to_dict
 
     sub_graph.update({"feedstock_name": name, "parsing_error": False, "branch": "main"})
@@ -232,17 +229,13 @@ def populate_feedstock_attributes(
     if mark_not_archived:
         sub_graph.update({"archived": False})
 
-    # handle all the raw strings
-    if isinstance(meta_yaml, Response):
-        sub_graph["parsing_error"] = f"make_graph: {meta_yaml.status_code}"
-        return sub_graph
-
     # strip out old keys - this removes old platforms when one gets disabled
     for key in list(sub_graph.keys()):
         if key.endswith("meta_yaml") or key.endswith("requirements") or key == "req":
             del sub_graph[key]
 
-    sub_graph["raw_meta_yaml"] = meta_yaml
+    if isinstance(meta_yaml, str):
+        sub_graph["raw_meta_yaml"] = meta_yaml
 
     # Get the conda-forge.yml
     if isinstance(conda_forge_yaml, str):
@@ -288,18 +281,19 @@ def populate_feedstock_attributes(
                         break
                 plat_arch.append((plat, arch))
 
-                variant_yamls.append(
-                    parse_meta_yaml(
-                        meta_yaml,
-                        platform=plat,
-                        arch=arch,
-                        cbc_path=cbc_path,
-                        orig_cbc_path=os.path.join(
-                            recipe_dir,
-                            "conda_build_config.yaml",
+                if isinstance(meta_yaml, str):
+                    variant_yamls.append(
+                        parse_meta_yaml(
+                            meta_yaml,
+                            platform=plat,
+                            arch=arch,
+                            cbc_path=cbc_path,
+                            orig_cbc_path=os.path.join(
+                                recipe_dir,
+                                "conda_build_config.yaml",
+                            ),
                         ),
-                    ),
-                )
+                    )
 
                 # sometimes the requirements come out to None or [None]
                 # and this ruins the aggregated meta_yaml / breaks stuff
@@ -338,10 +332,11 @@ def populate_feedstock_attributes(
             for k in set(sub_graph["conda-forge.yml"].get("provider", {})):
                 if "_" in k:
                     plat_arch.append(tuple(k.split("_")))
-            variant_yamls = [
-                parse_meta_yaml(meta_yaml, platform=plat, arch=arch)
-                for plat, arch in plat_arch
-            ]
+            if isinstance(meta_yaml, str):
+                variant_yamls = [
+                    parse_meta_yaml(meta_yaml, platform=plat, arch=arch)
+                    for plat, arch in plat_arch
+                ]
     except Exception as e:
         import traceback
 
@@ -451,8 +446,9 @@ def populate_feedstock_attributes(
 def load_feedstock_local(
     name: str,
     sub_graph: typing.MutableMapping,
-    meta_yaml: Optional[str] = None,
-    conda_forge_yaml: Optional[str] = None,
+    meta_yaml: str | None = None,
+    recipe_yaml: str | None = None,
+    conda_forge_yaml: str | None = None,
     mark_not_archived: bool = False,
 ):
     """Load a feedstock into subgraph based on its name. If meta_yaml and/or
@@ -464,8 +460,10 @@ def load_feedstock_local(
         Name of the feedstock
     sub_graph : MutableMapping
         The existing metadata if any
-    meta_yaml : Optional[str]
+    meta_yaml : str | None
         The string meta.yaml, overrides the file in the feedstock if provided
+    recipe_yaml: str | None
+        The string recipe.yaml, overrides the file in the feedstock if provided
     conda_forge_yaml : Optional[str]
         The string conda-forge.yaml, overrides the file in the feedstock if provided
     mark_not_archived : bool
@@ -480,24 +478,43 @@ def load_feedstock_local(
     with tempfile.TemporaryDirectory() as tmpdir:
         feedstock_dir = _fetch_static_repo(name, tmpdir)
 
-        if meta_yaml is None:
+        # If either `meta_yaml` or `recipe_yaml` is overridden, use that
+        # otherwise use "meta.yaml" file if it exists
+        # otherwise use "recipe.yaml" file if it exists
+        # if nothing is overridden and no file is present, error out
+        if meta_yaml is None and recipe_yaml is None:
             if isinstance(feedstock_dir, Response):
-                meta_yaml = feedstock_dir
+                sub_graph.update(
+                    {"feedstock_name": name, "parsing_error": False, "branch": "main"}
+                )
+
+                if mark_not_archived:
+                    sub_graph.update({"archived": False})
+
+                sub_graph["parsing_error"] = f"make_graph: {feedstock_dir.status_code}"
+                return sub_graph
+
+            meta_yaml_path = Path(feedstock_dir).joinpath("recipe", "meta.yaml")
+            recipe_yaml_path = Path(feedstock_dir).joinpath("recipe", "recipe.yaml")
+            if meta_yaml_path.exists():
+                meta_yaml = meta_yaml_path.read_text()
+            elif recipe_yaml_path.exists():
+                recipe_yaml = recipe_yaml_path.read_text()
             else:
-                with open(os.path.join(feedstock_dir, "recipe", "meta.yaml")) as fp:
-                    meta_yaml = fp.read()
+                raise ValueError(
+                    "Either `meta.yaml` or `recipe.yaml` need to be present in the feedstock"
+                )
 
         if conda_forge_yaml is None:
-            if isinstance(feedstock_dir, Response):
-                conda_forge_yaml = Response
-            else:
-                with open(os.path.join(feedstock_dir, "conda-forge.yml")) as fp:
-                    conda_forge_yaml = fp.read()
+            conda_forge_yaml_path = Path(feedstock_dir).joinpath("conda-forge.yml")
+            if conda_forge_yaml_path.exists():
+                conda_forge_yaml = conda_forge_yaml_path.read_text()
 
         populate_feedstock_attributes(
             name,
             sub_graph,
             meta_yaml=meta_yaml,
+            recipe_yaml=recipe_yaml,
             conda_forge_yaml=conda_forge_yaml,
             mark_not_archived=mark_not_archived,
             feedstock_dir=feedstock_dir,

--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -474,6 +474,10 @@ def load_feedstock_local(
     sub_graph : MutableMapping
         The sub_graph, now updated with the feedstock metadata
     """
+
+    if meta_yaml is not None and recipe_yaml is not None:
+        raise ValueError("Only either `meta_yaml` or `recipe_yaml` can be overridden.")
+
     # pull down one copy of the repo
     with tempfile.TemporaryDirectory() as tmpdir:
         feedstock_dir = _fetch_static_repo(name, tmpdir)

--- a/docker/run_bot_task.py
+++ b/docker/run_bot_task.py
@@ -347,6 +347,7 @@ def _parse_feedstock(
     *,
     attrs,
     meta_yaml,
+    recipe_yaml,
     conda_forge_yaml,
     mark_not_archived,
 ):
@@ -358,6 +359,7 @@ def _parse_feedstock(
         name,
         attrs,
         meta_yaml=meta_yaml,
+        recipe_yaml=recipe_yaml,
         conda_forge_yaml=conda_forge_yaml,
         mark_not_archived=mark_not_archived,
     )
@@ -477,6 +479,9 @@ def parse_meta_yaml(
 @existing_feedstock_node_attrs_option
 @click.option("--meta-yaml", default=None, type=str, help="The meta.yaml file to use.")
 @click.option(
+    "--recipe-yaml", default=None, type=str, help="The recipe.yaml file to use."
+)
+@click.option(
     "--conda-forge-yaml", default=None, type=str, help="The meta.yaml file to use."
 )
 @click.option(
@@ -486,6 +491,7 @@ def parse_feedstock(
     log_level,
     existing_feedstock_node_attrs,
     meta_yaml,
+    recipe_yaml,
     conda_forge_yaml,
     mark_not_archived,
 ):
@@ -494,6 +500,7 @@ def parse_feedstock(
         log_level=log_level,
         existing_feedstock_node_attrs=existing_feedstock_node_attrs,
         meta_yaml=meta_yaml,
+        recipe_yaml=recipe_yaml,
         conda_forge_yaml=conda_forge_yaml,
         mark_not_archived=mark_not_archived,
     )

--- a/tests/test_container_tasks.py
+++ b/tests/test_container_tasks.py
@@ -680,7 +680,7 @@ def test_migration_runner_run_migration_containerized_version(
     with open(os.path.join(tmpdir, fs_dir, "recipe", "meta.yaml"), "w") as f:
         f.write(inp)
 
-    pmy = populate_feedstock_attributes(name, {}, inp, "{}")
+    pmy = populate_feedstock_attributes(name, {}, inp, None, "{}")
 
     # these are here for legacy migrators
     pmy["version"] = pmy["meta_yaml"]["package"]["version"]

--- a/tests/test_migration_yaml_migration.py
+++ b/tests/test_migration_yaml_migration.py
@@ -201,7 +201,7 @@ def run_test_migration(
     except Exception:
         name = "blah"
 
-    pmy = populate_feedstock_attributes(name, {}, inp, cf_yml)
+    pmy = populate_feedstock_attributes(name, {}, inp, None, cf_yml)
 
     # these are here for legacy migrators
     pmy["version"] = pmy["meta_yaml"]["package"]["version"]

--- a/tests/test_migrators.py
+++ b/tests/test_migrators.py
@@ -480,7 +480,7 @@ def run_test_migration(
     except Exception:
         name = "blah"
 
-    pmy = populate_feedstock_attributes(name, {}, inp, cf_yml)
+    pmy = populate_feedstock_attributes(name, {}, inp, None, cf_yml)
 
     # these are here for legacy migrators
     pmy["version"] = pmy["meta_yaml"]["package"]["version"]
@@ -577,7 +577,7 @@ def run_minimigrator(
     except Exception:
         name = "blah"
 
-    pmy = populate_feedstock_attributes(name, {}, inp, cf_yml)
+    pmy = populate_feedstock_attributes(name, {}, inp, None, cf_yml)
     filtered = migrator.filter(pmy)
     if should_filter and filtered:
         return migrator

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -63,7 +63,7 @@ def test_env_is_protected_against_malicious_recipes(tmpdir, caplog, env_setup):
     with pushd(tmpdir):
         subprocess.run(["git", "init"])
 
-    pmy = populate_feedstock_attributes("blah", {}, in_yaml, "{}")
+    pmy = populate_feedstock_attributes("blah", {}, in_yaml, None, "{}")
 
     # This url gets saved in https://github.com/regro/cf-graph-countyfair
     pswd = os.environ.get("TEST_BOT_TOKEN_VAL", "unpassword")


### PR DESCRIPTION
- Some error handling is moved from `populate_feedstock_attributes` to `load_feedstock_local`
- This allowed to handle bad responses earlier and a bit less awkward
- Special case a few places which require `meta_yaml` to be present

<!-- Put your changes here -->

<!--
Thanks for contributing to cf-scripts!
We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

- [x] Pydantic model updated or no update needed
