### PR TITLE
feat: remove build to python-build migration

### DIFF
--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -709,15 +709,6 @@ def initialize_migrators(
     add_replacement_migrator(
         migrators,
         gx,
-        cast("PackageName", "build"),
-        cast("PackageName", "python-build"),
-        "The conda package name 'build' is deprecated "
-        "and too generic. Use 'python-build' instead.",
-    )
-
-    add_replacement_migrator(
-        migrators,
-        gx,
         cast("PackageName", "mpir"),
         cast("PackageName", "gmp"),
         "The package 'mpir' is deprecated and unmaintained. Use 'gmp' instead.",


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR removes the build to python-build migrator per https://github.com/conda-forge/conda-forge.github.io/issues/2269.

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

xref: https://github.com/conda-forge/conda-forge.github.io/issues/2269
