### PR TITLE
Add a migration for astropy-base

### DIFF
--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -719,6 +719,15 @@ def initialize_migrators(
         "The package 'mpir' is deprecated and unmaintained. Use 'gmp' instead.",
     )
 
+    add_replacement_migrator(
+        migrators,
+        gx,
+        cast("PackageName", "astropy"),
+        cast("PackageName", "astropy-base"),
+        "The astropy feedstock has been split into two packages, astropy-base only "
+        "has required dependancies and astropy has all optional dependancies.",
+    )
+
     # turned off due to issue with not editing build sections when there
     # is no host
     # with fold_log_lines("making `noarch: python` migrator"):


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

We split the astropy feedstock into astropy-base and astropy, most packages should migrate to depend on astropy-base (which would maintain old behaviour) so hopefully this will do that :smile: 

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

This needs https://github.com/conda-forge/astropy-feedstock/pull/150 to be merged so that there are old versions of astropy-base around.
