### PR TITLE
fix: ensure we migrate build sections for `noarch: python`

### DIFF
--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -719,15 +719,13 @@ def initialize_migrators(
         "The package 'mpir' is deprecated and unmaintained. Use 'gmp' instead.",
     )
 
-    # turned off due to issue with not editing build sections when there
-    # is no host
-    # with fold_log_lines("making `noarch: python` migrator"):
-    #     migrators.append(
-    #         NoarchPythonMinMigrator(
-    #             graph=gx,
-    #             pr_limit=1,  # will turn up later
-    #         ),
-    #     )
+    with fold_log_lines("making `noarch: python` migrator"):
+        migrators.append(
+            NoarchPythonMinMigrator(
+                graph=gx,
+                pr_limit=1,  # will turn up later
+            ),
+        )
 
     pinning_migrators: List[Migrator] = []
     migration_factory(pinning_migrators, gx)

--- a/conda_forge_tick/migrators/noarch_python_min.py
+++ b/conda_forge_tick/migrators/noarch_python_min.py
@@ -42,10 +42,51 @@ def _has_noarch_python(lines):
     return False
 
 
+def _is_comment_or_empty(line):
+    return line.strip() == "" or line.strip().startswith("#")
+
+
 def _has_build_section(lines):
+    in_requirements = False
+    indent = None
     for line in lines:
-        if line.lstrip().startswith("build:"):
+        if (
+            indent is not None
+            and not _is_comment_or_empty(line)
+            and len(line) - len(line.lstrip()) <= indent
+        ):
+            in_requirements = False
+            indent = None
+
+        if line.lstrip().startswith("requirements:"):
+            indent = len(line) - len(line.lstrip())
+            in_requirements = True
+
+        if line.lstrip().startswith("build:") and not in_requirements:
             return True
+
+    return False
+
+
+def _has_req_section(lines, section_name):
+    in_requirements = False
+    indent = None
+    for line in lines:
+        if (
+            indent is not None
+            and not _is_comment_or_empty(line)
+            and len(line) - len(line.lstrip()) <= indent
+        ):
+            in_requirements = False
+            indent = None
+
+        if line.lstrip().startswith("requirements:"):
+            indent = len(line) - len(line.lstrip())
+            in_requirements = True
+
+        if line.lstrip().startswith(section_name + ":") and in_requirements:
+            return True
+
     return False
 
 
@@ -56,6 +97,8 @@ def _process_req_list(section, req_list_name, new_python_req, force_apply=False)
     in_section = False
     adjusted_python = False
     python_min_override = None
+    req_or_test_indent = None
+    in_req_or_test = False
     for line in section:
         lstrip_line = line.lstrip()
 
@@ -67,6 +110,14 @@ def _process_req_list(section, req_list_name, new_python_req, force_apply=False)
         ):
             new_lines.append(line)
             continue
+
+        if (
+            req_or_test_indent is not None
+            and not _is_comment_or_empty(line)
+            and len(line) - len(line.lstrip()) <= req_or_test_indent
+        ):
+            in_req_or_test = False
+            req_or_test_indent = None
 
         indent = len(line) - len(lstrip_line)
         if curr_indent is None:
@@ -126,12 +177,18 @@ def _process_req_list(section, req_list_name, new_python_req, force_apply=False)
                 else:
                     new_line = line
         else:
-            if line.lstrip().startswith(req_list_name + ":"):
+            if line.lstrip().startswith(req_list_name + ":") and in_req_or_test:
                 logger.debug("found %s for processing req list", req_list_name)
                 in_section = True
                 found_it = True
 
             new_line = line
+
+        if line.lstrip().startswith("requirements:") or line.lstrip().startswith(
+            "test:"
+        ):
+            req_or_test_indent = len(line) - len(line.lstrip())
+            in_req_or_test = True
 
         new_lines.append(new_line)
         curr_indent = indent
@@ -180,12 +237,14 @@ def _add_test_requires(section):
     return new_lines
 
 
