### PR TITLE
Long running migrators can also be paused

### DIFF
--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -429,14 +429,14 @@ def main() -> None:
                     "__migrator",
                     {},
                 )
-                if (
+                if mgconf.get("paused", False):
+                    paused_status[migrator_name] = f"{migrator.name} Migration Status"
+                elif (
                     mgconf.get("longterm", False)
                     or isinstance(migrator, ArchRebuild)
                     or isinstance(migrator, OSXArm)
                 ):
                     longterm_status[migrator_name] = f"{migrator.name} Migration Status"
-                elif mgconf.get("paused", False):
-                    paused_status[migrator_name] = f"{migrator.name} Migration Status"
                 else:
                     regular_status[migrator_name] = f"{migrator.name} Migration Status"
             else:


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

Follow up to #2886 

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

The PyPy migrator is now paused (https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6292), but it doesn't appear in the paused_migrations.json because it is (was) a long running one and that category took precedence in the if-chain.