### PR TITLE
feat: enable cross-compilation by default

### DIFF
--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -189,7 +189,7 @@ def add_arch_migrate(migrators: MutableSequence[Migrator], gx: nx.DiGraph) -> No
                     CrossCompilationForARMAndPower(),
                     NoCondaInspectMigrator(),
                     MPIPinRunAsBuildCleanup(),
-                ],                
+                ],
             ),
         )
 
@@ -297,7 +297,7 @@ def add_rebuild_migration_yaml(
         Build2HostMigrator(),
         NoCondaInspectMigrator(),
         UpdateCMakeArgsMigrator(),
-        GuardTestingMigrator(),        
+        GuardTestingMigrator(),
         CrossCompilationForARMAndPower(),
         MPIPinRunAsBuildCleanup(),
     ]
@@ -768,7 +768,7 @@ def initialize_migrators(
                 NoCondaInspectMigrator(),
                 PipWheelMigrator(),
                 UpdateCMakeArgsMigrator(),
-                GuardTestingMigrator(),                
+                GuardTestingMigrator(),
                 CrossCompilationForARMAndPower(),
                 MPIPinRunAsBuildCleanup(),
                 DependencyUpdateMigrator(python_nodes),

--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -181,6 +181,15 @@ def add_arch_migrate(migrators: MutableSequence[Migrator], gx: nx.DiGraph) -> No
                 graph=total_graph,
                 pr_limit=PR_LIMIT,
                 name="aarch64 and ppc64le addition",
+                piggy_back_migrations=[
+                    Build2HostMigrator(),
+                    CondaForgeYAMLCleanup(),
+                    UpdateCMakeArgsMigrator(),
+                    GuardTestingMigrator(),
+                    CrossCompilationForARMAndPower(),
+                    NoCondaInspectMigrator(),
+                    MPIPinRunAsBuildCleanup(),
+                ],                
             ),
         )
 
@@ -287,6 +296,8 @@ def add_rebuild_migration_yaml(
         ExtraJinja2KeysCleanup(),
         Build2HostMigrator(),
         NoCondaInspectMigrator(),
+        UpdateCMakeArgsMigrator(),
+        GuardTestingMigrator(),        
         CrossCompilationForARMAndPower(),
         MPIPinRunAsBuildCleanup(),
     ]
@@ -756,6 +767,9 @@ def initialize_migrators(
                 Build2HostMigrator(),
                 NoCondaInspectMigrator(),
                 PipWheelMigrator(),
+                UpdateCMakeArgsMigrator(),
+                GuardTestingMigrator(),                
+                CrossCompilationForARMAndPower(),
                 MPIPinRunAsBuildCleanup(),
                 DependencyUpdateMigrator(python_nodes),
                 StdlibMigrator(),


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR turns on cross-compilation for aarch64+ppc64le by default.

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

closes #2930 
