### PR TITLE
chore: pin pydantic to <2.10 for now

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -37,7 +37,7 @@ dependencies:
   - numpy
   - packaging
   - psutil
-  - pydantic
+  - pydantic <2.10
   - pydantic-extra-types
   - pygithub
   - pymongo


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR pins pydantic to <2.10 for now due to failing test.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

xref: #3177 

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
