### PR TITLE
fix: weird newline for noarch: python migration

### DIFF
--- a/conda_forge_tick/migrators/noarch_python_min.py
+++ b/conda_forge_tick/migrators/noarch_python_min.py
@@ -125,11 +125,22 @@ def _process_req_list(section, req_list_name, new_python_req, force_apply=False)
 
         if in_section:
             if indent < curr_indent:
-                if not adjusted_python and req_list_name not in ["host", "run"]:
+                if not adjusted_python and req_list_name not in [
+                    "build",
+                    "host",
+                    "run",
+                ]:
                     logger.debug("adding python to section %s", req_list_name)
                     # insert python as spec
-                    new_line = curr_indent * " " + "- python " + new_python_req + "\n"
-                    new_lines.append(new_line)
+                    _new_line = curr_indent * " " + "- python " + new_python_req + "\n"
+                    loc = -1
+                    while new_lines[loc].strip() == "":
+                        loc -= 1
+                    if loc == -1:
+                        new_lines.append(_new_line)
+                    else:
+                        loc += 1
+                        new_lines = new_lines[:loc] + [_new_line] + new_lines[loc:]
 
                 # the section ended
                 in_section = False

--- a/tests/test_noarch_python_min_migrator.py
+++ b/tests/test_noarch_python_min_migrator.py
@@ -430,13 +430,14 @@ def test_apply_noarch_python_min(
             assert f.read() == expected_meta_yaml
 
 
-def test_noarch_python_min_migrator(tmpdir):
+@pytest.mark.parametrize("name", ["seaborn", "extra_new_line"])
+def test_noarch_python_min_migrator(tmpdir, name):
     with open(
-        os.path.join(TEST_YAML_PATH, "noarch_python_min_seaborn_before_meta.yaml")
+        os.path.join(TEST_YAML_PATH, f"noarch_python_min_{name}_before_meta.yaml")
     ) as f:
         recipe_before = f.read()
     with open(
-        os.path.join(TEST_YAML_PATH, "noarch_python_min_seaborn_after_meta.yaml")
+        os.path.join(TEST_YAML_PATH, f"noarch_python_min_{name}_after_meta.yaml")
     ) as f:
         recipe_after = f.read()
     m = NoarchPythonMinMigrator()

--- a/tests/test_yaml/noarch_python_min_extra_new_line_after_meta.yaml
+++ b/tests/test_yaml/noarch_python_min_extra_new_line_after_meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "semi-ate-apps-common" %}
+{% set version = "1.0.12" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/semi-ate-apps-common-{{ version }}.tar.gz
+  sha256: 5a7fae7dd6667f10239a848ad95ce22cf8d7c554f106084d519ef2f60c00a1ab
+
+build:
+  number: 1
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python {{ python_min }}
+  run:
+    - aiomqtt
+    - python >={{ python_min }}
+    - semi-ate-common
+    - semi-ate-stdf
+
+test:
+  imports:
+    - ate_apps_common
+  commands:
+    - pip check
+  requires:
+    - pip
+    - python {{ python_min }}
+
+about:
+  home: https://pypi.org/project/semi-ate-apps-common/
+  summary: Shared helpers used by the different ate-apps, i.e. master-app, control-app, etc.)
+  license: GPL-2.0-only
+  license_file: ate_apps_common/LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - nerohmot

--- a/tests/test_yaml/noarch_python_min_extra_new_line_before_meta.yaml
+++ b/tests/test_yaml/noarch_python_min_extra_new_line_before_meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "semi-ate-apps-common" %}
+{% set version = "1.0.12" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/semi-ate-apps-common-{{ version }}.tar.gz
+  sha256: 5a7fae7dd6667f10239a848ad95ce22cf8d7c554f106084d519ef2f60c00a1ab
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.8
+  run:
+    - aiomqtt
+    - python >=3.8
+    - semi-ate-common
+    - semi-ate-stdf
+
+test:
+  imports:
+    - ate_apps_common
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/semi-ate-apps-common/
+  summary: Shared helpers used by the different ate-apps, i.e. master-app, control-app, etc.)
+  license: GPL-2.0-only
+  license_file: ate_apps_common/LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - nerohmot


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR fixes an edge case where a newline is inserted into the `test.requires` when adding `python {{ python_min }}` for the `noarch: python` migration.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

closes #3217
