### PR TITLE
fix: make sure to put selectors in for all jinja2 vars

### DIFF
--- a/tests/test_recipe_parser.py
+++ b/tests/test_recipe_parser.py
@@ -215,6 +215,7 @@ build:
     true_new_meta_yaml = """\
 {% set foo = "bar" %}
 {% set xfoo = 10 %}  # [win or osx]
+{% set namesel = "val1" %}  # [py2k]
 {% set name = "val1" %}  # [py2k]
 {% set name = "val2" %}  # [py3k and win]
 {% set version = "4.5.6" %}

--- a/tests/test_recipe_parser.py
+++ b/tests/test_recipe_parser.py
@@ -16,6 +16,7 @@ from conda_forge_tick.recipe_parser._parser import (
 
 def test_parsing_ml_jinja2():
     meta_yaml = """\
+{% set namesel = 'val1' %}  # [py2k]
 {% set name = 'val1' %}  # [py2k]
 {% set name = 'val2' %}#[py3k and win]
 {% set version = '4.5.6' %}
@@ -77,6 +78,7 @@ build:
 """
 
     meta_yaml_canonical = """\
+{% set namesel = "val1" %}  # [py2k]
 {% set name = "val1" %}  # [py2k]
 {% set name = "val2" %}  # [py3k and win]
 {% set version = "4.5.6" %}
@@ -140,6 +142,7 @@ build:
     cm = CondaMetaYAML(meta_yaml)
 
     # check the jinja2 keys
+    assert cm.jinja2_vars["namesel__###conda-selector###__py2k"] == "val1"
     assert cm.jinja2_vars["name__###conda-selector###__py2k"] == "val1"
     assert cm.jinja2_vars["name__###conda-selector###__py3k and win"] == "val2"
     assert cm.jinja2_vars["version"] == "4.5.6"


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

jinja2 variables with selectors but not repeated were not properly reported as having selectors applied. This PR fixes that.

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
