### PR TITLE
chore: Add rattler-build dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -45,6 +45,7 @@ dependencies:
   - python-dateutil
   - python-graphviz
   - python-rapidjson
+  - rattler-build
   - requests
   - ruamel.yaml
   - ruamel.yaml.jinja2


### PR DESCRIPTION
It is already a transitive dependency, but since it will be used directly to render recipes, I think it makes sense to mention it here as well.