### PR TITLE
feat: disable dependency checking by default

### DIFF
--- a/conda_forge_tick/migrators/version.py
+++ b/conda_forge_tick/migrators/version.py
@@ -326,7 +326,7 @@ class Version(Migrator):
             feedstock_ctx.attrs,
             ["conda-forge.yml", "bot", "inspection"],
             {},
-            "hint",
+            "disabled",
         )
         logger.info("bot.inspection: %s", update_deps)
 


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR disables dependency checking by default for version migrations. Folks can still opt-in if they want.

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

closes #2929 
