### PR TITLE
fix: always ensure the parsing error key is present

### DIFF
--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -89,6 +89,8 @@ def get_attrs(name: str, mark_not_archived=False) -> LazyJson:
             data = load_feedstock(
                 name, sub_graph.data, mark_not_archived=mark_not_archived
             )
+            if "parsing_error" not in data:
+                data["parsing_error"] = False
             sub_graph.clear()
             sub_graph.update(data)
         except Exception as e:


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

For some reason some nodes do not have this key. I am adding it.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
