### PR TITLE
fix: remove edges from noarch python migrator graph

### DIFF
--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -718,6 +718,8 @@ def add_noarch_python_min_migrator(
             if not has_noarch_python:
                 pluck(gx2, node)
 
+        gx2.clear_edges()
+
         migrators.append(
             NoarchPythonMinMigrator(
                 graph=gx2,


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR removes the edges from the `noarch: python` migrator graph in an attempt to fix the status page (which shows all things being children of all things).

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
