### PR TITLE
Simplify `_parse_meta_yaml_impl`

### DIFF
--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -730,10 +730,7 @@ def _parse_meta_yaml_impl(
 
     logger.debug("jinja2 environmment:\n%s", pprint.pformat(cfg_as_dict))
 
-    if for_pinning:
-        content = _render_meta_yaml(text, for_pinning=for_pinning, **cfg_as_dict)
-    else:
-        content = _render_meta_yaml(text, **cfg_as_dict)
+    content = _render_meta_yaml(text, for_pinning=for_pinning, **cfg_as_dict)
 
     try:
         return parse(content, cbc)


### PR DESCRIPTION
`for_pinning` of  `_render_meta_yaml` already has the default value `False`, so the if condition didn't do anything.

- [x] Pydantic model updated or no update needed
