### PR TITLE
fix: always update for deps and skip making PR if it already exists

### DIFF
--- a/.github/workflows/relock.yml
+++ b/.github/workflows/relock.yml
@@ -35,7 +35,26 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           rm summary.txt
 
-      - name: Open PR
+      # https://stackoverflow.com/a/73828715/1745538
+      - name: skip if PR already exists
+        id: check
+        run: |
+          prs=$(gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --head 'relock-deps' \
+              --base 'master' \
+              --json title \
+              --jq 'length')
+          if [[ ${prs} !=  "0" ]]; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+
+      - name: open PR
+        if: ${{ steps.check.outputs.skip != 'true' }}
         id: pr
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
@@ -53,7 +72,7 @@ jobs:
           labels: dependencies
 
       - name: automerge
-        if: ${{ steps.pr.outputs.pull-request-number != '' }}
+        if: ${{ steps.check.outputs.skip != 'true' && steps.pr.outputs.pull-request-number != '' }}
         run: gh pr merge --merge --auto "${{ steps.pr.outputs.pull-request-number }}"
         env:
           GH_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}

--- a/autotick-bot/relock_me.py
+++ b/autotick-bot/relock_me.py
@@ -106,10 +106,6 @@ def main(lockfile, reformat_only, force):
         for spec in envyml["dependencies"]:
             spec = MatchSpec(spec)
 
-            # we always pull the latest on the fly when the bot runs
-            if spec.name == "conda-forge-pinning":
-                continue
-
             for platform in envyml["platforms"]:
                 if old_platform_pkg_to_ver[platform].get(
                     spec.name


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

This PR fixes a bug where we did not update for all pinnings packages. We used to pull the pinnings packages directly, but now we only use the conda package so we have to always update.

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
