### PR TITLE
fix: add static override for pyyaml

### DIFF
--- a/conda_forge_tick/pypi_name_mapping_static.yaml
+++ b/conda_forge_tick/pypi_name_mapping_static.yaml
@@ -119,3 +119,7 @@
 - pypi_name: libigl
   import_name: igl
   conda_name: igl
+
+- pypi_name: pyyaml
+  import_name: yaml
+  conda_name: pyyaml


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR adds a static override for pyyaml for pypi mappings. The issue here is that the pyyaml recipe has two imports for testing (`yaml` and `_yaml`), and this confuses the bot's code. I don't want to fix that since TBH the code the bot is using here is complex and not where we should be going. So a manual override is expedient. 

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

closes #3031
