### PR TITLE
model check should not run on PRs or pushes

### DIFF
--- a/.github/workflows/test-model.yml
+++ b/.github/workflows/test-model.yml
@@ -1,13 +1,9 @@
 name: test-model
 
 on:
-  push:
-    branches:
-      - master
-  pull_request: null
   workflow_dispatch:
   schedule:
-    - cron: "10 8 * * *" # every hour
+    - cron: "10 8 * * *" # daily at 8:10 UTC
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test-model.yml
+++ b/.github/workflows/test-model.yml
@@ -49,6 +49,8 @@ jobs:
       - name: run pytest (model)
         run: |
           cd cf-graph
+          # for pull requests, a failed model test should not be a failed check
+          # this is a hack around the absence of https://github.com/orgs/community/discussions/15452
           pytest \
             --durations 10 \
-            ../tests/model
+            ../tests/model ${{ github.event_name == 'pull_request' && '|| [ $? = 1 ]' || '' }}

--- a/.github/workflows/test-model.yml
+++ b/.github/workflows/test-model.yml
@@ -1,6 +1,7 @@
 name: test-model
 
 on:
+  pull_request: null
   workflow_dispatch:
   schedule:
     - cron: "10 8 * * *" # daily at 8:10 UTC


### PR DESCRIPTION
<!-- Put your changes here -->
The model check should only be run periodically and on request, not on pushes to master or PRs.

xref https://github.com/regro/cf-scripts/issues/2244#issuecomment-2200064651

For debugging, it is still possible to run this on request or locally.

Unfortunately, there is no other good way to remove confusion about the red crosses: https://github.com/orgs/community/discussions/15452

<!--
Thanks for contributing to cf-scripts!
We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

- [x] Pydantic model updated or no update needed
