### PR TITLE
chore: Extend typo extend-exclude glob

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -1,7 +1,7 @@
 [files]
 extend-exclude = [
-    ".git/",
-    ".pixi/",
+    ".git/**",
+    ".pixi/**",
     ".codespellrc",
     ".codespellignorelines",
     ".codespellignorewords",


### PR DESCRIPTION
Seems like my original pattern for `.git` and `.pixi` didn't actually work

- [x] Pydantic model updated or no update needed