-def _process_section(section, force_noarch_python=False, force_apply=False):
+def _process_section(
+    section, force_noarch_python=False, force_apply=False, build_or_host="host"
+):
     if (not _has_noarch_python(section)) and (not force_noarch_python):
         return section, None
 
     found_it, section, python_min_override = _process_req_list(
-        section, "host", "{{ python_min }}", force_apply=force_apply
+        section, build_or_host, "{{ python_min }}", force_apply=force_apply
     )
     logger.debug("applied `noarch: python` host? %s", found_it)
     found_it, section, _ = _process_req_list(
@@ -227,9 +286,20 @@ def _apply_noarch_python_min(
             # _process_section returns list of lines already
             _new_lines, _python_min_override = _process_section(
                 section,
-                force_noarch_python=has_global_noarch_python
-                and (not has_build_override),
+                force_noarch_python=(
+                    has_global_noarch_python
+                    and (
+                        (not has_build_override)
+                        or (has_build_override and _has_noarch_python(section))
+                    )
+                ),
                 force_apply=not preserve_existing_specs,
+                build_or_host=(
+                    "build"
+                    if not _has_req_section(section, "host")
+                    and _has_req_section(section, "build")
+                    else "host"
+                ),
             )
             new_lines += _new_lines
             if _python_min_override is not None:
@@ -267,6 +337,7 @@ def _apply_noarch_python_min(
 class NoarchPythonMinMigrator(Migrator):
     """Migrator for converting `noarch: python` recipes to the CFEP-25 syntax."""
 
+    migrator_version = 1
     bump_number = 1
 
     def __init__(
@@ -329,12 +400,12 @@ class NoarchPythonMinMigrator(Migrator):
         body = super().pr_body(feedstock_ctx)
         body = body.format(
             textwrap.dedent(
-                """
-            This PR updates the recipe to use the `noarch: python` syntax as described in
-            [CFEP-25](https://github.com/conda-forge/cfep/blob/main/cfep-25.md). Please
-            see our [documentation](https://conda-forge.org/docs/maintainer/knowledge_base/#noarch-python)
-            for more details.
-            """,
+                """\
+This PR updates the recipe to use the `noarch: python` syntax as described in \
+[CFEP-25](https://github.com/conda-forge/cfep/blob/main/cfep-25.md). Please \
+see our [documentation](https://conda-forge.org/docs/maintainer/knowledge_base/#noarch-python) \
+for more details.
+""",
             )
         )
         return body

--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -26,6 +26,7 @@ from conda_forge_tick.migrators import (
     GraphMigrator,
     MatplotlibBase,
     Migrator,
+    NoarchPythonMinMigrator,
     OSXArm,
     Replacement,
     Version,
@@ -424,7 +425,11 @@ def main() -> None:
         )
         print("name:", migrator_name, flush=True)
 
-        if isinstance(migrator, GraphMigrator) or isinstance(migrator, Replacement):
+        if (
+            isinstance(migrator, GraphMigrator)
+            or isinstance(migrator, Replacement)
+            or isinstance(migrator, NoarchPythonMinMigrator)
+        ):
             if isinstance(migrator, GraphMigrator):
                 mgconf = yaml.safe_load(getattr(migrator, "yaml_contents", "{}")).get(
                     "__migrator",

--- a/tests/test_noarch_python_min_migrator.py
+++ b/tests/test_noarch_python_min_migrator.py
@@ -22,6 +22,7 @@ NEXT_GLOBAL_PYTHON_MIN = (
 )
 
 
+@pytest.mark.parametrize("replace_host_with_build", [True, False])
 @pytest.mark.parametrize(
     "meta_yaml,expected_meta_yaml",
     [
@@ -403,7 +404,14 @@ NEXT_GLOBAL_PYTHON_MIN = (
 def test_apply_noarch_python_min(
     meta_yaml,
     expected_meta_yaml,
+    replace_host_with_build,
 ):
+    if replace_host_with_build:
+        meta_yaml = meta_yaml.replace("host:", "build:")
+        expected_meta_yaml = expected_meta_yaml.replace("host:", "build:")
+        assert "host" not in meta_yaml
+        assert "host" not in expected_meta_yaml
+
     with tempfile.TemporaryDirectory() as recipe_dir:
         mypth = os.path.join(recipe_dir, "meta.yaml")
         with open(mypth, "w") as f:


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

Trying again with build sections now included for `noarch: python`.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
