### PR TITLE
add piggyback migrator that changes pypi.io to pypi.org

### DIFF
--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -60,6 +60,7 @@ from conda_forge_tick.migrators import (
     Numpy2Migrator,
     PipMigrator,
     PipWheelMigrator,
+    PyPIOrgMigrator,
     QtQtMainMigrator,
     Replacement,
     RUCRTCleanup,
@@ -290,6 +291,7 @@ def add_rebuild_migration_yaml(
         NoCondaInspectMigrator(),
         CrossCompilationForARMAndPower(),
         MPIPinRunAsBuildCleanup(),
+        PyPIOrgMigrator(),
     ]
     if migration_name == "qt515":
         piggy_back_migrations.append(QtQtMainMigrator())

--- a/conda_forge_tick/migrators/__init__.py
+++ b/conda_forge_tick/migrators/__init__.py
@@ -28,6 +28,7 @@ from .mpi_pin_run_as_build import MPIPinRunAsBuildCleanup
 from .numpy2 import Numpy2Migrator
 from .pip_check import PipCheckMigrator
 from .pip_wheel_dep import PipWheelMigrator
+from .pypi_org import PyPIOrgMigrator
 from .qt_to_qt_main import QtQtMainMigrator
 from .r_ucrt import RUCRTCleanup
 from .replacement import Replacement

--- a/conda_forge_tick/migrators/pypi_org.py
+++ b/conda_forge_tick/migrators/pypi_org.py
@@ -1,0 +1,32 @@
+import os
+import re
+
+from conda_forge_tick.migrators.core import MiniMigrator, _skip_due_to_schema
+from conda_forge_tick.migrators.libboost import _replacer
+
+# detect "url: https://pypi.io/packages/..."
+raw_pat_pypi_io = r"^(?P<before>[\s\-]*url: )(?:https?://pypi\.io/)(?P<after>.*)"
+pat_pypi_io = re.compile(raw_pat_pypi_io)
+
+
+class PyPIOrgMigrator(MiniMigrator):
+    def filter(self, attrs, not_bad_str_start=""):
+        lines = attrs["raw_meta_yaml"].splitlines()
+        has_pypi_io = any(pat_pypi_io.search(line) for line in lines)
+        # filter() returns True if we _don't_ want to migrate
+        return (not has_pypi_io) or _skip_due_to_schema(
+            attrs, self.allowed_schema_versions
+        )
+
+    def migrate(self, recipe_dir, attrs, **kwargs):
+        fname = os.path.join(recipe_dir, "meta.yaml")
+        if os.path.exists(fname):
+            with open(fname) as fp:
+                lines = fp.readlines()
+
+            lines = _replacer(
+                lines, raw_pat_pypi_io, r"\g<before>https://pypi.org/\g<after>"
+            )
+
+            with open(fname, "w") as fp:
+                fp.write("".join(lines))

--- a/tests/test_pypi_org.py
+++ b/tests/test_pypi_org.py
@@ -1,0 +1,49 @@
+import os
+
+import pytest
+from test_migrators import run_test_migration
+
+from conda_forge_tick.migrators import PyPIOrgMigrator, Version
+
+TEST_YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")
+
+
+PYPI_ORG = PyPIOrgMigrator()
+VERSION_WITH_PYPI_ORG = Version(
+    set(),
+    piggy_back_migrations=[PYPI_ORG],
+)
+
+
+@pytest.mark.parametrize(
+    "feedstock,new_ver",
+    [
+        ("seaborn", "0.13.2"),
+    ],
+)
+def test_pypi_org(feedstock, new_ver, tmpdir):
+    before = f"pypi_org_{feedstock}_before_meta.yaml"
+    with open(os.path.join(TEST_YAML_PATH, before)) as fp:
+        in_yaml = fp.read()
+
+    after = f"pypi_org_{feedstock}_after_meta.yaml"
+    with open(os.path.join(TEST_YAML_PATH, after)) as fp:
+        out_yaml = fp.read()
+
+    recipe_dir = os.path.join(tmpdir, f"{feedstock}-feedstock")
+    os.makedirs(recipe_dir, exist_ok=True)
+
+    run_test_migration(
+        m=VERSION_WITH_PYPI_ORG,
+        inp=in_yaml,
+        output=out_yaml,
+        kwargs={"new_version": new_ver},
+        prb="Dependencies have been updated if changed",
+        mr_out={
+            "migrator_name": "Version",
+            "migrator_version": VERSION_WITH_PYPI_ORG.migrator_version,
+            "version": new_ver,
+        },
+        tmpdir=recipe_dir,
+        should_filter=False,
+    )

--- a/tests/test_yaml/pypi_org_seaborn_after_meta.yaml
+++ b/tests/test_yaml/pypi_org_seaborn_after_meta.yaml
@@ -1,0 +1,74 @@
+{% set version = "0.13.2" %}
+{% set build = 0 %}
+
+package:
+  name: seaborn-split
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/s/seaborn/seaborn-{{ version }}.tar.gz
+  sha256: 93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7
+
+build:
+  number: {{ build }}
+  noarch: python
+
+test:
+  imports:
+    - seaborn
+  requires:
+    - pip
+  commands:
+    - pip check
+
+outputs:
+  - name: seaborn-base
+    build:
+      noarch: python
+    script: build_base.bat  # [win]
+    script: build_base.sh  # [not win]
+    requirements:
+      host:
+        - python >=3.8
+        - pip
+        - flit-core >=3.2,<4
+      run:
+        - python >=3.8
+        - numpy >=1.20,!=1.24.0
+        - matplotlib-base >=3.4,!=3.6.1
+        - scipy >=1.7
+        - pandas >=1.2
+      run_constrained:
+        # should be {{ pin_subpackage("seaborn", exact=True) }}
+        # but this seems to be broken right now: https://github.com/conda/conda-build/issues/4415
+        - seaborn ={{ version }}=*_{{ build }}
+      test:
+        imports:
+          - seaborn
+
+  - name: seaborn
+    build:
+      noarch: python
+    requirements:
+      run:
+        - statsmodels >=0.12
+        - {{ pin_subpackage('seaborn-base', exact=True) }}
+
+about:
+  home: https://seaborn.pydata.org
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.md
+  summary: Statistical data visualization
+  description: |
+    Seaborn is a Python visualization library based on matplotlib. It
+    provides a high-level interface for drawing attractive statistical graphics.
+  doc_url: https://seaborn.pydata.org
+  dev_url: https://github.com/mwaskom/seaborn
+
+extra:
+  feedstock-name: seaborn
+  recipe-maintainers:
+    - msarahan
+    - r-jain1
+    - croth1

--- a/tests/test_yaml/pypi_org_seaborn_before_meta.yaml
+++ b/tests/test_yaml/pypi_org_seaborn_before_meta.yaml
@@ -1,0 +1,74 @@
+{% set version = "0.13.1" %}
+{% set build = 2 %}
+
+package:
+  name: seaborn-split
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/s/seaborn/seaborn-{{ version }}.tar.gz
+  sha256: bfad65e9c5989e5e1897e61bdbd2f22e62455940ca76fd49eca3ed69345b9179
+
+build:
+  number: {{ build }}
+  noarch: python
+
+test:
+  imports:
+    - seaborn
+  requires:
+    - pip
+  commands:
+    - pip check
+
+outputs:
+  - name: seaborn-base
+    build:
+      noarch: python
+    script: build_base.bat  # [win]
+    script: build_base.sh  # [not win]
+    requirements:
+      host:
+        - python >=3.8
+        - pip
+        - flit-core >=3.2,<4
+      run:
+        - python >=3.8
+        - numpy >=1.20,!=1.24.0
+        - matplotlib-base >=3.4,!=3.6.1
+        - scipy >=1.7
+        - pandas >=1.2
+      run_constrained:
+        # should be {{ pin_subpackage("seaborn", exact=True) }}
+        # but this seems to be broken right now: https://github.com/conda/conda-build/issues/4415
+        - seaborn ={{ version }}=*_{{ build }}
+      test:
+        imports:
+          - seaborn
+
+  - name: seaborn
+    build:
+      noarch: python
+    requirements:
+      run:
+        - statsmodels >=0.12
+        - {{ pin_subpackage('seaborn-base', exact=True) }}
+
+about:
+  home: https://seaborn.pydata.org
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.md
+  summary: Statistical data visualization
+  description: |
+    Seaborn is a Python visualization library based on matplotlib. It
+    provides a high-level interface for drawing attractive statistical graphics.
+  doc_url: https://seaborn.pydata.org
+  dev_url: https://github.com/mwaskom/seaborn
+
+extra:
+  feedstock-name: seaborn
+  recipe-maintainers:
+    - msarahan
+    - r-jain1
+    - croth1


### PR DESCRIPTION
Smithy now [warns](https://github.com/conda-forge/conda-smithy/pull/2104) feedstocks to switch from pypi.io to pypi.org. I remember @ocefpaf saying we should write a minimigrator, but cannot find the message across several channels now.

This PR would be a pretty simple way to write a migrator (with a test), plus enable it for all migrations. Feel free to use this as the basis if you want to write your own implementation, or you can add tests for favourite feedstocks with how the before/after should look (note: due to limitations of the testing infrastructure, we need to attach a minimigrator to _something_, and the easiest thing is a version migrator).

```diff
>git diff HEAD:tests/test_yaml/pypi_org_seaborn_before_meta.yaml..HEAD:tests/test_yaml/pypi_org_seaborn_after_meta.yaml
diff --git a/tests/test_yaml/pypi_org_seaborn_before_meta.yaml b/tests/test_yaml/pypi_org_seaborn_after_meta.yaml
index df058850..2ce55c18 100644
--- a/tests/test_yaml/pypi_org_seaborn_before_meta.yaml
+++ b/tests/test_yaml/pypi_org_seaborn_after_meta.yaml
@@ -1,13 +1,13 @@
-{% set version = "0.13.1" %}
-{% set build = 2 %}
+{% set version = "0.13.2" %}
+{% set build = 0 %}

 package:
   name: seaborn-split
   version: {{ version }}

 source:
-  url: https://pypi.io/packages/source/s/seaborn/seaborn-{{ version }}.tar.gz
-  sha256: bfad65e9c5989e5e1897e61bdbd2f22e62455940ca76fd49eca3ed69345b9179
+  url: https://pypi.org/packages/source/s/seaborn/seaborn-{{ version }}.tar.gz
+  sha256: 93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7

 build:
   number: {{ build }}
```

