### PR TITLE
fix: use proper graph for `noarch: python` min migrator

### DIFF
--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -703,7 +703,9 @@ def create_migration_yaml_creator(
                 continue
 
 
-def add_noarch_python_min_migrator(migrators: MutableSequence[Migrator], gx: nx.DiGraph):
+def add_noarch_python_min_migrator(
+    migrators: MutableSequence[Migrator], gx: nx.DiGraph
+):
     with fold_log_lines("making `noarch: python` migrator"):
         gx2 = copy.deepcopy(gx)
         for node in list(gx2.nodes):

--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -26,7 +26,6 @@ from conda_forge_tick.migrators import (
     GraphMigrator,
     MatplotlibBase,
     Migrator,
-    NoarchPythonMinMigrator,
     OSXArm,
     Replacement,
     Version,
@@ -426,9 +425,12 @@ def main() -> None:
         print("name:", migrator_name, flush=True)
 
         if (
-            isinstance(migrator, GraphMigrator)
-            or isinstance(migrator, Replacement)
-            or isinstance(migrator, NoarchPythonMinMigrator)
+            (
+                isinstance(migrator, GraphMigrator)
+                or isinstance(migrator, Replacement)
+                or isinstance(migrator, Migrator)
+            )
+            and not isinstance(migrator, Version)
         ):
             if isinstance(migrator, GraphMigrator):
                 mgconf = yaml.safe_load(getattr(migrator, "yaml_contents", "{}")).get(
@@ -447,6 +449,7 @@ def main() -> None:
                     regular_status[migrator_name] = f"{migrator.name} Migration Status"
             else:
                 regular_status[migrator_name] = f"{migrator.name} Migration Status"
+
             status, _, gv = graph_migrator_status(migrator, mctx.graph)
             num_viz = status.pop("_num_viz", 0)
             with open(

--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -425,13 +425,10 @@ def main() -> None:
         print("name:", migrator_name, flush=True)
 
         if (
-            (
-                isinstance(migrator, GraphMigrator)
-                or isinstance(migrator, Replacement)
-                or isinstance(migrator, Migrator)
-            )
-            and not isinstance(migrator, Version)
-        ):
+            isinstance(migrator, GraphMigrator)
+            or isinstance(migrator, Replacement)
+            or isinstance(migrator, Migrator)
+        ) and not isinstance(migrator, Version):
             if isinstance(migrator, GraphMigrator):
                 mgconf = yaml.safe_load(getattr(migrator, "yaml_contents", "{}")).get(
                     "__migrator",


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

I forgot to cut down the input nodes to only those that need a migration.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
