### PR TITLE
Add piggyback migrator for flang

### DIFF
--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -47,6 +47,7 @@ from conda_forge_tick.migrators import (
     DependencyUpdateMigrator,
     DuplicateLinesCleanup,
     ExtraJinja2KeysCleanup,
+    FlangMigrator,
     GraphMigrator,
     GuardTestingMigrator,
     Jinja2VarsCleanup,
@@ -301,6 +302,8 @@ def add_rebuild_migration_yaml(
         piggy_back_migrations.append(Numpy2Migrator())
     if migration_name.startswith("r-base44"):
         piggy_back_migrations.append(RUCRTCleanup())
+    if migration_name.startswith("flang19"):
+        piggy_back_migrations.append(FlangMigrator())
     # stdlib migrator runs on top of ALL migrations, see
     # https://github.com/conda-forge/conda-forge.github.io/issues/2102
     piggy_back_migrations.append(StdlibMigrator())

--- a/conda_forge_tick/migrators/__init__.py
+++ b/conda_forge_tick/migrators/__init__.py
@@ -18,6 +18,7 @@ from .cstdlib import StdlibMigrator
 from .dep_updates import DependencyUpdateMigrator
 from .duplicate_lines import DuplicateLinesCleanup
 from .extra_jinj2a_keys_cleanup import ExtraJinja2KeysCleanup
+from .flang import FlangMigrator
 from .jinja2_vars_cleanup import Jinja2VarsCleanup
 from .jpegturbo import JpegTurboMigrator
 from .libboost import LibboostMigrator

--- a/conda_forge_tick/migrators/flang.py
+++ b/conda_forge_tick/migrators/flang.py
@@ -37,12 +37,15 @@ def _process_section(lines):
 
     comp_bools = [(i, pat_comp.match(x)) for i, x in enumerate(lines)]
     comp_lines = [i for i, is_comp in comp_bools if is_comp]
+    # extend in both directions so we can take forward and backward differences;
+    # -2 is so that `diff > 1` below will be true even if there's a comment in
+    # the very first line; needed to get matching number of block beginnings/ends.
+    comp_lines_ext = [-2] + comp_lines + [len(lines)]
     comp_fw_diff = [
-        (i, i_next - i)
-        for i, i_next in zip(comp_lines, comp_lines[1:] + [len(lines) + 2])
+        (i, i_next - i) for i, i_next in zip(comp_lines, comp_lines_ext[2:])
     ]
     comp_bw_diff = [
-        (i, i - i_prev) for i, i_prev in zip(comp_lines, [-2] + comp_lines[:-1])
+        (i, i - i_prev) for i, i_prev in zip(comp_lines, comp_lines_ext[:-2])
     ]
     comp_blocks_end = [i for i, diff in comp_fw_diff if diff > 1]
     comp_blocks_begin = [i for i, diff in comp_bw_diff if diff > 1]

--- a/conda_forge_tick/migrators/flang.py
+++ b/conda_forge_tick/migrators/flang.py
@@ -1,0 +1,99 @@
+import os
+import re
+
+from conda_forge_tick.migrators.core import MiniMigrator, _skip_due_to_schema
+from conda_forge_tick.migrators.libboost import _replacer, _slice_into_output_sections
+
+# compiler("m2w64_fortran")
+#           ^^    ^
+#           m2    f
+raw_pat_m2f = r"^(?P<indent>\s*)- \{\{\s*compiler\([\"\']m2w64_fortran.*"
+pat_m2f = re.compile(raw_pat_m2f)
+
+# fortran, but with a selector
+raw_pat_fws = (
+    r"^(?P<indent>\s*)- \{\{\s*compiler\([\"\']fortran[\"\']\)\s*\}\}\s*\# \[.*"
+)
+pat_fws = re.compile(raw_pat_fws)
+
+# a compiler OR a comment
+raw_pat_comp = r".*\{\{\s*(compiler|stdlib)\([\"\'](?:m2w64_)?(?P<lang>c(?:xx)?|fortran)\W.*|\s*\#.*"
+pat_comp = re.compile(raw_pat_comp)
+
+
+def _process_section(lines):
+    """
+    Migrate requirements per section.
+
+    We want to migrate as follows:
+    - find if there's a `{{ compiler("m2w64_fortran") }}` in a section
+    - if so, find all the surrounding lines that are a compiler or stdlib jinja
+    - determine the compiler languages (modulo `m2w64_`)
+    - write a selector-less compiler block with stdlib and all the right languages
+    """
+    # the below does not apply if there's no `{{ compiler("m2w64_fortran") }}`
+    if not any(pat_m2f.match(x) for x in lines):
+        return lines
+
+    comp_bools = [(i, pat_comp.match(x)) for i, x in enumerate(lines)]
+    comp_lines = [i for i, is_comp in comp_bools if is_comp]
+    comp_fw_diff = [
+        (i, i_next - i)
+        for i, i_next in zip(comp_lines, comp_lines[1:] + [len(lines) + 2])
+    ]
+    comp_bw_diff = [
+        (i, i - i_prev) for i, i_prev in zip(comp_lines, [-2] + comp_lines[:-1])
+    ]
+    comp_blocks_end = [i for i, diff in comp_fw_diff if diff > 1]
+    comp_blocks_begin = [i for i, diff in comp_bw_diff if diff > 1]
+
+    m2f_line = [i for i, x in enumerate(lines) if pat_m2f.match(x)][0]
+    indent = pat_m2f.sub(r"\g<indent>", lines[m2f_line])
+    begin, end = [
+        (b, e) for b, e in zip(comp_blocks_begin, comp_blocks_end) if b <= m2f_line <= e
+    ][0]
+
+    langs = {pat_comp.sub(r"\g<lang>", x) for x in lines[begin : end + 1]}
+    # if we caught a comment, lang will be ""
+    langs = sorted([x for x in langs if x])
+    comp_block_new = [f'{indent}- {{{{ compiler("{lang}") }}}}' for lang in langs]
+    comp_block_new = [f'{indent}- {{{{ stdlib("c") }}}}'] + comp_block_new
+
+    new_lines = lines[:begin] + comp_block_new + lines[end + 1 :]
+    return new_lines
+
+
+class FlangMigrator(MiniMigrator):
+    def filter(self, attrs, not_bad_str_start=""):
+        lines = attrs["raw_meta_yaml"].splitlines()
+        has_m2f = any(pat_m2f.search(line) or pat_fws.search(line) for line in lines)
+        # filter() returns True if we _don't_ want to migrate
+        return (not (has_m2f)) or _skip_due_to_schema(
+            attrs, self.allowed_schema_versions
+        )
+
+    def migrate(self, recipe_dir, attrs, **kwargs):
+        fname = os.path.join(recipe_dir, "meta.yaml")
+        if os.path.exists(fname):
+            with open(fname) as fp:
+                # strip trailing newlines, because it breaks regex processing
+                lines = [x.rstrip() for x in fp.readlines()]
+
+            new_lines = []
+            sections = _slice_into_output_sections(lines, attrs)
+            for section in sections.values():
+                # _process_section returns list of lines already
+                new_lines += _process_section(section)
+
+            # for non-m2w64 compilers, remove selectors from `{{ compiler("fortran") }}`
+            new_lines = _replacer(
+                new_lines, raw_pat_fws, r'\g<indent>- {{ compiler("fortran") }}'
+            )
+
+            # remove some obsolete outputs
+            new_lines = _replacer(new_lines, r"- flang.*", "")
+            new_lines = _replacer(new_lines, r"- vs2019_win-64.*", "")
+            new_lines = _replacer(new_lines, r"- m2w64-gcc-(lib)?gfortran.*", "")
+
+            with open(fname, "w") as fp:
+                fp.write("\n".join(new_lines))

--- a/tests/test_flang.py
+++ b/tests/test_flang.py
@@ -26,6 +26,8 @@ VERSION_WITH_FLANG = Version(
         ("mfront", "1.10.0"),
         # includes cxx (non-m2w64) as a language
         ("plplot", "1.10.0"),
+        # includes m2w64_cxx compiler
+        ("pcmsolver-split", "1.10.0"),
     ],
 )
 def test_stdlib(feedstock, new_ver, tmpdir):

--- a/tests/test_flang.py
+++ b/tests/test_flang.py
@@ -30,7 +30,7 @@ VERSION_WITH_FLANG = Version(
         ("pcmsolver-split", "1.10.0"),
     ],
 )
-def test_stdlib(feedstock, new_ver, tmpdir):
+def test_flang(feedstock, new_ver, tmpdir):
     before = f"flang_{feedstock}_before_meta.yaml"
     with open(os.path.join(TEST_YAML_PATH, before)) as fp:
         in_yaml = fp.read()

