### PR TITLE
fix: ensure RUN_URL is passed to container

### DIFF
--- a/conda_forge_tick/migration_runner.py
+++ b/conda_forge_tick/migration_runner.py
@@ -171,6 +171,7 @@ def run_migration_containerized(
                 if isinstance(node_attrs, LazyJson)
                 else dumps(node_attrs)
             ),
+            extra_container_args=["-e", "RUN_URL"],
         )
 
         sync_dirs(


### PR DESCRIPTION
This should fix the run url not being put in the bot PR descriptions properly.