### PR TITLE
Link to migration on conda-forge.org in PR description

### DIFF
--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -285,10 +285,11 @@ class MigrationYaml(GraphMigrator):
 
     def pr_body(self, feedstock_ctx: ClonedFeedstockContext) -> str:
         body = super().pr_body(feedstock_ctx)
+        url = f"https://conda-forge.org/status/migration/?name={self.name}"
         if feedstock_ctx.feedstock_name == "conda-forge-pinning":
             additional_body = (
                 "This PR has been triggered in an effort to close out the "
-                "migration for **{name}**.\n\n"
+                "migration for [**{name}**]({url}).\n\n"
                 "Notes and instructions for merging this PR:\n"
                 "1. Please merge the PR only after the tests have passed. \n"
                 "2. Feel free to push to the bot's branch to update this PR "
@@ -300,11 +301,13 @@ class MigrationYaml(GraphMigrator):
                 "<hr>"
                 "".format(
                     name=self.name,
+                    url=url,
                 )
             )
         else:
             additional_body = (
-                "This PR has been triggered in an effort to update **{name}**.\n\n"
+                "This PR has been triggered in an effort to update "
+                "[**{name}**]({url}).\n\n"
                 "Notes and instructions for merging this PR:\n"
                 "1. Please merge the PR only after the tests have passed. \n"
                 "2. Feel free to push to the bot's branch to update this PR "
@@ -316,6 +319,7 @@ class MigrationYaml(GraphMigrator):
                 "<hr>"
                 "".format(
                     name=self.name,
+                    url=url,
                 )
             )
 

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -18,6 +18,7 @@ from conda_forge_tick.os_utils import pushd
 from conda_forge_tick.utils import (
     get_bot_run_url,
     get_keys_default,
+    get_migrator_name,
     pluck,
     yaml_safe_dump,
     yaml_safe_load,
@@ -285,7 +286,8 @@ class MigrationYaml(GraphMigrator):
 
     def pr_body(self, feedstock_ctx: ClonedFeedstockContext) -> str:
         body = super().pr_body(feedstock_ctx)
-        url = f"https://conda-forge.org/status/migration/?name={self.name}"
+        name = get_migrator_name(self)
+        url = f"https://conda-forge.org/status/migration/?name={name}"
         if feedstock_ctx.feedstock_name == "conda-forge-pinning":
             additional_body = (
                 "This PR has been triggered in an effort to close out the "
@@ -300,7 +302,7 @@ class MigrationYaml(GraphMigrator):
                 "the your rebuild has been merged.**\n\n"
                 "<hr>"
                 "".format(
-                    name=self.name,
+                    name=name,
                     url=url,
                 )
             )
@@ -318,7 +320,7 @@ class MigrationYaml(GraphMigrator):
                 "the your rebuild has been merged.**\n\n"
                 "<hr>"
                 "".format(
-                    name=self.name,
+                    name=name,
                     url=url,
                 )
             )

--- a/tests/test_container_tasks.py
+++ b/tests/test_container_tasks.py
@@ -644,7 +644,8 @@ def test_migration_runner_run_migration_containerized_yaml_rebuild(tmpdir):
     assert migration_data["commit_message"] == "Rebuild for hi"
     assert migration_data["pr_title"] == "Rebuild for hi"
     assert migration_data["pr_body"].startswith(
-        "This PR has been triggered in an effort to update **hi**."
+        "This PR has been triggered in an effort to update "
+        "[**hi**](https://conda-forge.org/status/migration/?name=hi)."
     )
 
     with open(os.path.join(rp_dir, "meta.yaml")) as f:

--- a/tests/test_migration_runner.py
+++ b/tests/test_migration_runner.py
@@ -65,7 +65,8 @@ def test_migration_runner_run_migration_local_yaml_rebuild(tmpdir):
     assert migration_data["commit_message"] == "Rebuild for hi"
     assert migration_data["pr_title"] == "Rebuild for hi"
     assert migration_data["pr_body"].startswith(
-        "This PR has been triggered in an effort to update **hi**."
+        "This PR has been triggered in an effort to update "
+        "[**hi**](https://conda-forge.org/status/migration/?name=hi)."
     )
 
     with open(os.path.join(tmpdir, "recipe/meta.yaml")) as f:


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR modifies the PR description for migrations to include a link to the migration page on conda-forge.org. This may help (will help me) maintainers understand the status of the whole migration and where their package update sits in the grand scheme of things.

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