--- a/tests/test_flang.py
+++ b/tests/test_flang.py
@@ -18,6 +18,8 @@ VERSION_WITH_FLANG = Version(
 @pytest.mark.parametrize(
     "feedstock,new_ver",
     [
+        # multiple outputs
+        ("lapack", "1.10.0"),
     ],
 )
 def test_stdlib(feedstock, new_ver, tmpdir):

--- a/tests/test_flang.py
+++ b/tests/test_flang.py
@@ -1,0 +1,48 @@
+import os
+
+import pytest
+from test_migrators import run_test_migration
+
+from conda_forge_tick.migrators import FlangMigrator, Version
+
+TEST_YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")
+
+
+FLANG = FlangMigrator()
+VERSION_WITH_FLANG = Version(
+    set(),
+    piggy_back_migrations=[FLANG],
+)
+
+
+@pytest.mark.parametrize(
+    "feedstock,new_ver",
+    [
+    ],
+)
+def test_stdlib(feedstock, new_ver, tmpdir):
+    before = f"flang_{feedstock}_before_meta.yaml"
+    with open(os.path.join(TEST_YAML_PATH, before)) as fp:
+        in_yaml = fp.read()
+
+    after = f"flang_{feedstock}_after_meta.yaml"
+    with open(os.path.join(TEST_YAML_PATH, after)) as fp:
+        out_yaml = fp.read()
+
+    recipe_dir = os.path.join(tmpdir, f"{feedstock}-feedstock")
+    os.makedirs(recipe_dir, exist_ok=True)
+
+    run_test_migration(
+        m=VERSION_WITH_FLANG,
+        inp=in_yaml,
+        output=out_yaml,
+        kwargs={"new_version": new_ver},
+        prb="Dependencies have been updated if changed",
+        mr_out={
+            "migrator_name": "Version",
+            "migrator_version": VERSION_WITH_FLANG.migrator_version,
+            "version": new_ver,
+        },
+        tmpdir=recipe_dir,
+        should_filter=False,
+    )

--- a/tests/test_flang.py
+++ b/tests/test_flang.py
@@ -22,6 +22,8 @@ VERSION_WITH_FLANG = Version(
         ("lapack", "1.10.0"),
         # comments in compiler block
         ("prima", "1.10.0"),
+        # remove selector for non-m2w64 fortran compilers
+        ("mfront", "1.10.0"),
     ],
 )
 def test_stdlib(feedstock, new_ver, tmpdir):

--- a/tests/test_flang.py
+++ b/tests/test_flang.py
@@ -24,6 +24,8 @@ VERSION_WITH_FLANG = Version(
         ("prima", "1.10.0"),
         # remove selector for non-m2w64 fortran compilers
         ("mfront", "1.10.0"),
+        # includes cxx (non-m2w64) as a language
+        ("plplot", "1.10.0"),
     ],
 )
 def test_stdlib(feedstock, new_ver, tmpdir):

--- a/tests/test_flang.py
+++ b/tests/test_flang.py
@@ -20,6 +20,8 @@ VERSION_WITH_FLANG = Version(
     [
         # multiple outputs
         ("lapack", "1.10.0"),
+        # comments in compiler block
+        ("prima", "1.10.0"),
     ],
 )
 def test_stdlib(feedstock, new_ver, tmpdir):

