### PR TITLE
fix: make sure parser works for jinja2 set statements with newline ad…

### DIFF
--- a/tests/test_recipe_parser.py
+++ b/tests/test_recipe_parser.py
@@ -1285,9 +1285,9 @@ extra:
 
 
 def test_recipe_parses_cupy():
-    recipe = r"""{% set name = "cupy" %}
-{% set version = "10.1.0" %}
-{% set sha256 = "ad28e7311b2023391f2278b7649828decdd9d9599848e18845eb4ab1b2d01936" %}
+    recipe = r"""{% set name = "cupy" -%}
+{%- set version = "10.1.0" %}
+{%- set sha256 = "ad28e7311b2023391f2278b7649828decdd9d9599848e18845eb4ab1b2d01936" -%}
 
 {% if cuda_compiler_version in (None, "None", True, False) %}
 {% set cuda_major = 0 %}


### PR DESCRIPTION
…justments

<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR ensures the recipe parser works for jinja2 set statements with newline adjustments.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

fixes #3211 

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
