### PR TITLE
fix: try version feeds before raw urls

### DIFF
--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -618,6 +618,10 @@ class GithubReleases(AbstractSource):
         return latest
 
 
+# TODO: this one does not work because the atom feeds from libraries.io
+# all return 403 and I cannot find the correct URL to use
+# also url_contains is not defined
+# also package_name is not defined
 class LibrariesIO(VersionFromFeed):
     name = "LibrariesIO"
 

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -618,20 +618,6 @@ class GithubReleases(AbstractSource):
         return latest
 
 
-class LibrariesIO(VersionFromFeed):
-    name = "LibrariesIO"
-
-    def get_url(self, meta_yaml) -> Optional[str]:
-        urls = meta_yaml["url"]
-        if not isinstance(meta_yaml["url"], list):
-            urls = [urls]
-        for url in urls:
-            if self.url_contains not in url:
-                continue
-            pkg = self.package_name(url)
-            return f"https://libraries.io/{self.name}/{pkg}/versions.atom"
-
-
 class NVIDIA(AbstractSource):
     """Like BaseRawURL but it embeds logic based on NVIDIA's packaging schema."""
 

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -618,6 +618,20 @@ class GithubReleases(AbstractSource):
         return latest
 
 
+class LibrariesIO(VersionFromFeed):
+    name = "LibrariesIO"
+
+    def get_url(self, meta_yaml) -> Optional[str]:
+        urls = meta_yaml["url"]
+        if not isinstance(meta_yaml["url"], list):
+            urls = [urls]
+        for url in urls:
+            if self.url_contains not in url:
+                continue
+            pkg = self.package_name(url)
+            return f"https://libraries.io/{self.name}/{pkg}/versions.atom"
+
+
 class NVIDIA(AbstractSource):
     """Like BaseRawURL but it embeds logic based on NVIDIA's packaging schema."""
 

--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -421,12 +421,12 @@ def all_version_sources():
         CRAN(),
         CratesIO(),
         NPM(),
-        ROSDistro(),
-        RawURL(),
         Github(),
         GithubReleases(),
-        IncrementAlphaRawURL(),
         NVIDIA(),
+        ROSDistro(),
+        RawURL(),
+        IncrementAlphaRawURL(),
     )
 
 

--- a/tests/test_upstream_versions.py
+++ b/tests/test_upstream_versions.py
@@ -1257,12 +1257,12 @@ default_sources = (
     "CRAN",
     "CratesIO",
     "NPM",
-    "ROSDistro",
-    "RawURL",
     "Github",
     "GithubReleases",
-    "IncrementAlphaRawURL",
     "NVIDIA",
+    "ROSDistro",
+    "RawURL",
+    "IncrementAlphaRawURL",
 )
 
 


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR puts version feed updates before raw urls. Hopefully it saves us time and is more reliable. I feel like someone may have suggested this in the past and I was not in support for some reason, but now I cannot recall. Let's go ahead and see what rustles up.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
