### PR TITLE
fix: use conda-build to parse variant files normally when getting source

### DIFF
--- a/conda_forge_tick/provide_source_code.py
+++ b/conda_forge_tick/provide_source_code.py
@@ -1,7 +1,6 @@
 import glob
 import logging
 import os
-import pprint
 import shutil
 import sys
 import tempfile
@@ -134,10 +133,6 @@ def provide_source_code_local(recipe_dir):
             from conda_build.api import render
             from conda_build.config import get_or_merge_config
             from conda_build.source import provide
-            from conda_build.variants import (
-                get_package_variants,
-                list_of_dicts_to_dict_of_lists,
-            )
 
             # Use conda build to do all the downloading/extracting bits
             config = get_or_merge_config(None)
@@ -151,20 +146,12 @@ def provide_source_code_local(recipe_dir):
                     # try global pinnings
                     os.path.join(os.environ["CONDA_PREFIX"], "conda_build_config.yaml")
                 ]
-            variants = get_package_variants(recipe_dir, config=config)[0]
-            variants = list_of_dicts_to_dict_of_lists([variants])
-            for key in CONDA_BUILD_SPECIAL_KEYS:
-                if key in variants:
-                    del variants[key]
-            logger.debug(
-                "conda build src input variants:\n%s", pprint.pformat(variants)
-            )
 
             md = render(
                 recipe_dir,
+                config=config,
                 finalize=False,
                 bypass_env_check=True,
-                variants=variants,
             )
             if not md:
                 return None


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR fixes a bug where I was not properly using conda-build to parse variant config files when getting the source.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
