### PR TITLE
fix: wrong filter condition for `noarch: python` python_min migration

### DIFF
--- a/conda_forge_tick/migrators/noarch_python_min.py
+++ b/conda_forge_tick/migrators/noarch_python_min.py
@@ -455,8 +455,12 @@ class NoarchPythonMinMigrator(Migrator):
         )
 
     def migrate(self, recipe_dir, attrs, **kwargs):
-        # the actual migration is done via a mini-migrator so that we can
-        # apply this to other migrators as well
+        # if the feedstock has already been update, return a migration ID
+        # and make no changes.
+        for line in attrs.get("raw_meta_yaml", "").splitlines():
+            if "{{ python_min }}" in line:
+                return super().migrate(recipe_dir, attrs)
+
         self.set_build_number(os.path.join(recipe_dir, "meta.yaml"))
         _apply_noarch_python_min(
             recipe_dir,

--- a/conda_forge_tick/migrators/noarch_python_min.py
+++ b/conda_forge_tick/migrators/noarch_python_min.py
@@ -443,18 +443,14 @@ class NoarchPythonMinMigrator(Migrator):
 
     def filter(self, attrs) -> bool:
         has_noarch_python = False
-        has_python_min = False
         for line in attrs.get("raw_meta_yaml", "").splitlines():
             if line.lstrip().startswith("noarch: python"):
                 has_noarch_python = True
-            if "{{ python_min }}" in line:
-                has_python_min = True
-
-        needs_migration = has_noarch_python and (not has_python_min)
+                break
 
         return (
             super().filter(attrs)
-            or (not needs_migration)
+            or (not has_noarch_python)
             or _skip_due_to_schema(attrs, self.allowed_schema_versions)
         )
 

--- a/conda_forge_tick/migrators/noarch_python_min.py
+++ b/conda_forge_tick/migrators/noarch_python_min.py
@@ -455,13 +455,14 @@ class NoarchPythonMinMigrator(Migrator):
         )
 
     def migrate(self, recipe_dir, attrs, **kwargs):
-        # if the feedstock has already been update, return a migration ID
+        # if the feedstock has already been updated, return a migration ID
         # and make no changes.
+        self.set_build_number(os.path.join(recipe_dir, "meta.yaml"))
+
         for line in attrs.get("raw_meta_yaml", "").splitlines():
             if "{{ python_min }}" in line:
                 return super().migrate(recipe_dir, attrs)
 
-        self.set_build_number(os.path.join(recipe_dir, "meta.yaml"))
         _apply_noarch_python_min(
             recipe_dir,
             attrs,


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR will fix feedstocks marked as "awaiting parents" in the status page. The current filter condition excludes things already migrated, but that is not right. It should only exclude things the never need a migration. The bot can then decide what to do when it attempts to migrate them.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
