### PR TITLE
perf: rely only on pypi api

### DIFF
--- a/conda_forge_tick/url_transforms.py
+++ b/conda_forge_tick/url_transforms.py
@@ -215,9 +215,9 @@ def gen_transformed_urls(url):
             _jinja2_munger_factory("name"),
             _jinja2_munger_factory("version"),
             _jinja2_munger_factory("name[0]"),
-            _pypi_munger,
-            _pypi_domain_munger,
-            _pypi_name_munger,
+            # _pypi_munger,
+            # _pypi_domain_munger,
+            # _pypi_name_munger,
             _github_munger,
         ],
     ):


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR turns off PyPI url transforms since we get what we need from the PyPI api.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
