### PR TITLE
fix: use mini-migrators for everything

### DIFF
--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -56,6 +56,7 @@ from conda_forge_tick.migrators import (
     LicenseMigrator,
     MigrationYaml,
     Migrator,
+    MiniMigrator,
     MPIPinRunAsBuildCleanup,
     NoarchPythonMinMigrator,
     NoCondaInspectMigrator,
@@ -97,6 +98,29 @@ PR_LIMIT = 5
 MAX_PR_LIMIT = 50
 MAX_SOLVER_ATTEMPTS = 50
 CHECK_SOLVABLE_TIMEOUT = 90  # 90 days
+DEFAULT_MINI_MIGRATORS = [
+    CondaForgeYAMLCleanup,
+    Jinja2VarsCleanup,
+    DuplicateLinesCleanup,
+    PipMigrator,
+    LicenseMigrator,
+    CondaForgeYAMLCleanup,
+    ExtraJinja2KeysCleanup,
+    Build2HostMigrator,
+    NoCondaInspectMigrator,
+    MPIPinRunAsBuildCleanup,
+    PyPIOrgMigrator,
+]
+
+
+def _make_mini_migrators_with_defaults(
+    extra_mini_migrators: list[MiniMigrator] = None,
+) -> list[MiniMigrator]:
+    extra_mini_migrators = extra_mini_migrators or []
+    for klass in DEFAULT_MINI_MIGRATORS:
+        if not any(isinstance(m, klass) for m in extra_mini_migrators):
+            extra_mini_migrators.append(klass())
+    return extra_mini_migrators
 
 
 def add_replacement_migrator(
@@ -283,17 +307,7 @@ def add_rebuild_migration_yaml(
         if (node in total_graph) and len(list(total_graph.predecessors(node))) == 0
     }
     piggy_back_migrations = [
-        Jinja2VarsCleanup(),
-        DuplicateLinesCleanup(),
-        PipMigrator(),
-        LicenseMigrator(),
-        CondaForgeYAMLCleanup(),
-        ExtraJinja2KeysCleanup(),
-        Build2HostMigrator(),
-        NoCondaInspectMigrator(),
         CrossCompilationForARMAndPower(),
-        MPIPinRunAsBuildCleanup(),
-        PyPIOrgMigrator(),
         StdlibMigrator(),
     ]
     if migration_name == "qt515":
@@ -308,6 +322,10 @@ def add_rebuild_migration_yaml(
         piggy_back_migrations.append(RUCRTCleanup())
     if migration_name.startswith("flang19"):
         piggy_back_migrations.append(FlangMigrator())
+    piggy_back_migrations = _make_mini_migrators_with_defaults(
+        extra_mini_migrators=piggy_back_migrations
+    )
+
     cycles = set()
     for cyc in nx.simple_cycles(total_graph):
         cycles |= set(cyc)
@@ -723,7 +741,8 @@ def add_noarch_python_min_migrator(
         migrators.append(
             NoarchPythonMinMigrator(
                 graph=gx2,
-                pr_limit=1,  # will turn up later
+                pr_limit=1,
+                piggy_back_migrations=_make_mini_migrators_with_defaults(),
             ),
         )
 
@@ -777,22 +796,13 @@ def initialize_migrators(
             python_nodes=python_nodes,
             graph=gx,
             pr_limit=PR_LIMIT * 4,
-            piggy_back_migrations=[
-                CondaForgeYAMLCleanup(),
-                Jinja2VarsCleanup(),
-                DuplicateLinesCleanup(),
-                PipMigrator(),
-                LicenseMigrator(),
-                CondaForgeYAMLCleanup(),
-                ExtraJinja2KeysCleanup(),
-                Build2HostMigrator(),
-                NoCondaInspectMigrator(),
-                PipWheelMigrator(),
-                MPIPinRunAsBuildCleanup(),
-                DependencyUpdateMigrator(python_nodes),
-                PyPIOrgMigrator(),
-                StdlibMigrator(),
-            ],
+            piggy_back_migrations=_make_mini_migrators_with_defaults(
+                extra_mini_migrators=[
+                    PipWheelMigrator(),
+                    DependencyUpdateMigrator(python_nodes),
+                    StdlibMigrator(),
+                ],
+            ),
         )
 
         random.shuffle(pinning_migrators)


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR adds a set of default mini-migrators for every thing we can.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
