### PR TITLE
fix: remove old rerender code

### DIFF
--- a/conda_forge_tick/container_cli.py
+++ b/conda_forge_tick/container_cli.py
@@ -17,7 +17,6 @@ import glob
 import json
 import logging
 import os
-import shutil
 import subprocess
 import sys
 import tempfile


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR removes old rerender code.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