--- a/tests/test_yaml/flang_lapack_after_meta.yaml
+++ b/tests/test_yaml/flang_lapack_after_meta.yaml
@@ -1,0 +1,269 @@
+{% set version = "1.10.0" %}
+# if build is reset to 0 (for new version), update increment for blas_minor below
+{% set build = 0 %}
+{% set version_major = version.split(".")[0] %}
+# blas_major denotes major infrastructural change to how blas is managed
+{% set blas_major = "2" %}
+# make sure we do not create colliding version strings of output "blas"
+# for builds across lapack-versions within the same blas_major
+{% set blas_minor = build + 200 %}
+
+{% if unix %}
+{% set library = "" %}
+{% else %}
+{% set library = "Library/" %}
+{% endif %}
+
+package:
+  name: blas-split
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 3f9e587a96844a9b4ee7f998cfe4dc3964dc95c4ca94d7de6a77bffb99f873da
+  # url: https://github.com/Reference-LAPACK/lapack/archive/v{{ version }}.tar.gz
+  # sha256: 4b9ba79bfd4921ca820e83979db76ab3363155709444a787979e81c22285ffa9
+  # patches:
+  #   # Avoid setting current_version and compatibility_version
+  #   - patches/0001-Avoid-setting-current_version-and-compatibility_vers.patch  # [osx]
+
+build:
+  number: {{ build }}
+
+requirements:
+  build:
+    - {{ stdlib("c") }}
+    - {{ compiler("c") }}
+    - {{ compiler("fortran") }}
+    - ninja                             # [win]
+    - make                              # [unix]
+    - cmake
+
+outputs:
+  - name: libblas
+    build:
+      string: {{ build_num }}_h{{ PKG_HASH }}_netlib
+      track_features:
+        # netlib variants must have at least 1 more feature
+        # than all variants of non-netlib blas implementations
+        - blas_netlib
+        - blas_netlib_2
+      run_exports:
+        - {{ pin_subpackage("libblas", max_pin="x") }}
+    requirements:
+      build:
+        - {{ stdlib("c") }}
+        - {{ compiler("c") }}
+        - {{ compiler("fortran") }}
+      run_constrained:
+        - blas * netlib
+    files:
+      - {{ library }}lib/pkgconfig/blas.pc
+      - lib/libblas.so                          # [linux]
+      - lib/libblas.so.{{ version_major }}      # [linux]
+      - lib/libblas.so.{{ version }}            # [linux]
+      - lib/libblas.dylib                       # [osx]
+      - lib/libblas.{{ version_major }}.dylib   # [osx]
+      - lib/libblas.{{ version }}.dylib         # [osx]
+      - Library/bin/libblas.dll                 # [win]
+      - Library/lib/blas.lib                    # [win]
+      - Library/lib/libblas.dll.a               # [win]
+    test:
+      commands:
+        - echo "no need to revalidate `files:` specification"
+
+  - name: libtmglib
+    build:
+      string: {{ build_num }}_h{{ PKG_HASH }}_netlib
+      track_features:
+        - blas_netlib
+        - blas_netlib_2
+      run_exports:
+        - {{ pin_subpackage("libtmglib", max_pin="x") }}
+    requirements:
+      build:
+        - {{ stdlib("c") }}
+        - {{ compiler("c") }}
+        - {{ compiler("fortran") }}
+      run_constrained:
+        - blas * netlib
+    files:
+      - lib/libtmglib.so                          # [linux]
+      - lib/libtmglib.so.{{ version_major }}      # [linux]
+      - lib/libtmglib.so.{{ version }}            # [linux]
+      - lib/libtmglib.dylib                       # [osx]
+      - lib/libtmglib.{{ version_major }}.dylib   # [osx]
+      - lib/libtmglib.{{ version }}.dylib         # [osx]
+      - Library/bin/libtmglib.dll                 # [win]
+      - Library/lib/libtmglib.dll.a               # [win]
+    test:
+      commands:
+        - echo "no need to revalidate `files:` specification"
+
+  - name: libcblas
+    build:
+      string: {{ build_num }}_h{{ PKG_HASH }}_netlib
+      track_features:
+        - blas_netlib
+        - blas_netlib_2
+      run_exports:
+        - {{ pin_subpackage("libcblas", max_pin="x") }}
+    requirements:
+      build:
+        - {{ stdlib("c") }}
+        - {{ compiler("c") }}
+        - {{ compiler("fortran") }}
+      run:
+        - libblas {{ version }}
+    files:
+      - {{ library }}include/cblas*.h
+      - {{ library }}lib/pkgconfig/cblas.pc
+      - {{ library }}lib/cmake/cblas-{{ version }}/*.cmake
+      - lib/libcblas.so                          # [linux]
+      - lib/libcblas.so.{{ version_major }}      # [linux]
+      - lib/libcblas.so.{{ version }}            # [linux]
+      - lib/libcblas.dylib                       # [osx]
+      - lib/libcblas.{{ version_major }}.dylib   # [osx]
+      - lib/libcblas.{{ version }}.dylib         # [osx]
+      - Library/bin/libcblas.dll                 # [win]
+      - Library/lib/cblas.lib                    # [win]
+      - Library/lib/libcblas.dll.a               # [win]
+    test:
+      commands:
+        - echo "no need to revalidate `files:` specification"
+
+  - name: liblapack
+    build:
+      string: {{ build_num }}_h{{ PKG_HASH }}_netlib
+      track_features:
+        - blas_netlib
+        - blas_netlib_2
+      run_exports:
+        - {{ pin_subpackage("liblapack", max_pin="x") }}
+    requirements:
+      build:
+        - {{ stdlib("c") }}
+        - {{ compiler("c") }}
+        - {{ compiler("fortran") }}
+      run:
+        - libblas {{ version }}
+    files:
+      - {{ library }}lib/pkgconfig/lapack.pc
+      - {{ library }}lib/cmake/lapack-{{ version }}/*.cmake
+      - lib/liblapack.so                          # [linux]
+      - lib/liblapack.so.{{ version_major }}      # [linux]
+      - lib/liblapack.so.{{ version }}            # [linux]
+      - lib/liblapack.dylib                       # [osx]
+      - lib/liblapack.{{ version_major }}.dylib   # [osx]
+      - lib/liblapack.{{ version }}.dylib         # [osx]
+      - Library/bin/liblapack.dll                 # [win]
+      - Library/lib/lapack.lib                    # [win]
+      - Library/lib/liblapack.dll.a               # [win]
+    test:
+      commands:
+        - echo "no need to revalidate `files:` specification"
+
+  - name: liblapacke
+    build:
+      string: {{ build_num }}_h{{ PKG_HASH }}_netlib
+      track_features:
+        - blas_netlib
+        - blas_netlib_2
+      run_exports:
+        - {{ pin_subpackage("liblapacke", max_pin="x") }}
+    requirements:
+      build:
+        - {{ stdlib("c") }}
+        - {{ compiler("c") }}
+        - {{ compiler("fortran") }}
+      run:
+        - libblas    {{ version }}
+        - libcblas   {{ version }}
+        - liblapack  {{ version }}
+    files:
+      - {{ library }}include/lapack*.h
+      - {{ library }}lib/pkgconfig/lapacke.pc
+      - {{ library }}lib/cmake/lapacke-{{ version }}/*.cmake
+      - lib/liblapacke.so                          # [linux]
+      - lib/liblapacke.so.{{ version_major }}      # [linux]
+      - lib/liblapacke.so.{{ version }}            # [linux]
+      - lib/liblapacke.dylib                       # [osx]
+      - lib/liblapacke.{{ version_major }}.dylib   # [osx]
+      - lib/liblapacke.{{ version }}.dylib         # [osx]
+      - Library/bin/liblapacke.dll                 # [win]
+      - Library/lib/lapacke.lib                    # [win]
+      - Library/lib/liblapacke.dll.a               # [win]
+    test:
+      commands:
+        - echo "no need to revalidate `files:` specification"
+
+  - name: blas-devel
+    build:
+      string: {{ build_num }}_netlib
+      track_features:
+        - blas_netlib
+        - blas_netlib_2
+    requirements:
+      run:
+        - {{ pin_subpackage("libblas", exact=True) }}
+        - {{ pin_subpackage("libcblas", exact=True) }}
+        - {{ pin_subpackage("liblapack", exact=True) }}
+        - {{ pin_subpackage("liblapacke", exact=True) }}
+    test:
+      commands:
+        - echo "pure meta-package"
+
+  # For conda-forge blas selector, see also blas-feedstock
+  - name: blas
+    version: {{ blas_major }}.{{ blas_minor }}
+    build:
+      string: netlib
+      track_features:
+        - blas_netlib
+        - blas_netlib_2
+    requirements:
+      - {{ pin_subpackage("liblapack", exact=True) }}
+      - {{ pin_subpackage("liblapacke", exact=True) }}
+      - {{ pin_subpackage("libcblas", exact=True) }}
+      - {{ pin_subpackage("libblas", exact=True) }}
+      - {{ pin_subpackage("blas-devel", exact=True) }}
+      - {{ pin_subpackage("libtmglib", exact=True) }}
+    test:
+      commands:
+        {% for each_lib in ['blas', 'cblas', 'lapack', 'lapacke'] %}
+        - test -f $PREFIX/lib/lib{{ each_lib }}.so                          # [linux]
+        - test -f $PREFIX/lib/lib{{ each_lib }}.so.{{ version_major }}      # [linux]
+        - test -f $PREFIX/lib/lib{{ each_lib }}.so.{{ version }}            # [linux]
+        - test -f $PREFIX/lib/lib{{ each_lib }}.dylib                       # [osx]
+        - test -f $PREFIX/lib/lib{{ each_lib }}.{{ version_major }}.dylib   # [osx]
+        - test -f $PREFIX/lib/lib{{ each_lib }}.{{ version }}.dylib         # [osx]
+        - test -f $PREFIX/lib/pkgconfig/{{ each_lib }}.pc                   # [unix]
+        - if not exist "%LIBRARY_LIB%\\pkgconfig\\{{ each_lib }}.pc" exit 1  # [win]
+        - if not exist "%LIBRARY_LIB%\\{{ each_lib }}.lib" exit 1           # [win]
+        - if not exist "%LIBRARY_BIN%\\lib{{ each_lib }}.dll" exit 1        # [win]
+        {% endfor %}
+
+  # For compatiblity (see #33)
+  - name: lapack
+    build:
+      string: netlib
+    requirements:
+      run:
+        - liblapack {{ version }}
+    test:
+      commands:
+        - echo "pure meta-package"
+
+about:
+  home: http://www.netlib.org/lapack
+  license: BSD-3-Clause
+  license_file: LICENSE
+  summary: Linear Algebra PACKage
+
+extra:
+  feedstock-name: lapack
+  recipe-maintainers:
+    - jakirkham
+    - isuruf
+    - h-vetinari

--- a/tests/test_yaml/flang_lapack_before_meta.yaml
+++ b/tests/test_yaml/flang_lapack_before_meta.yaml
@@ -1,0 +1,289 @@
+{% set version = "1.9.0" %}
+# if build is reset to 0 (for new version), update increment for blas_minor below
+{% set build = 0 %}
+{% set version_major = version.split(".")[0] %}
+# blas_major denotes major infrastructural change to how blas is managed
+{% set blas_major = "2" %}
+# make sure we do not create colliding version strings of output "blas"
+# for builds across lapack-versions within the same blas_major
+{% set blas_minor = build + 200 %}
+
+{% if unix %}
+{% set library = "" %}
+{% else %}
+{% set library = "Library/" %}
+{% endif %}
+
+package:
+  name: blas-split
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: b6d893dc7dcd4138b9e9df59a13c59695e50e80dc5c2cacee0674670693951a1
+  # url: https://github.com/Reference-LAPACK/lapack/archive/v{{ version }}.tar.gz
+  # sha256: 4b9ba79bfd4921ca820e83979db76ab3363155709444a787979e81c22285ffa9
+  # patches:
+  #   # Avoid setting current_version and compatibility_version
+  #   - patches/0001-Avoid-setting-current_version-and-compatibility_vers.patch  # [osx]
+
+build:
+  number: {{ build }}
+
+requirements:
+  build:
+    - {{ compiler("c") }}               # [unix]
+    - {{ stdlib("c") }}                 # [unix]
+    - {{ compiler("fortran") }}         # [unix]
+    - {{ compiler("m2w64_c") }}         # [win]
+    - {{ stdlib("m2w64_c") }}           # [win]
+    - {{ compiler("m2w64_fortran") }}   # [win]
+    # This is just for creating the import libaries
+    - vs2019_win-64                     # [win64]
+    - ninja                             # [win]
+    - make                              # [unix]
+    - cmake
+
+outputs:
+  - name: libblas
+    build:
+      string: {{ build_num }}_h{{ PKG_HASH }}_netlib
+      track_features:
+        # netlib variants must have at least 1 more feature
+        # than all variants of non-netlib blas implementations
+        - blas_netlib
+        - blas_netlib_2
+      run_exports:
+        - {{ pin_subpackage("libblas", max_pin="x") }}
+    requirements:
+      build:
+        - {{ compiler("c") }}               # [unix]
+        - {{ stdlib("c") }}                 # [unix]
+        - {{ compiler("fortran") }}         # [unix]
+        - {{ compiler("m2w64_c") }}         # [win]
+        - {{ stdlib("m2w64_c") }}           # [win]
+        - {{ compiler("m2w64_fortran") }}   # [win]
+      run_constrained:
+        - blas * netlib
+    files:
+      - {{ library }}lib/pkgconfig/blas.pc
+      - lib/libblas.so                          # [linux]
+      - lib/libblas.so.{{ version_major }}      # [linux]
+      - lib/libblas.so.{{ version }}            # [linux]
+      - lib/libblas.dylib                       # [osx]
+      - lib/libblas.{{ version_major }}.dylib   # [osx]
+      - lib/libblas.{{ version }}.dylib         # [osx]
+      - Library/bin/libblas.dll                 # [win]
+      - Library/lib/blas.lib                    # [win]
+      - Library/lib/libblas.dll.a               # [win]
+    test:
+      commands:
+        - echo "no need to revalidate `files:` specification"
+
+  - name: libtmglib
+    build:
+      string: {{ build_num }}_h{{ PKG_HASH }}_netlib
+      track_features:
+        - blas_netlib
+        - blas_netlib_2
+      run_exports:
+        - {{ pin_subpackage("libtmglib", max_pin="x") }}
+    requirements:
+      build:
+        - {{ compiler("c") }}               # [unix]
+        - {{ stdlib("c") }}                 # [unix]
+        - {{ compiler("fortran") }}         # [unix]
+        - {{ compiler("m2w64_c") }}         # [win]
+        - {{ stdlib("m2w64_c") }}           # [win]
+        - {{ compiler("m2w64_fortran") }}   # [win]
+      run_constrained:
+        - blas * netlib
+    files:
+      - lib/libtmglib.so                          # [linux]
+      - lib/libtmglib.so.{{ version_major }}      # [linux]
+      - lib/libtmglib.so.{{ version }}            # [linux]
+      - lib/libtmglib.dylib                       # [osx]
+      - lib/libtmglib.{{ version_major }}.dylib   # [osx]
+      - lib/libtmglib.{{ version }}.dylib         # [osx]
+      - Library/bin/libtmglib.dll                 # [win]
+      - Library/lib/libtmglib.dll.a               # [win]
+    test:
+      commands:
+        - echo "no need to revalidate `files:` specification"
+
+  - name: libcblas
+    build:
+      string: {{ build_num }}_h{{ PKG_HASH }}_netlib
+      track_features:
+        - blas_netlib
+        - blas_netlib_2
+      run_exports:
+        - {{ pin_subpackage("libcblas", max_pin="x") }}
+    requirements:
+      build:
+        - {{ compiler("c") }}               # [unix]
+        - {{ stdlib("c") }}                 # [unix]
+        - {{ compiler("fortran") }}         # [unix]
+        - {{ compiler("m2w64_c") }}         # [win]
+        - {{ stdlib("m2w64_c") }}           # [win]
+        - {{ compiler("m2w64_fortran") }}   # [win]
+      run:
+        - libblas {{ version }}
+    files:
+      - {{ library }}include/cblas*.h
+      - {{ library }}lib/pkgconfig/cblas.pc
+      - {{ library }}lib/cmake/cblas-{{ version }}/*.cmake
+      - lib/libcblas.so                          # [linux]
+      - lib/libcblas.so.{{ version_major }}      # [linux]
+      - lib/libcblas.so.{{ version }}            # [linux]
+      - lib/libcblas.dylib                       # [osx]
+      - lib/libcblas.{{ version_major }}.dylib   # [osx]
+      - lib/libcblas.{{ version }}.dylib         # [osx]
+      - Library/bin/libcblas.dll                 # [win]
+      - Library/lib/cblas.lib                    # [win]
+      - Library/lib/libcblas.dll.a               # [win]
+    test:
+      commands:
+        - echo "no need to revalidate `files:` specification"
+
+  - name: liblapack
+    build:
+      string: {{ build_num }}_h{{ PKG_HASH }}_netlib
+      track_features:
+        - blas_netlib
+        - blas_netlib_2
+      run_exports:
+        - {{ pin_subpackage("liblapack", max_pin="x") }}
+    requirements:
+      build:
+        - {{ compiler("c") }}               # [unix]
+        - {{ stdlib("c") }}                 # [unix]
+        - {{ compiler("fortran") }}         # [unix]
+        - {{ compiler("m2w64_c") }}         # [win]
+        - {{ stdlib("m2w64_c") }}           # [win]
+        - {{ compiler("m2w64_fortran") }}   # [win]
+      run:
+        - libblas {{ version }}
+    files:
+      - {{ library }}lib/pkgconfig/lapack.pc
+      - {{ library }}lib/cmake/lapack-{{ version }}/*.cmake
+      - lib/liblapack.so                          # [linux]
+      - lib/liblapack.so.{{ version_major }}      # [linux]
+      - lib/liblapack.so.{{ version }}            # [linux]
+      - lib/liblapack.dylib                       # [osx]
+      - lib/liblapack.{{ version_major }}.dylib   # [osx]
+      - lib/liblapack.{{ version }}.dylib         # [osx]
+      - Library/bin/liblapack.dll                 # [win]
+      - Library/lib/lapack.lib                    # [win]
+      - Library/lib/liblapack.dll.a               # [win]
+    test:
+      commands:
+        - echo "no need to revalidate `files:` specification"
+
+  - name: liblapacke
+    build:
+      string: {{ build_num }}_h{{ PKG_HASH }}_netlib
+      track_features:
+        - blas_netlib
+        - blas_netlib_2
+      run_exports:
+        - {{ pin_subpackage("liblapacke", max_pin="x") }}
+    requirements:
+      build:
+        - {{ compiler("c") }}               # [unix]
+        - {{ stdlib("c") }}                 # [unix]
+        - {{ compiler("fortran") }}         # [unix]
+        - {{ compiler("m2w64_c") }}         # [win]
+        - {{ stdlib("m2w64_c") }}           # [win]
+        - {{ compiler("m2w64_fortran") }}   # [win]
+      run:
+        - libblas    {{ version }}
+        - libcblas   {{ version }}
+        - liblapack  {{ version }}
+    files:
+      - {{ library }}include/lapack*.h
+      - {{ library }}lib/pkgconfig/lapacke.pc
+      - {{ library }}lib/cmake/lapacke-{{ version }}/*.cmake
+      - lib/liblapacke.so                          # [linux]
+      - lib/liblapacke.so.{{ version_major }}      # [linux]
+      - lib/liblapacke.so.{{ version }}            # [linux]
+      - lib/liblapacke.dylib                       # [osx]
+      - lib/liblapacke.{{ version_major }}.dylib   # [osx]
+      - lib/liblapacke.{{ version }}.dylib         # [osx]
+      - Library/bin/liblapacke.dll                 # [win]
+      - Library/lib/lapacke.lib                    # [win]
+      - Library/lib/liblapacke.dll.a               # [win]
+    test:
+      commands:
+        - echo "no need to revalidate `files:` specification"
+
+  - name: blas-devel
+    build:
+      string: {{ build_num }}_netlib
+      track_features:
+        - blas_netlib
+        - blas_netlib_2
+    requirements:
+      run:
+        - {{ pin_subpackage("libblas", exact=True) }}
+        - {{ pin_subpackage("libcblas", exact=True) }}
+        - {{ pin_subpackage("liblapack", exact=True) }}
+        - {{ pin_subpackage("liblapacke", exact=True) }}
+    test:
+      commands:
+        - echo "pure meta-package"
+
+  # For conda-forge blas selector, see also blas-feedstock
+  - name: blas
+    version: {{ blas_major }}.{{ blas_minor }}
+    build:
+      string: netlib
+      track_features:
+        - blas_netlib
+        - blas_netlib_2
+    requirements:
+      - {{ pin_subpackage("liblapack", exact=True) }}
+      - {{ pin_subpackage("liblapacke", exact=True) }}
+      - {{ pin_subpackage("libcblas", exact=True) }}
+      - {{ pin_subpackage("libblas", exact=True) }}
+      - {{ pin_subpackage("blas-devel", exact=True) }}
+      - {{ pin_subpackage("libtmglib", exact=True) }}
+    test:
+      commands:
+        {% for each_lib in ['blas', 'cblas', 'lapack', 'lapacke'] %}
+        - test -f $PREFIX/lib/lib{{ each_lib }}.so                          # [linux]
+        - test -f $PREFIX/lib/lib{{ each_lib }}.so.{{ version_major }}      # [linux]
+        - test -f $PREFIX/lib/lib{{ each_lib }}.so.{{ version }}            # [linux]
+        - test -f $PREFIX/lib/lib{{ each_lib }}.dylib                       # [osx]
+        - test -f $PREFIX/lib/lib{{ each_lib }}.{{ version_major }}.dylib   # [osx]
+        - test -f $PREFIX/lib/lib{{ each_lib }}.{{ version }}.dylib         # [osx]
+        - test -f $PREFIX/lib/pkgconfig/{{ each_lib }}.pc                   # [unix]
+        - if not exist "%LIBRARY_LIB%\\pkgconfig\\{{ each_lib }}.pc" exit 1  # [win]
+        - if not exist "%LIBRARY_LIB%\\{{ each_lib }}.lib" exit 1           # [win]
+        - if not exist "%LIBRARY_BIN%\\lib{{ each_lib }}.dll" exit 1        # [win]
+        {% endfor %}
+
+  # For compatiblity (see #33)
+  - name: lapack
+    build:
+      string: netlib
+    requirements:
+      run:
+        - liblapack {{ version }}
+    test:
+      commands:
+        - echo "pure meta-package"
+
+about:
+  home: http://www.netlib.org/lapack
+  license: BSD-3-Clause
+  license_file: LICENSE
+  summary: Linear Algebra PACKage
+
+extra:
+  feedstock-name: lapack
+  recipe-maintainers:
+    - jakirkham
+    - isuruf
+    - h-vetinari

--- a/tests/test_yaml/flang_mfront_after_meta.yaml
+++ b/tests/test_yaml/flang_mfront_after_meta.yaml
@@ -1,0 +1,86 @@
+{% set name = "mfront" %}
+{% set version = "1.10.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 3f9e587a96844a9b4ee7f998cfe4dc3964dc95c4ca94d7de6a77bffb99f873da
+  # fn: {{ name }}_{{ version }}.tar.gz
+  # url: https://github.com/thelfer/tfel/archive/refs/tags/TFEL-{{ version }}.tar.gz
+  # sha256: {{ sha256 }}
+  # patches:
+  #   - patches/support_llvm-flang.patch  # [win]
+
+build:
+  number: 0
+  skip: true  # [py2k or osx or (python_impl == 'pypy')]
+  skip: true  # [win and py<39]
+  detect_binary_files_with_prefix: true
+  run_exports:
+    - {{ pin_subpackage('mfront', max_pin='x.x.x') }}
+
+requirements:
+  build:
+    - {{ compiler("fortran") }}
+    - {{ compiler('c') }}
+    - {{ stdlib("c") }}
+    - {{ compiler('cxx') }}
+    - cmake
+    - make  # [not win]
+    - ninja                       # [win]
+    - clang                       # [win]
+    - lld                         # [win]
+    - libgomp  # [linux]
+    - llvm-openmp  # [osx]
+  host:
+    - libboost-python-devel
+    - python
+    - zlib  # [linux]
+  run:
+    - python
+    - libstdcxx-ng  # [linux]
+    - libgcc-ng  # [linux]
+
+test:
+  commands:
+    - tfel-config --version
+    - tfel-doc --version  # [linux]
+    - tfel-check --version  # [linux]
+    - mtest --version
+    - mfront --list-stress-criteria
+    - mfront-doc --version
+    - mfront-query --version
+    - mfm --version
+    - test -f $PREFIX/lib/libTFELConfig.so  # [linux]
+    - test -f $PREFIX/lib/libTFELUnicodeSupport.so  # [linux]
+    - test -f $PREFIX/lib/libTFELGlossary.so  # [linux]
+    - test -f $PREFIX/lib/libTFELException.so  # [linux]
+    - test -f $PREFIX/lib/libTFELUtilities.so  # [linux]
+
+  imports:
+    - tfel
+    - tfel.math
+    - tfel.material
+
+about:
+  home: http://tfel.sourceforge.net
+  license: GPL-3.0-only
+  license_family: GPL
+  license_file: LICENCE-GNU-GPL
+  summary: MFront, a code generation tool dedicated to material knowledge
+  description: |
+    MFront is a code generator which translates a set of closely related domain specific languages into plain C++ on top of the TFEL library. Those languages cover three kinds of material knowledge:
+    material properties (for instance the Young modulus, the thermal conductivity, etc.)
+    mechanical behaviours. Numerical performances of generated mechanical behaviours were given a particular attention. Various benchmarks show that MFront implementations are competitive with native implementations available in the Cast3M, Code-Aster, Abaqus Standard and Cyrano3 solvers.
+    simple point-wise models, such as material swelling used in fuel performance codes.
+  doc_url: http://tfel.sourceforge.net/documentations.html
+  dev_url: http://tfel.sourceforge.net/devel.html
+
+extra:
+  recipe-maintainers:
+    - Krande
+    - ldallolio

--- a/tests/test_yaml/flang_mfront_before_meta.yaml
+++ b/tests/test_yaml/flang_mfront_before_meta.yaml
@@ -1,0 +1,87 @@
+{% set name = "mfront" %}
+{% set version = "1.9.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: b6d893dc7dcd4138b9e9df59a13c59695e50e80dc5c2cacee0674670693951a1
+  # fn: {{ name }}_{{ version }}.tar.gz
+  # url: https://github.com/thelfer/tfel/archive/refs/tags/TFEL-{{ version }}.tar.gz
+  # sha256: {{ sha256 }}
+  # patches:
+  #   - patches/support_llvm-flang.patch  # [win]
+
+build:
+  number: 2
+  skip: true  # [py2k or osx or (python_impl == 'pypy')]
+  skip: true  # [win and py<39]
+  detect_binary_files_with_prefix: true
+  run_exports:
+    - {{ pin_subpackage('mfront', max_pin='x.x.x') }}
+
+requirements:
+  build:
+    - {{ compiler('fortran') }}  # [not win]
+    - {{ compiler('c') }}
+    - {{ stdlib("c") }}
+    - {{ compiler('cxx') }}
+    - cmake
+    - make  # [not win]
+    - ninja                       # [win]
+    - flang                       # [win]
+    - clang                       # [win]
+    - lld                         # [win]
+    - libgomp  # [linux]
+    - llvm-openmp  # [osx]
+  host:
+    - libboost-python-devel
+    - python
+    - zlib  # [linux]
+  run:
+    - python
+    - libstdcxx-ng  # [linux]
+    - libgcc-ng  # [linux]
+
+test:
+  commands:
+    - tfel-config --version
+    - tfel-doc --version  # [linux]
+    - tfel-check --version  # [linux]
+    - mtest --version
+    - mfront --list-stress-criteria
+    - mfront-doc --version
+    - mfront-query --version
+    - mfm --version
+    - test -f $PREFIX/lib/libTFELConfig.so  # [linux]
+    - test -f $PREFIX/lib/libTFELUnicodeSupport.so  # [linux]
+    - test -f $PREFIX/lib/libTFELGlossary.so  # [linux]
+    - test -f $PREFIX/lib/libTFELException.so  # [linux]
+    - test -f $PREFIX/lib/libTFELUtilities.so  # [linux]
+
+  imports:
+    - tfel
+    - tfel.math
+    - tfel.material
+
+about:
+  home: http://tfel.sourceforge.net
+  license: GPL-3.0-only
+  license_family: GPL
+  license_file: LICENCE-GNU-GPL
+  summary: MFront, a code generation tool dedicated to material knowledge
+  description: |
+    MFront is a code generator which translates a set of closely related domain specific languages into plain C++ on top of the TFEL library. Those languages cover three kinds of material knowledge:
+    material properties (for instance the Young modulus, the thermal conductivity, etc.)
+    mechanical behaviours. Numerical performances of generated mechanical behaviours were given a particular attention. Various benchmarks show that MFront implementations are competitive with native implementations available in the Cast3M, Code-Aster, Abaqus Standard and Cyrano3 solvers.
+    simple point-wise models, such as material swelling used in fuel performance codes.
+  doc_url: http://tfel.sourceforge.net/documentations.html
+  dev_url: http://tfel.sourceforge.net/devel.html
+
+extra:
+  recipe-maintainers:
+    - Krande
+    - ldallolio

--- a/tests/test_yaml/flang_pcmsolver-split_after_meta.yaml
+++ b/tests/test_yaml/flang_pcmsolver-split_after_meta.yaml
@@ -1,0 +1,165 @@
+{% set name = "PCMSolver" %}
+{% set version = "1.10.0" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name|lower }}-split
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 3f9e587a96844a9b4ee7f998cfe4dc3964dc95c4ca94d7de6a77bffb99f873da
+  # url: https://github.com/{{ name }}/{{ name|lower }}/archive/v{{ version }}.tar.gz
+  # patches:
+  #   # 0004 and 0005 introduced at build=10
+  #   - [...]
+  # sha256: {{ sha256 }}
+
+build:
+  number: {{ build }}
+  # Only build for one python version because python module is repackaged as noarch
+  skip: true  # [py != 312]
+
+requirements:
+  build:
+    - python                              # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}  # [build_platform != target_platform]
+    - {{ stdlib("c") }}
+    - {{ compiler("c") }}
+    - {{ compiler("cxx") }}
+    - {{ compiler("fortran") }}
+    - cmake
+    - make                                # [unix]
+    - ninja                               # [win]
+  host:
+    - libboost-devel
+    - eigen
+    - python
+    - zlib
+  run:
+    - python
+
+outputs:
+  - name: pcmsolver
+    build:
+      noarch: python
+      # Only one pcmsolver variant by having a shared build string for all platforms
+      string: py_{{ build }}
+      run_exports:
+        - {{ pin_subpackage('pcmsolver', max_pin='x.x.x') }}
+        - {{ pin_subpackage('libpcm', max_pin='x.x.x') }}
+    requirements:
+      host:
+        - python
+      run:
+        - python
+        - {{ pin_subpackage('libpcm', max_pin='x.x.x') }}
+    files:
+      - bin/*.py                                                       # [unix]
+      - lib/python3.12/site-packages/pcmsolver                         # [unix]
+      - Library/bin/*.py                                               # [win]
+      - Lib/site-packages/pcmsolver                                    # [win]
+    test:
+      imports:
+        - pcmsolver
+      files:
+        - molecule.inp
+      requires:
+        - m2w64-binutils                                               # [win]   # provides objdump.exe
+      commands:
+        # Verify library
+        - test -L $PREFIX/lib/libpcm$SHLIB_EXT                         # [unix]
+        - test ! -f $PREFIX/lib/libpcm.a                               # [unix]
+        - test -f $SP_DIR/pcmsolver/pcmparser.py                       # [unix]
+        - if not exist %PREFIX%\\Library\\lib\\libpcm.dll.a exit 1     # [win]   # gnu import lib
+        - if not exist %PREFIX%\\Library\\lib\\libpcm.lib exit 1       # [win]   # ms import lib
+        - if not exist %PREFIX%\\Library\\bin\\libpcm.dll exit 1       # [win]   # gnu/ms dyn lib
+        - if exist %PREFIX%\\Library\\lib\\libpcm.a exit 1             # [win]   # gnu static lib removed
+        - if not exist %SP_DIR%\\pcmsolver\\pcmparser.py exit 1        # [win]
+        # Verify executable
+        - test -f $PREFIX/bin/go_pcm.py                                # [unix]
+        - test -f $PREFIX/bin/run_pcm                                  # [unix]
+        - if not exist %PREFIX%\\Library\\bin\\go_pcm.py exit 1        # [win]
+        - if not exist %PREFIX%\\Library\\bin\\run_pcm.exe exit 1      # [win]
+        # Verify accessories
+        - test -e $PREFIX/include/PCMSolver/pcmsolver.h                # [unix]
+        - test -e $PREFIX/share/cmake/PCMSolver/PCMSolverConfig.cmake  # [unix]
+        - if not exist %PREFIX%\\Library\\include\\PCMSolver\\pcmsolver.h exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\share\\cmake\\PCMSolver\\PCMSolverConfig.cmake exit 1  # [win]
+        # Inspect linkage
+        - ldd -v $PREFIX/lib/libpcm$SHLIB_EXT                          # [linux and build_platform == target_platform]
+        - otool -L $PREFIX/lib/libpcm$SHLIB_EXT                        # [osx]
+        - objdump.exe -p %PREFIX%\\Library\\bin\\libpcm.dll | findstr /i "dll"  # [win]
+        # Actually test
+        - python $PREFIX/bin/go_pcm.py --inp molecule.inp --exe $PREFIX/bin  # [unix]
+        - python %PREFIX%\\Library\\bin\\go_pcm.py --inp molecule.inp --exe %PREFIX%\\Library\\bin  # [win]
+        - cat molecule.out                                             # [unix]
+        - type molecule.out                                            # [win]
+
+  - name: libpcm
+    build:
+      run_exports:
+        - {{ pin_subpackage('libpcm', max_pin='x.x.x') }}
+    requirements:
+      build:
+        - {{ stdlib("c") }}
+        - {{ compiler("c") }}
+        - {{ compiler("cxx") }}
+        - {{ compiler("fortran") }}
+      host:
+        - libboost-headers
+        - eigen
+        - zlib
+      run:
+    files:
+      - bin/run_pcm                        # [unix]
+      - lib/libpcm*                        # [unix]
+      - share/cmake/PCMSolver              # [unix]
+      - include/PCMSolver                  # [unix]
+      - Library/include/PCMSolver          # [win]
+      - Library/bin/run_pcm*               # [win]
+      - Library/bin/libpcm*                # [win]
+      - Library/lib/libpcm*                # [win]
+      - Library/share/cmake/PCMSolver      # [win]
+    test:
+      requires:
+        - m2w64-binutils                                               # [win]   # provides objdump.exe
+      commands:
+        # Verify library
+        - test -L $PREFIX/lib/libpcm$SHLIB_EXT                         # [unix]
+        - test ! -f $PREFIX/lib/libpcm.a                               # [unix]
+        - if not exist %PREFIX%\\Library\\lib\\libpcm.dll.a exit 1     # [win]   # gnu import lib
+        - if not exist %PREFIX%\\Library\\lib\\libpcm.lib exit 1       # [win]   # ms import lib
+        - if not exist %PREFIX%\\Library\\bin\\libpcm.dll exit 1       # [win]   # gnu/ms dyn lib
+        - if exist %PREFIX%\\Library\\lib\\libpcm.a exit 1             # [win]   # gnu static lib removed
+        # Verify executable
+        - test -f $PREFIX/bin/run_pcm                                  # [unix]
+        - if not exist %PREFIX%\\Library\\bin\\run_pcm.exe exit 1      # [win]
+        # Verify accessories
+        - test -e $PREFIX/include/PCMSolver/pcmsolver.h                # [unix]
+        - test -e $PREFIX/share/cmake/PCMSolver/PCMSolverConfig.cmake  # [unix]
+        - if not exist %PREFIX%\\Library\\include\\PCMSolver\\pcmsolver.h exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\share\\cmake\\PCMSolver\\PCMSolverConfig.cmake exit 1  # [win]
+        # Inspect linkage
+        - ldd -v $PREFIX/lib/libpcm$SHLIB_EXT                          # [linux and build_platform == target_platform]
+        - otool -L $PREFIX/lib/libpcm$SHLIB_EXT                        # [osx]
+        - objdump.exe -p %PREFIX%\\Library\\bin\\libpcm.dll | findstr /i "dll"  # [win]
+
+about:
+  home: https://github.com/PCMSolver/pcmsolver
+  dev_url: https://github.com/PCMSolver/pcmsolver
+  doc_url: https://pcmsolver.readthedocs.io/en/stable/
+  doc_source_url: https://github.com/PCMSolver/pcmsolver/tree/master/doc
+  license: LGPL-3.0-only AND MIT AND MIT-0 AND Apache-2.0
+  license_url: https://opensource.org/license/lgpl-3-0/
+  license_file:
+    - LICENSE
+    - THIRD-PARTY-LICENSES
+  license_family: LGPL
+  summary: "R. Di Remigio & L. Frediani's Polarizable Continuum Model (PCM)"
+
+extra:
+  recipe-maintainers:
+    - loriab
+    - robertodr

--- a/tests/test_yaml/flang_pcmsolver-split_before_meta.yaml
+++ b/tests/test_yaml/flang_pcmsolver-split_before_meta.yaml
@@ -1,0 +1,173 @@
+{% set name = "PCMSolver" %}
+{% set version = "1.9.0" %}
+{% set build = 14 %}
+
+package:
+  name: {{ name|lower }}-split
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: b6d893dc7dcd4138b9e9df59a13c59695e50e80dc5c2cacee0674670693951a1
+  # url: https://github.com/{{ name }}/{{ name|lower }}/archive/v{{ version }}.tar.gz
+  # patches:
+  #   # 0004 and 0005 introduced at build=10
+  #   - [...]
+  # sha256: {{ sha256 }}
+
+build:
+  number: {{ build }}
+  # Only build for one python version because python module is repackaged as noarch
+  skip: true  # [py != 312]
+
+requirements:
+  build:
+    - python                              # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}  # [build_platform != target_platform]
+    - {{ compiler('c') }}                 # [unix]
+    - {{ stdlib("c") }}                   # [unix]
+    - {{ compiler('cxx') }}               # [unix]
+    - {{ compiler('fortran') }}           # [unix]
+    - {{ compiler('m2w64_c') }}           # [win]
+    - {{ stdlib("c") }}                   # [win]
+    - {{ compiler('m2w64_fortran') }}     # [win]
+    - cmake
+    - make                                # [unix]
+    - ninja                               # [win]
+  host:
+    - libboost-devel
+    - eigen
+    - python
+    - zlib
+  run:
+    - m2w64-gcc-libgfortran               # [win]
+    - python
+
+outputs:
+  - name: pcmsolver
+    build:
+      noarch: python
+      # Only one pcmsolver variant by having a shared build string for all platforms
+      string: py_{{ build }}
+      run_exports:
+        - {{ pin_subpackage('pcmsolver', max_pin='x.x.x') }}
+        - {{ pin_subpackage('libpcm', max_pin='x.x.x') }}
+    requirements:
+      host:
+        - python
+      run:
+        - python
+        - {{ pin_subpackage('libpcm', max_pin='x.x.x') }}
+    files:
+      - bin/*.py                                                       # [unix]
+      - lib/python3.12/site-packages/pcmsolver                         # [unix]
+      - Library/bin/*.py                                               # [win]
+      - Lib/site-packages/pcmsolver                                    # [win]
+    test:
+      imports:
+        - pcmsolver
+      files:
+        - molecule.inp
+      requires:
+        - m2w64-binutils                                               # [win]   # provides objdump.exe
+      commands:
+        # Verify library
+        - test -L $PREFIX/lib/libpcm$SHLIB_EXT                         # [unix]
+        - test ! -f $PREFIX/lib/libpcm.a                               # [unix]
+        - test -f $SP_DIR/pcmsolver/pcmparser.py                       # [unix]
+        - if not exist %PREFIX%\\Library\\lib\\libpcm.dll.a exit 1     # [win]   # gnu import lib
+        - if not exist %PREFIX%\\Library\\lib\\libpcm.lib exit 1       # [win]   # ms import lib
+        - if not exist %PREFIX%\\Library\\bin\\libpcm.dll exit 1       # [win]   # gnu/ms dyn lib
+        - if exist %PREFIX%\\Library\\lib\\libpcm.a exit 1             # [win]   # gnu static lib removed
+        - if not exist %SP_DIR%\\pcmsolver\\pcmparser.py exit 1        # [win]
+        # Verify executable
+        - test -f $PREFIX/bin/go_pcm.py                                # [unix]
+        - test -f $PREFIX/bin/run_pcm                                  # [unix]
+        - if not exist %PREFIX%\\Library\\bin\\go_pcm.py exit 1        # [win]
+        - if not exist %PREFIX%\\Library\\bin\\run_pcm.exe exit 1      # [win]
+        # Verify accessories
+        - test -e $PREFIX/include/PCMSolver/pcmsolver.h                # [unix]
+        - test -e $PREFIX/share/cmake/PCMSolver/PCMSolverConfig.cmake  # [unix]
+        - if not exist %PREFIX%\\Library\\include\\PCMSolver\\pcmsolver.h exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\share\\cmake\\PCMSolver\\PCMSolverConfig.cmake exit 1  # [win]
+        # Inspect linkage
+        - ldd -v $PREFIX/lib/libpcm$SHLIB_EXT                          # [linux and build_platform == target_platform]
+        - otool -L $PREFIX/lib/libpcm$SHLIB_EXT                        # [osx]
+        - objdump.exe -p %PREFIX%\\Library\\bin\\libpcm.dll | findstr /i "dll"  # [win]
+        # Actually test
+        - python $PREFIX/bin/go_pcm.py --inp molecule.inp --exe $PREFIX/bin  # [unix]
+        - python %PREFIX%\\Library\\bin\\go_pcm.py --inp molecule.inp --exe %PREFIX%\\Library\\bin  # [win]
+        - cat molecule.out                                             # [unix]
+        - type molecule.out                                            # [win]
+
+  - name: libpcm
+    build:
+      run_exports:
+        - {{ pin_subpackage('libpcm', max_pin='x.x.x') }}
+    requirements:
+      build:
+        - {{ compiler('c') }}              # [unix]
+        - {{ stdlib("c") }}                # [unix]
+        - {{ compiler('cxx') }}            # [unix]
+        - {{ compiler('fortran') }}        # [unix]
+        - {{ compiler('m2w64_c') }}        # [win]
+        - {{ stdlib("c") }}                # [win]
+        - {{ compiler('m2w64_fortran') }}  # [win]
+      host:
+        - libboost-headers
+        - eigen
+        - zlib
+      run:
+        - m2w64-gcc-libgfortran            # [win]
+    files:
+      - bin/run_pcm                        # [unix]
+      - lib/libpcm*                        # [unix]
+      - share/cmake/PCMSolver              # [unix]
+      - include/PCMSolver                  # [unix]
+      - Library/include/PCMSolver          # [win]
+      - Library/bin/run_pcm*               # [win]
+      - Library/bin/libpcm*                # [win]
+      - Library/lib/libpcm*                # [win]
+      - Library/share/cmake/PCMSolver      # [win]
+    test:
+      requires:
+        - m2w64-binutils                                               # [win]   # provides objdump.exe
+      commands:
+        # Verify library
+        - test -L $PREFIX/lib/libpcm$SHLIB_EXT                         # [unix]
+        - test ! -f $PREFIX/lib/libpcm.a                               # [unix]
+        - if not exist %PREFIX%\\Library\\lib\\libpcm.dll.a exit 1     # [win]   # gnu import lib
+        - if not exist %PREFIX%\\Library\\lib\\libpcm.lib exit 1       # [win]   # ms import lib
+        - if not exist %PREFIX%\\Library\\bin\\libpcm.dll exit 1       # [win]   # gnu/ms dyn lib
+        - if exist %PREFIX%\\Library\\lib\\libpcm.a exit 1             # [win]   # gnu static lib removed
+        # Verify executable
+        - test -f $PREFIX/bin/run_pcm                                  # [unix]
+        - if not exist %PREFIX%\\Library\\bin\\run_pcm.exe exit 1      # [win]
+        # Verify accessories
+        - test -e $PREFIX/include/PCMSolver/pcmsolver.h                # [unix]
+        - test -e $PREFIX/share/cmake/PCMSolver/PCMSolverConfig.cmake  # [unix]
+        - if not exist %PREFIX%\\Library\\include\\PCMSolver\\pcmsolver.h exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\share\\cmake\\PCMSolver\\PCMSolverConfig.cmake exit 1  # [win]
+        # Inspect linkage
+        - ldd -v $PREFIX/lib/libpcm$SHLIB_EXT                          # [linux and build_platform == target_platform]
+        - otool -L $PREFIX/lib/libpcm$SHLIB_EXT                        # [osx]
+        - objdump.exe -p %PREFIX%\\Library\\bin\\libpcm.dll | findstr /i "dll"  # [win]
+
+about:
+  home: https://github.com/PCMSolver/pcmsolver
+  dev_url: https://github.com/PCMSolver/pcmsolver
+  doc_url: https://pcmsolver.readthedocs.io/en/stable/
+  doc_source_url: https://github.com/PCMSolver/pcmsolver/tree/master/doc
+  license: LGPL-3.0-only AND MIT AND MIT-0 AND Apache-2.0
+  license_url: https://opensource.org/license/lgpl-3-0/
+  license_file:
+    - LICENSE
+    - THIRD-PARTY-LICENSES
+  license_family: LGPL
+  summary: "R. Di Remigio & L. Frediani's Polarizable Continuum Model (PCM)"
+
+extra:
+  recipe-maintainers:
+    - loriab
+    - robertodr

--- a/tests/test_yaml/flang_plplot_after_meta.yaml
+++ b/tests/test_yaml/flang_plplot_after_meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "plplot" %}
+{% set version = "1.10.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 3f9e587a96844a9b4ee7f998cfe4dc3964dc95c4ca94d7de6a77bffb99f873da
+  # url: http://downloads.sourceforge.net/sourceforge/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  # sha256: b92de4d8f626a9b20c84fc94f4f6a9976edd76e33fb1eae44f6804bdcc628c7b
+  # patches:
+  #   - plgridd.c-rename.patch  # [win]
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x') }}
+
+requirements:
+  build:
+    - {{ stdlib("c") }}
+    - {{ compiler("c") }}
+    - {{ compiler("cxx") }}
+    - {{ compiler("fortran") }}
+    - clang  # [win]
+    - cmake
+    - ninja
+    - pkg-config
+  host:
+    - tk
+    - cairo <1.18  # [win]
+    - cairo        # [not win]
+    - pango
+    - zlib
+    - glib
+  run:
+    - tk
+
+test:
+  requires:
+    - pkg-config
+  commands:
+    - pkg-config --exact-version {{ version }} {{ name }}
+    - pkg-config --exact-version {{ version }} {{ name }}-tcl
+    - pkg-config --exact-version {{ version }} {{ name }}-fortran
+    - pkg-config --exact-version {{ version }} {{ name }}-c++
+
+about:
+  home: http://plplot.sourceforge.net
+  license: LGPL-2.0-or-later
+  license_file: Copyright
+  summary: A cross-platform software package for creating scientific plots
+
+extra:
+  recipe-maintainers:
+    - awvwgk

--- a/tests/test_yaml/flang_plplot_before_meta.yaml
+++ b/tests/test_yaml/flang_plplot_before_meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "plplot" %}
+{% set version = "1.9.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: b6d893dc7dcd4138b9e9df59a13c59695e50e80dc5c2cacee0674670693951a1
+  # url: http://downloads.sourceforge.net/sourceforge/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  # sha256: b92de4d8f626a9b20c84fc94f4f6a9976edd76e33fb1eae44f6804bdcc628c7b
+  # patches:
+  #   - plgridd.c-rename.patch  # [win]
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x') }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ stdlib("c") }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('fortran') }}  # [unix]
+    - {{ compiler('m2w64_fortran') }}  # [win]
+    - clang  # [win]
+    - cmake
+    - ninja
+    - pkg-config
+  host:
+    - tk
+    - cairo <1.18  # [win]
+    - cairo        # [not win]
+    - pango
+    - zlib
+    - glib
+  run:
+    - tk
+
+test:
+  requires:
+    - pkg-config
+  commands:
+    - pkg-config --exact-version {{ version }} {{ name }}
+    - pkg-config --exact-version {{ version }} {{ name }}-tcl
+    - pkg-config --exact-version {{ version }} {{ name }}-fortran
+    - pkg-config --exact-version {{ version }} {{ name }}-c++
+
+about:
+  home: http://plplot.sourceforge.net
+  license: LGPL-2.0-or-later
+  license_file: Copyright
+  summary: A cross-platform software package for creating scientific plots
+
+extra:
+  recipe-maintainers:
+    - awvwgk

--- a/tests/test_yaml/flang_prima_after_meta.yaml
+++ b/tests/test_yaml/flang_prima_after_meta.yaml
@@ -1,0 +1,47 @@
+{% set version = "1.10.0" %}
+
+package:
+  name: prima
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 3f9e587a96844a9b4ee7f998cfe4dc3964dc95c4ca94d7de6a77bffb99f873da
+  # url: https://github.com/libprima/prima/archive/refs/tags/v{{ version }}.tar.gz
+  # sha256: b2cc3547e5601de494267d501f7a8ad2b42482d189c647e312c41917d81ed8e7
+  # patches:
+  #   - stop.patch  # [win]
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('prima', max_pin='x.x') }}
+
+requirements:
+  build:
+    - cmake
+    - ninja
+    - {{ stdlib("c") }}
+    - {{ compiler("c") }}
+    - {{ compiler("fortran") }}
+  run:
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/prima/prima.h  # [unix]
+    - test -f ${PREFIX}/lib/libprimac${SHLIB_EXT}  # [unix]
+    - if not exist %PREFIX%\\Library\\include\\prima\\prima.h exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\libprimac.dll.a exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\bin\\libprimac.dll exit 1  # [win]
+
+about:
+  home: https://github.com/libprima/prima
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENCE.txt
+  summary: package for solving general nonlinear optimization problems without using derivatives
+
+extra:
+  recipe-maintainers:
+    - jschueller

--- a/tests/test_yaml/flang_prima_before_meta.yaml
+++ b/tests/test_yaml/flang_prima_before_meta.yaml
@@ -1,0 +1,52 @@
+{% set version = "1.9.0" %}
+
+package:
+  name: prima
+  version: {{ version }}
+
+source:
+  # fake source url to get version migrator to pass
+  url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: b6d893dc7dcd4138b9e9df59a13c59695e50e80dc5c2cacee0674670693951a1
+  # url: https://github.com/libprima/prima/archive/refs/tags/v{{ version }}.tar.gz
+  # sha256: b2cc3547e5601de494267d501f7a8ad2b42482d189c647e312c41917d81ed8e7
+  # patches:
+  #   - stop.patch  # [win]
+
+build:
+  number: 1
+  run_exports:
+    - {{ pin_subpackage('prima', max_pin='x.x') }}
+
+requirements:
+  build:
+    - cmake
+    - ninja
+    - {{ compiler("c") }}               # [unix]
+    - {{ stdlib("c") }}                 # [unix]
+    - {{ compiler("fortran") }}         # [unix]
+    # flang does not support F2018, use gfortran
+    - {{ compiler("m2w64_c") }}         # [win]
+    - {{ stdlib("m2w64_c") }}           # [win]
+    - {{ compiler("m2w64_fortran") }}   # [win]
+  run:
+    - m2w64-gcc-libgfortran  # [win]
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/prima/prima.h  # [unix]
+    - test -f ${PREFIX}/lib/libprimac${SHLIB_EXT}  # [unix]
+    - if not exist %PREFIX%\\Library\\include\\prima\\prima.h exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\libprimac.dll.a exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\bin\\libprimac.dll exit 1  # [win]
+
+about:
+  home: https://github.com/libprima/prima
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENCE.txt
+  summary: package for solving general nonlinear optimization problems without using derivatives
+
+extra:
+  recipe-maintainers:
+    - jschueller


### PR DESCRIPTION
This one was harder than usual because of some fun Python regex bugs and the "take all consecutive compilers in a block" logic. 🙃 

I'll note that the target here (as for most piggyback migrators) is not 100% perfection, but to reliably switch over to flang. It's better that a bot PR fails spuriously and we fix it manually, rather than that it is rerendered incorrectly (i.e. not activating flang) and merged prematurely simply because CI is green.

Here the diffs for the before/after in the tests for ease of review (minus the spurious version bumps from abusing the version migrator as a crutch), generated with
```
git diff HEAD:tests/test_yaml/flang_<pkg>_before_meta.yaml..HEAD:tests/test_yaml/flang_<pkg>_after_meta.yaml
```

<details>
<summary>lapack</summary>

```diff
diff --git a/tests/test_yaml/flang_lapack_before_meta.yaml b/tests/test_yaml/flang_lapack_after_meta.yaml
index 6c3f45cf..1189ba3d 100644
--- a/tests/test_yaml/flang_lapack_before_meta.yaml
+++ b/tests/test_yaml/flang_lapack_after_meta.yaml
@@ -33,14 +33,9 @@ build:
 
 requirements:
   build:
-    - {{ compiler("c") }}               # [unix]
-    - {{ stdlib("c") }}                 # [unix]
-    - {{ compiler("fortran") }}         # [unix]
-    - {{ compiler("m2w64_c") }}         # [win]
-    - {{ stdlib("m2w64_c") }}           # [win]
-    - {{ compiler("m2w64_fortran") }}   # [win]
-    # This is just for creating the import libaries
-    - vs2019_win-64                     # [win64]
+    - {{ stdlib("c") }}
+    - {{ compiler("c") }}
+    - {{ compiler("fortran") }}
     - ninja                             # [win]
     - make                              # [unix]
     - cmake
@@ -58,12 +53,9 @@ outputs:
         - {{ pin_subpackage("libblas", max_pin="x") }}
     requirements:
       build:
-        - {{ compiler("c") }}               # [unix]
-        - {{ stdlib("c") }}                 # [unix]
-        - {{ compiler("fortran") }}         # [unix]
-        - {{ compiler("m2w64_c") }}         # [win]
-        - {{ stdlib("m2w64_c") }}           # [win]
-        - {{ compiler("m2w64_fortran") }}   # [win]
+        - {{ stdlib("c") }}
+        - {{ compiler("c") }}
+        - {{ compiler("fortran") }}
       run_constrained:
         - blas * netlib
     files:
@@ -91,12 +83,9 @@ outputs:
         - {{ pin_subpackage("libtmglib", max_pin="x") }}
     requirements:
       build:
-        - {{ compiler("c") }}               # [unix]
-        - {{ stdlib("c") }}                 # [unix]
-        - {{ compiler("fortran") }}         # [unix]
-        - {{ compiler("m2w64_c") }}         # [win]
-        - {{ stdlib("m2w64_c") }}           # [win]
-        - {{ compiler("m2w64_fortran") }}   # [win]
+        - {{ stdlib("c") }}
+        - {{ compiler("c") }}
+        - {{ compiler("fortran") }}
       run_constrained:
         - blas * netlib
     files:
@@ -122,12 +111,9 @@ outputs:
         - {{ pin_subpackage("libcblas", max_pin="x") }}
     requirements:
       build:
-        - {{ compiler("c") }}               # [unix]
-        - {{ stdlib("c") }}                 # [unix]
-        - {{ compiler("fortran") }}         # [unix]
-        - {{ compiler("m2w64_c") }}         # [win]
-        - {{ stdlib("m2w64_c") }}           # [win]
-        - {{ compiler("m2w64_fortran") }}   # [win]
+        - {{ stdlib("c") }}
+        - {{ compiler("c") }}
+        - {{ compiler("fortran") }}
       run:
         - libblas {{ version }}
     files:
@@ -157,12 +143,9 @@ outputs:
         - {{ pin_subpackage("liblapack", max_pin="x") }}
     requirements:
       build:
-        - {{ compiler("c") }}               # [unix]
-        - {{ stdlib("c") }}                 # [unix]
-        - {{ compiler("fortran") }}         # [unix]
-        - {{ compiler("m2w64_c") }}         # [win]
-        - {{ stdlib("m2w64_c") }}           # [win]
-        - {{ compiler("m2w64_fortran") }}   # [win]
+        - {{ stdlib("c") }}
+        - {{ compiler("c") }}
+        - {{ compiler("fortran") }}
       run:
         - libblas {{ version }}
     files:
@@ -191,12 +174,9 @@ outputs:
         - {{ pin_subpackage("liblapacke", max_pin="x") }}
     requirements:
       build:
-        - {{ compiler("c") }}               # [unix]
-        - {{ stdlib("c") }}                 # [unix]
-        - {{ compiler("fortran") }}         # [unix]
-        - {{ compiler("m2w64_c") }}         # [win]
-        - {{ stdlib("m2w64_c") }}           # [win]
-        - {{ compiler("m2w64_fortran") }}   # [win]
+        - {{ stdlib("c") }}
+        - {{ compiler("c") }}
+        - {{ compiler("fortran") }}
       run:
         - libblas    {{ version }}
         - libcblas   {{ version }}
```

</details>

<details>
<summary>prima</summary>

```diff
diff --git a/tests/test_yaml/flang_prima_before_meta.yaml b/tests/test_yaml/flang_prima_after_meta.yaml
index 26c0b13e..33c42fe9 100644
--- a/tests/test_yaml/flang_prima_before_meta.yaml
+++ b/tests/test_yaml/flang_prima_after_meta.yaml
@@ -22,15 +22,10 @@ requirements:
   build:
     - cmake
     - ninja
-    - {{ compiler("c") }}               # [unix]
-    - {{ stdlib("c") }}                 # [unix]
-    - {{ compiler("fortran") }}         # [unix]
-    # flang does not support F2018, use gfortran
-    - {{ compiler("m2w64_c") }}         # [win]
-    - {{ stdlib("m2w64_c") }}           # [win]
-    - {{ compiler("m2w64_fortran") }}   # [win]
+    - {{ stdlib("c") }}
+    - {{ compiler("c") }}
+    - {{ compiler("fortran") }}
   run:
-    - m2w64-gcc-libgfortran  # [win]
 
 test:
   commands:
```

</details>

</details>

<details>
<summary>mfront</summary>

```diff
diff --git a/tests/test_yaml/flang_mfront_before_meta.yaml b/tests/test_yaml/flang_mfront_after_meta.yaml
index 398792f4..c0f4d1b6 100644
--- a/tests/test_yaml/flang_mfront_before_meta.yaml
+++ b/tests/test_yaml/flang_mfront_after_meta.yaml
@@ -25,14 +25,13 @@ build:
 
 requirements:
   build:
-    - {{ compiler('fortran') }}  # [not win]
+    - {{ compiler("fortran") }}
     - {{ compiler('c') }}
     - {{ stdlib("c") }}
     - {{ compiler('cxx') }}
     - cmake
     - make  # [not win]
     - ninja                       # [win]
-    - flang                       # [win]
     - clang                       # [win]
     - lld                         # [win]
     - libgomp  # [linux]
```

</details>

</details>

<details>
<summary>plplot</summary>

```diff
diff --git a/tests/test_yaml/flang_plplot_before_meta.yaml b/tests/test_yaml/flang_plplot_after_meta.yaml
index e3bcd4a0..2201afb1 100644
--- a/tests/test_yaml/flang_plplot_before_meta.yaml
+++ b/tests/test_yaml/flang_plplot_after_meta.yaml
@@ -21,11 +21,10 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
     - {{ stdlib("c") }}
-    - {{ compiler('cxx') }}
-    - {{ compiler('fortran') }}  # [unix]
-    - {{ compiler('m2w64_fortran') }}  # [win]
+    - {{ compiler("c") }}
+    - {{ compiler("cxx") }}
+    - {{ compiler("fortran") }}
     - clang  # [win]
     - cmake
     - ninja
```

</details>

</details>

<details>
<summary>pcmsolver-split</summary>

```diff
diff --git a/tests/test_yaml/flang_pcmsolver-split_before_meta.yaml b/tests/test_yaml/flang_pcmsolver-split_after_meta.yaml
index 7e6898bb..02503f40 100644
--- a/tests/test_yaml/flang_pcmsolver-split_before_meta.yaml
+++ b/tests/test_yaml/flang_pcmsolver-split_after_meta.yaml
@@ -25,13 +25,10 @@ requirements:
   build:
     - python                              # [build_platform != target_platform]
     - cross-python_{{ target_platform }}  # [build_platform != target_platform]
-    - {{ compiler('c') }}                 # [unix]
-    - {{ stdlib("c") }}                   # [unix]
-    - {{ compiler('cxx') }}               # [unix]
-    - {{ compiler('fortran') }}           # [unix]
-    - {{ compiler('m2w64_c') }}           # [win]
-    - {{ stdlib("c") }}                   # [win]
-    - {{ compiler('m2w64_fortran') }}     # [win]
+    - {{ stdlib("c") }}
+    - {{ compiler("c") }}
+    - {{ compiler("cxx") }}
+    - {{ compiler("fortran") }}
     - cmake
     - make                                # [unix]
     - ninja                               # [win]
@@ -41,7 +38,6 @@ requirements:
     - python
     - zlib
   run:
-    - m2w64-gcc-libgfortran               # [win]
     - python
 
 outputs:
@@ -107,19 +103,15 @@ outputs:
         - {{ pin_subpackage('libpcm', max_pin='x.x.x') }}
     requirements:
       build:
-        - {{ compiler('c') }}              # [unix]
-        - {{ stdlib("c") }}                # [unix]
-        - {{ compiler('cxx') }}            # [unix]
-        - {{ compiler('fortran') }}        # [unix]
-        - {{ compiler('m2w64_c') }}        # [win]
-        - {{ stdlib("c") }}                # [win]
-        - {{ compiler('m2w64_fortran') }}  # [win]
+        - {{ stdlib("c") }}
+        - {{ compiler("c") }}
+        - {{ compiler("cxx") }}
+        - {{ compiler("fortran") }}
       host:
         - libboost-headers
         - eigen
         - zlib
       run:
-        - m2w64-gcc-libgfortran            # [win]
     files:
       - bin/run_pcm                        # [unix]
       - lib/libpcm*                        # [unix]
```

</details>