### PR TITLE
fix: ensure code works with API change in networkx>=3.6

### DIFF
--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -837,7 +837,7 @@ def default(obj: Any) -> Any:
     elif isinstance(obj, Set):
         return {"__set__": True, "elements": sorted(obj)}
     elif isinstance(obj, nx.DiGraph):
-        nld = nx.node_link_data(obj)
+        nld = nx.node_link_data(obj, edges="links")
         links = nld["links"]
         links2 = sorted(links, key=lambda x: f'{x["source"]}{x["target"]}')
         nld["links"] = links2

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -1041,7 +1041,7 @@ def pluck(G: nx.DiGraph, node_id: Any) -> None:
 
 
 def dump_graph_json(gx: nx.DiGraph, filename: str = "graph.json") -> None:
-    nld = nx.node_link_data(gx)
+    nld = nx.node_link_data(gx, edges="links")
     links = nld["links"]
     links2 = sorted(links, key=lambda x: f'{x["source"]}{x["target"]}')
     nld["links"] = links2


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR ensures that the code will work with networkx >=3.6.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
