### PR TITLE
feat: use pypi api directly to get urls

### DIFF
--- a/conda_forge_tick/update_recipe/version.py
+++ b/conda_forge_tick/update_recipe/version.py
@@ -148,12 +148,15 @@ def _try_pypi_api(url_tmpl: str, context: MutableMapping, hash_type: str):
     if "version" not in context:
         return None, None
 
-    if not any(pypi_slug in url_tmpl for pypi_slug in ["/pypi.org", "/pypi.io", "/files.pythonhosted.org"]):
+    if not any(
+        pypi_slug in url_tmpl
+        for pypi_slug in ["/pypi.org", "/pypi.io", "/files.pythonhosted.org"]
+    ):
         return None, None
 
     r = requests.get(
         f"https://pypi.org/simple/{context['name']}/",
-        headers={"Accept": "application/vnd.pypi.simple.v1+json"}
+        headers={"Accept": "application/vnd.pypi.simple.v1+json"},
     )
     r.raise_for_status()
 
@@ -171,7 +174,9 @@ def _try_pypi_api(url_tmpl: str, context: MutableMapping, hash_type: str):
                 break
 
     if finfo is None or ext is None:
-        logger.debug("src dist for version %s not found in PyPI API", context["version"])
+        logger.debug(
+            "src dist for version %s not found in PyPI API", context["version"]
+        )
         return None, None
 
     bn, _ = os.path.split(url_tmpl)
@@ -193,7 +198,9 @@ def _try_pypi_api(url_tmpl: str, context: MutableMapping, hash_type: str):
     if name_tmpl is not None:
         new_url_tmpl = os.path.join(bn, name_tmpl + "-" + "{{ version }}" + ext)
     else:
-        new_url_tmpl = os.path.join(bn, finfo["filename"].replace(context["version"], "{{ version }}"))
+        new_url_tmpl = os.path.join(
+            bn, finfo["filename"].replace(context["version"], "{{ version }}")
+        )
 
     logger.debug("new url template from PyPI API: %s", new_url_tmpl)
     url = _render_jinja2(new_url_tmpl, context)

--- a/tests/test_version_migrator.py
+++ b/tests/test_version_migrator.py
@@ -61,6 +61,7 @@ VARIANT_SOURCES_NOT_IMPLEMENTED = (
         ("quart_trio", "0.11.1"),
         ("reproc", "14.2.5"),
         ("riskfolio_lib", "6.3.1"),
+        ("algotree", "0.7.3"),
         # these contain sources that depend on conda build config variants
         pytest.param(
             "polars_mixed_selectors",

--- a/tests/test_yaml/version_21cmfast_correct.yaml
+++ b/tests/test_yaml/version_21cmfast_correct.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name|lower }}/{{ name|lower }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.lower() }}-{{ version }}.tar.gz
   sha256: aff3b5a2adb30ad9a6c2274461901686606e9fdb5e3ff7040cbdf22755d7469f
 
 

--- a/tests/test_yaml/version_algotree.yaml
+++ b/tests/test_yaml/version_algotree.yaml
@@ -1,0 +1,45 @@
+{% set name = "algotree" %}
+{% set version = "0.7.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/algotree-{{ version }}.tar.gz
+  sha256: 13bb4dc6583a58e1784adee20f4d803bd4105359f1c6f52151e496d23f07152a
+
+build:
+  entry_points:
+    - jt=bin.jt:main
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+    - setuptools
+  run:
+    - python >=3.6
+
+test:
+  imports:
+    - AlgoTree
+  commands:
+    - pip check
+    - jt --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/queelius/AlgoTree
+  doc_url: https://queelius.github.io/AlgoTree/
+  summary: A algorithmic tookit for working with trees in Python
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - thewchan

--- a/tests/test_yaml/version_algotree_correct.yaml
+++ b/tests/test_yaml/version_algotree_correct.yaml
@@ -1,0 +1,45 @@
+{% set name = "algotree" %}
+{% set version = "0.7.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/AlgoTree-{{ version }}.tar.gz
+  sha256: 349eee21a57c5f40f157be218788f944a723047b35b7945a56058219b383287d
+
+build:
+  entry_points:
+    - jt=bin.jt:main
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+    - setuptools
+  run:
+    - python >=3.6
+
+test:
+  imports:
+    - AlgoTree
+  commands:
+    - pip check
+    - jt --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/queelius/AlgoTree
+  doc_url: https://queelius.github.io/AlgoTree/
+  summary: A algorithmic tookit for working with trees in Python
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - thewchan

--- a/tests/test_yaml/version_dash_extensions_correct.yaml
+++ b/tests/test_yaml/version_dash_extensions_correct.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name.replace('-', '_').lower() }}/{{ name.replace('-', '_').lower() }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   sha256: b36fcf6fd74d87cafdbabc9568c3ae0097712ccee8f7d59be8e916b51d40b106
 
 build:

--- a/tests/test_yaml/version_pypiurl_correct.yaml
+++ b/tests/test_yaml/version_pypiurl_correct.yaml
@@ -6,7 +6,7 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name.replace('_', '-').lower() }}/{{ name.replace('_', '-').lower() }}-{{ version }}.tar.gz"
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('_', '-') }}-{{ version }}.tar.gz"
   sha256: f3fe3f89011899b82451669cf1dbe4978523b8ac0f62c9c116429876fe8b6be8
 
 build:

--- a/tests/test_yaml/version_pyrsmq_correct.yaml
+++ b/tests/test_yaml/version_pyrsmq_correct.yaml
@@ -6,7 +6,7 @@ package:
   version: "{{ version }}"
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.lower() }}-{{ version }}.tar.gz
   sha256: dd1f8467e541935489be018dbb0ba1df8b903eb855bf1725947ceee41df92fa4
 
 build:


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR uses the PyPI api directly to get urls. It should be faster than the existing guess-and-check approach to transforming urls. 

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

fixes #3146
