### PR TITLE
fix: keep paused migrators in status reports

### DIFF
--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -141,6 +141,7 @@ class MigrationYaml(GraphMigrator):
         effective_graph: nx.DiGraph = None,
         force_pr_after_solver_attempts=100,
         longterm=False,
+        paused=False,
         **kwargs: Any,
     ):
         if not hasattr(self, "_init_args"):
@@ -163,6 +164,7 @@ class MigrationYaml(GraphMigrator):
                 "effective_graph": effective_graph,
                 "longterm": longterm,
                 "force_pr_after_solver_attempts": force_pr_after_solver_attempts,
+                "paused": paused,
             }
             self._init_kwargs.update(copy.deepcopy(kwargs))
 
@@ -187,6 +189,7 @@ class MigrationYaml(GraphMigrator):
         self.max_solver_attempts = max_solver_attempts
         self.longterm = longterm
         self.force_pr_after_solver_attempts = force_pr_after_solver_attempts
+        self.paused = paused
 
         self._reset_effective_graph()
 

--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -402,7 +402,7 @@ def main() -> None:
             pinning_version=pinning_version,
             dry_run=False,
         )
-        migrators = load_migrators()
+        migrators = load_migrators(skip_paused=False)
 
     os.makedirs("./status/migration_json", exist_ok=True)
     os.makedirs("./status/migration_svg", exist_ok=True)


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

This PR adds code to try and keep paused migrators around in the bot system.

xref #2885 

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

closes #2885 