### PR TITLE
Version updates: report version for pending updates, remove `errored` set (redundant with `errors.keys()`)

### DIFF
--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -67,10 +67,9 @@ def _ok_version(ver):
 def write_version_migrator_status(migrator, mctx):
     """write the status of the version migrator"""
 
-    out: Dict[str, Any] = {
-        "queued": set(),
-        "errored": set(),
-        "errors": {},
+    out: Dict[str, Dict[str, str]] = {
+        "queued": {},  # name -> pending version
+        "errors": {},  # name -> error
     }
 
     gx = mctx.graph
@@ -109,9 +108,8 @@ def write_version_migrator_status(migrator, mctx):
                 ):
                     attempts = vpri.get("new_version_attempts", {}).get(new_version, 0)
                     if attempts == 0:
-                        out["queued"].add(node)
+                        out["queued"][node] = new_version
                     else:
-                        out["errored"].add(node)
                         out["errors"][node] = f"{attempts:.2f} attempts - " + vpri.get(
                             "new_version_errors",
                             {},


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

Update `version_status.json`:

- Turn `queued` set into a dictionary that maps the package name to the pending version update.
- Remove `errored` from the JSON payload because it's redundant with the keys of `errors`.

#### Checklist:

- [X] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->


Part of https://github.com/conda-forge/conda-forge.github.io/issues/2289