### PR TITLE
fix: handle upper bounds for `noarch: python` min migration

### DIFF
--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -773,7 +773,7 @@ def initialize_migrators(
         "To maintain the old behavior you should migrate to astropy-base.",
     )
 
-    #add_noarch_python_min_migrator(migrators, gx)
+    # add_noarch_python_min_migrator(migrators, gx)
 
     pinning_migrators: List[Migrator] = []
     migration_factory(pinning_migrators, gx)

--- a/tests/test_noarch_python_min_migrator.py
+++ b/tests/test_noarch_python_min_migrator.py
@@ -148,6 +148,46 @@ NEXT_GLOBAL_PYTHON_MIN = (
         ),
         (
             textwrap.dedent(
+                """\
+                build:
+                  noarch: python
+
+                requirements:
+                  host:
+                    - python 3.6.*  # this is cool
+                    - numpy
+                  run:
+                    - python <=3.12
+                    - numpy
+
+                test:
+                  requires:
+                    - python =3.6
+                    - numpy
+                """
+            ),
+            textwrap.dedent(
+                """\
+                build:
+                  noarch: python
+
+                requirements:
+                  host:
+                    - python {{ python_min }}  # this is cool
+                    - numpy
+                  run:
+                    - python >={{ python_min }},<3.13a0
+                    - numpy
+
+                test:
+                  requires:
+                    - python {{ python_min }}
+                    - numpy
+                """
+            ),
+        ),
+        (
+            textwrap.dedent(
                 f"""\
                 build:
                   noarch: python
@@ -157,7 +197,7 @@ NEXT_GLOBAL_PYTHON_MIN = (
                     - python >={NEXT_GLOBAL_PYTHON_MIN}  # this is cool
                     - numpy
                   run:
-                    - python
+                    - python >={NEXT_GLOBAL_PYTHON_MIN}
                     - numpy
 
                 test:
@@ -198,7 +238,7 @@ NEXT_GLOBAL_PYTHON_MIN = (
                     - python >={GLOBAL_PYTHON_MIN}  # this is cool
                     - numpy
                   run:
-                    - python
+                    - python >={GLOBAL_PYTHON_MIN}
                     - numpy
 
                 test:
@@ -218,6 +258,87 @@ NEXT_GLOBAL_PYTHON_MIN = (
                     - numpy
                   run:
                     - python >={{ python_min }}
+                    - numpy
+
+                test:
+                  requires:
+                    - python {{ python_min }}
+                    - numpy
+                """
+            ),
+        ),
+        (
+            textwrap.dedent(
+                f"""\
+                build:
+                  noarch: python
+
+                requirements:
+                  host:
+                    - python >={NEXT_GLOBAL_PYTHON_MIN}  # this is cool
+                    - numpy
+                  run:
+                    - python >={NEXT_GLOBAL_PYTHON_MIN},<3.13
+                    - numpy
+
+                test:
+                  requires:
+                    - python =3.6
+                    - numpy
+                """
+            ),
+            textwrap.dedent(
+                f"""\
+                {{% set python_min = '{NEXT_GLOBAL_PYTHON_MIN}' %}}
+                build:
+                  noarch: python
+
+                requirements:
+                  host:
+                    - python {{{{ python_min }}}}  # this is cool
+                    - numpy
+                  run:
+                    - python >={{{{ python_min }}}},<3.13
+                    - numpy
+
+                test:
+                  requires:
+                    - python {{{{ python_min }}}}
+                    - numpy
+                """
+            ),
+        ),
+        (
+            textwrap.dedent(
+                f"""\
+                build:
+                  noarch: python
+
+                requirements:
+                  host:
+                    - python >={GLOBAL_PYTHON_MIN}  # this is cool
+                    - numpy
+                  run:
+                    - python >={GLOBAL_PYTHON_MIN},<3.12
+                    - numpy
+
+                test:
+                  requires:
+                    - python =3.6
+                    - numpy
+                """
+            ),
+            textwrap.dedent(
+                """\
+                build:
+                  noarch: python
+
+                requirements:
+                  host:
+                    - python {{ python_min }}  # this is cool
+                    - numpy
+                  run:
+                    - python >={{ python_min }},<3.12
                     - numpy
 
                 test:
@@ -430,7 +551,7 @@ def test_apply_noarch_python_min(
             assert f.read() == expected_meta_yaml
 
 
-@pytest.mark.parametrize("name", ["seaborn", "extra_new_line"])
+@pytest.mark.parametrize("name", ["seaborn", "extra_new_line", "zospy"])
 def test_noarch_python_min_migrator(tmpdir, name):
     with open(
         os.path.join(TEST_YAML_PATH, f"noarch_python_min_{name}_before_meta.yaml")

--- a/tests/test_yaml/noarch_python_min_zospy_after_meta.yaml
+++ b/tests/test_yaml/noarch_python_min_zospy_after_meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "zospy" %}
+{% set version = "1.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/zospy-{{ version }}.tar.gz
+  sha256: 202d05fda8f8a81db6ddadd62712424763e1abd51d56d6c30fbaaf07463083b2
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 1
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - flit-core >=3.2,<4
+    - pip
+  run:
+    - eval_type_backport
+    - lark ~=1.2.0
+    - pydantic >=2.4.0
+    - python >={{ python_min }},<3.13
+    - pythonnet >=3.0.1,<3.1.dev0
+    - pandas
+    - numpy
+    - semver >=3.0.0,<3.1.dev0
+    - __win
+
+test:
+  imports:
+    - zospy
+  commands:
+    - pip check
+  requires:
+    - pip
+    - python {{ python_min }}
+
+about:
+  home: https://zospy.readthedocs.io/
+  summary: A Python package used to communicate with Zemax OpticStudio through the API
+  doc_url: https://zospy.readthedocs.io/
+  dev_url: https://github.com/MREYE-LUMC/ZOSPy/
+  license: MIT
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - LucVV
+    - crnh
+    - jwmbeenakker

--- a/tests/test_yaml/noarch_python_min_zospy_before_meta.yaml
+++ b/tests/test_yaml/noarch_python_min_zospy_before_meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "zospy" %}
+{% set version = "1.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/zospy-{{ version }}.tar.gz
+  sha256: 202d05fda8f8a81db6ddadd62712424763e1abd51d56d6c30fbaaf07463083b2
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.9,<3.13
+    - flit-core >=3.2,<4
+    - pip
+  run:
+    - eval_type_backport
+    - lark ~=1.2.0
+    - pydantic >=2.4.0
+    - python >=3.9,<3.13
+    - pythonnet >=3.0.1,<3.1.dev0
+    - pandas
+    - numpy
+    - semver >=3.0.0,<3.1.dev0
+    - __win
+
+test:
+  imports:
+    - zospy
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://zospy.readthedocs.io/
+  summary: A Python package used to communicate with Zemax OpticStudio through the API
+  doc_url: https://zospy.readthedocs.io/
+  dev_url: https://github.com/MREYE-LUMC/ZOSPy/
+  license: MIT
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - LucVV
+    - crnh
+    - jwmbeenakker


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

This PR allows the code to handle upper bounds when migrating to the new `noarch: python` syntax.

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

fixes #3229