### PR TITLE
fix: pyproject.toml metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "conda-forge-tick"
+name = "cf-scripts"
 authors = [
     {name = "conda-forge-tick development team", email = "condaforge@gmail.com"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "cf-scripts"
 authors = [
-    {name = "conda-forge-tick development team", email = "condaforge@gmail.com"},
+    {name = "cf-scripts development team", email = "condaforge@gmail.com"},
 ]
 description = "Flagship repo for cf-regro-autotick-bot"
 dynamic = ["version"]


### PR DESCRIPTION
Never [uv](https://github.com/astral-sh/uv) versions (which pixi uses behind the scenes) seem to be more strict than pip here
