### PR TITLE
feat: Add `for_pinning` support for `recipe.yaml`

### DIFF
--- a/docker/run_bot_task.py
+++ b/docker/run_bot_task.py
@@ -394,6 +394,7 @@ def _parse_recipe_yaml(
     for_pinning,
     platform,
     arch,
+    cbc_path,
     log_debug,
 ):
     from conda_forge_tick.utils import parse_recipe_yaml_local
@@ -403,6 +404,7 @@ def _parse_recipe_yaml(
         for_pinning=for_pinning,
         platform=platform,
         arch=arch,
+        cbc_path=cbc_path,
         log_debug=log_debug,
     )
 
@@ -511,12 +513,16 @@ def parse_meta_yaml(
     default=None,
     help="The CPU architecture (e.g., '64', 'aarch64').",
 )
+@click.option(
+    "--cbc-path", type=str, default=None, help="The path to global pinning file."
+)
 @click.option("--log-debug", is_flag=True, help="Log debug information.")
 def parse_recipe_yaml(
     log_level,
     for_pinning,
     platform,
     arch,
+    cbc_path,
     log_debug,
 ):
     return _run_bot_task(
@@ -526,6 +532,7 @@ def parse_recipe_yaml(
         for_pinning=for_pinning,
         platform=platform,
         arch=arch,
+        cbc_path=cbc_path,
         log_debug=log_debug,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ extend-exclude = ["conda_forge_tick/migrators/disabled/legacy.py"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]
+ignore = ["E501"]
 preview = true
 
 [tool.ruff.lint.pycodestyle]

--- a/tests/test_recipe_yaml/slepc.yaml
+++ b/tests/test_recipe_yaml/slepc.yaml
@@ -1,0 +1,39 @@
+schema_version: 1
+
+context:
+  version: 3.19.1
+  sha256: 280737e9ef762d7f0079ad3ad29913215c799ebf124651c723c1972f71fbc0db
+  build: 0
+
+package:
+  name: slepc
+  version: ${{ version }}
+
+source:
+  url: http://slepc.upv.es/download/distrib/slepc-${{ version }}.tar.gz
+  sha256: ${{ sha256 }}
+
+build:
+  number: ${{ build }}
+  string: real_h${{ PKG_HASH }}_${{ build }}
+  skip:
+    - win
+
+requirements:
+  run:
+    - petsc
+    - suitesparse
+  run_exports:
+    - ${{ pin_subpackage('slepc', upper_bound='x.x') }}
+
+about:
+  summary: SLEPc Scalable Library for Eigenvalue Problem Computations
+  license: BSD-2-Clause
+  license_file: LICENSE.md
+  homepage: http://slepc.upv.es/
+
+extra:
+  recipe-maintainers:
+    - dalcinl
+    - joseeroman
+    - minrk


### PR DESCRIPTION
- Replaces and quotes `pin_subpackage` and `pin_compatible` as done with `meta.yaml`
- Adds tests for newly introduced functions
- Includes missing pieces for `cbc` support from graph PR
- Ignore ruff lint for long lines, since formatting is enforced anyway