### PR TITLE
fix: try munged pypi urls with middle section left alone

### DIFF
--- a/conda_forge_tick/url_transforms.py
+++ b/conda_forge_tick/url_transforms.py
@@ -150,13 +150,7 @@ def _pypi_munger(url):
                                 + "/"
                                 + eurl.replace(_v, vrep)
                             )
-                            yield (
-                                burl
-                                + "/"
-                                + murl
-                                + "/"
-                                + eurl.replace(_v, vrep)
-                            )
+                            yield (burl + "/" + murl + "/" + eurl.replace(_v, vrep))
                 elif vhave in eurl or vhave in murl:
                     assert isinstance(vrep, tuple)
                     yield (
@@ -166,13 +160,7 @@ def _pypi_munger(url):
                         + "/"
                         + eurl.replace(vhave, vrep[0])
                     )
-                    yield (
-                        burl
-                        + "/"
-                        + murl
-                        + "/"
-                        + eurl.replace(vhave, vrep[0])
-                    )
+                    yield (burl + "/" + murl + "/" + eurl.replace(vhave, vrep[0]))
                     if len(vrep) > 1:
                         yield (
                             burl
@@ -181,13 +169,7 @@ def _pypi_munger(url):
                             + "/"
                             + eurl.replace(vhave, vrep[1])
                         )
-                        yield (
-                            burl
-                            + "/"
-                            + murl
-                            + "/"
-                            + eurl.replace(vhave, vrep[1])
-                        )
+                        yield (burl + "/" + murl + "/" + eurl.replace(vhave, vrep[1]))
 
 
 def _github_munger(url):

--- a/conda_forge_tick/url_transforms.py
+++ b/conda_forge_tick/url_transforms.py
@@ -150,6 +150,13 @@ def _pypi_munger(url):
                                 + "/"
                                 + eurl.replace(_v, vrep)
                             )
+                            yield (
+                                burl
+                                + "/"
+                                + murl
+                                + "/"
+                                + eurl.replace(_v, vrep)
+                            )
                 elif vhave in eurl or vhave in murl:
                     assert isinstance(vrep, tuple)
                     yield (
@@ -159,11 +166,25 @@ def _pypi_munger(url):
                         + "/"
                         + eurl.replace(vhave, vrep[0])
                     )
+                    yield (
+                        burl
+                        + "/"
+                        + murl
+                        + "/"
+                        + eurl.replace(vhave, vrep[0])
+                    )
                     if len(vrep) > 1:
                         yield (
                             burl
                             + "/"
                             + murl.replace(vhave, vrep[1])
+                            + "/"
+                            + eurl.replace(vhave, vrep[1])
+                        )
+                        yield (
+                            burl
+                            + "/"
+                            + murl
                             + "/"
                             + eurl.replace(vhave, vrep[1])
                         )

--- a/tests/test_url_transforms.py
+++ b/tests/test_url_transforms.py
@@ -82,6 +82,16 @@ def test_url_transform_pypi():
         "https://files.pythonhosted.org/{{ name.replace('_', '-').lower() }}/{{ name.replace('_', '-').lower() }}-barf",
         "https://pypi.io/{{ name.replace('-', '_').lower() }}/{{ name.replace('-', '_').lower() }}-barf",
         "https://pypi.io/{{ name.replace('_', '-').lower() }}/{{ name.replace('_', '-').lower() }}-barf",
+        "https://pypi.io/{{ name }}/{{ name.replace('-', '_').lower() }}-barf",
+        "https://files.pythonhosted.org/{{ name }}/{{ name.replace('_', '-').lower() }}-barf",
+        "https://pypi.io/{{ name }}/{{ name.replace('_', '-') }}-barf",
+        "https://files.pythonhosted.org/{{ name }}/{{ name|lower }}-barf",
+        "https://files.pythonhosted.org/{{ name }}/{{ name.replace('-', '_').lower() }}-barf",
+        "https://pypi.io/{{ name }}/{{ name.replace('-', '_') }}-barf",
+        "https://pypi.io/{{ name }}/{{ name.replace('_', '-').lower() }}-barf",
+        "https://files.pythonhosted.org/{{ name }}/{{ name.replace('-', '_') }}-barf",
+        "https://pypi.io/{{ name }}/{{ name|lower }}-barf",
+        "https://files.pythonhosted.org/{{ name }}/{{ name.replace('_', '-') }}-barf",
     }
 
     urls = set(


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

I am trying to catch more pypi errored versions.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
