### PR TITLE
fix: get correct total graph for noarch py min

### DIFF
--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -72,6 +72,7 @@ from conda_forge_tick.migrators import (
     UpdateConfigSubGuessMigrator,
     Version,
     make_from_lazy_json_data,
+    skip_migrator_due_to_schema,
 )
 from conda_forge_tick.migrators.arch import OSXArm
 from conda_forge_tick.migrators.migration_yaml import (
@@ -729,11 +730,14 @@ def add_noarch_python_min_migrator(
         for node in list(gx2.nodes):
             has_noarch_python = False
             with gx2.nodes[node]["payload"] as attrs:
+                skip_schema = skip_migrator_due_to_schema(
+                    attrs, NoarchPythonMinMigrator.allowed_schema_versions
+                )
                 for line in attrs.get("raw_meta_yaml", "").splitlines():
                     if line.lstrip().startswith("noarch: python"):
                         has_noarch_python = True
                         break
-            if not has_noarch_python:
+            if (not has_noarch_python) or skip_schema:
                 pluck(gx2, node)
 
         gx2.clear_edges()

--- a/conda_forge_tick/migrators/__init__.py
+++ b/conda_forge_tick/migrators/__init__.py
@@ -2,7 +2,13 @@
 from .arch import ArchRebuild, OSXArm
 from .broken_rebuild import RebuildBroken
 from .conda_forge_yaml_cleanup import CondaForgeYAMLCleanup
-from .core import GraphMigrator, Migrator, MiniMigrator, make_from_lazy_json_data
+from .core import (
+    GraphMigrator,
+    Migrator,
+    MiniMigrator,
+    make_from_lazy_json_data,
+    skip_migrator_due_to_schema,
+)
 from .cos7 import Cos7Config
 from .cross_compile import (
     Build2HostMigrator,

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -31,7 +31,7 @@ if typing.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _skip_due_to_schema(
+def skip_migrator_due_to_schema(
     attrs: "AttrsTypedDict", allowed_schema_versions: List[int]
 ) -> bool:
     __name = attrs.get("name", "")
@@ -399,7 +399,7 @@ class Migrator:
             attrs.get("archived", False)
             or parse_already_pred()
             or bad_attr
-            or _skip_due_to_schema(attrs, self.allowed_schema_versions)
+            or skip_migrator_due_to_schema(attrs, self.allowed_schema_versions)
         )
 
     def get_possible_feedstock_branches(self, attrs: "AttrsTypedDict") -> List[str]:

--- a/conda_forge_tick/migrators/cross_compile.py
+++ b/conda_forge_tick/migrators/cross_compile.py
@@ -3,7 +3,7 @@ import os
 import typing
 from typing import Any
 
-from conda_forge_tick.migrators.core import MiniMigrator, _skip_due_to_schema
+from conda_forge_tick.migrators.core import MiniMigrator, skip_migrator_due_to_schema
 from conda_forge_tick.os_utils import pushd
 from conda_forge_tick.provide_source_code import provide_source_code
 from conda_forge_tick.utils import yaml_safe_dump, yaml_safe_load
@@ -28,7 +28,9 @@ class CrossCompilationMigratorBase(MiniMigrator):
             if compiler in build_reqs:
                 needed = True
                 break
-        return (not needed) or _skip_due_to_schema(attrs, self.allowed_schema_versions)
+        return (not needed) or skip_migrator_due_to_schema(
+            attrs, self.allowed_schema_versions
+        )
 
 
 class UpdateConfigSubGuessMigrator(CrossCompilationMigratorBase):
@@ -153,7 +155,7 @@ class CrossPythonMigrator(CrossCompilationMigratorBase):
         return (
             "python" not in host_reqs
             or "python" in build_reqs
-            or _skip_due_to_schema(attrs, self.allowed_schema_versions)
+            or skip_migrator_due_to_schema(attrs, self.allowed_schema_versions)
         )
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
@@ -211,7 +213,7 @@ class CrossPythonMigrator(CrossCompilationMigratorBase):
 class UpdateCMakeArgsMigrator(CrossCompilationMigratorBase):
     def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
         build_reqs = attrs.get("requirements", {}).get("build", set())
-        return "cmake" not in build_reqs or _skip_due_to_schema(
+        return "cmake" not in build_reqs or skip_migrator_due_to_schema(
             attrs, self.allowed_schema_versions
         )
 
@@ -244,7 +246,7 @@ class Build2HostMigrator(MiniMigrator):
         build_reqs = attrs.get("requirements", {}).get("build", set())
         host_reqs = attrs.get("requirements", {}).get("host", set())
         run_reqs = attrs.get("requirements", {}).get("run", set())
-        skip_schema = _skip_due_to_schema(attrs, self.allowed_schema_versions)
+        skip_schema = skip_migrator_due_to_schema(attrs, self.allowed_schema_versions)
         if (
             len(attrs.get("outputs_names", [])) <= 1
             and "python" in build_reqs
@@ -289,7 +291,7 @@ class NoCondaInspectMigrator(MiniMigrator):
     post_migration = True
 
     def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
-        skip_schema = _skip_due_to_schema(attrs, self.allowed_schema_versions)
+        skip_schema = skip_migrator_due_to_schema(attrs, self.allowed_schema_versions)
         if "conda inspect" in attrs.get("raw_meta_yaml", "") and not skip_schema:
             return False
         else:
@@ -323,7 +325,7 @@ ${R} CMD INSTALL --build . ${R_ARGS}
 class CrossRBaseMigrator(CrossCompilationMigratorBase):
     def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
         host_reqs = attrs.get("requirements", {}).get("host", set())
-        skip_schema = _skip_due_to_schema(attrs, self.allowed_schema_versions)
+        skip_schema = skip_migrator_due_to_schema(attrs, self.allowed_schema_versions)
         if (
             "r-base" in host_reqs or attrs.get("name", "").startswith("r-")
         ) and not skip_schema:
@@ -383,7 +385,7 @@ class CrossCompilationForARMAndPower(MiniMigrator):
     post_migration = True
 
     def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
-        return _skip_due_to_schema(attrs, self.allowed_schema_versions)
+        return skip_migrator_due_to_schema(attrs, self.allowed_schema_versions)
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
         with pushd(recipe_dir):

--- a/conda_forge_tick/migrators/cstdlib.py
+++ b/conda_forge_tick/migrators/cstdlib.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-from conda_forge_tick.migrators.core import MiniMigrator, _skip_due_to_schema
+from conda_forge_tick.migrators.core import MiniMigrator, skip_migrator_due_to_schema
 from conda_forge_tick.migrators.libboost import _replacer, _slice_into_output_sections
 
 pat_stub = re.compile(r"(c|cxx|fortran)_compiler_stub")
@@ -201,7 +201,7 @@ class StdlibMigrator(MiniMigrator):
         has_sysroot = any(pat_sysroot_217.search(line) for line in lines)
         # filter() returns True if we _don't_ want to migrate
         return (
-            _skip_due_to_schema(attrs, self.allowed_schema_versions)
+            skip_migrator_due_to_schema(attrs, self.allowed_schema_versions)
             or already_migrated
             or not (has_compiler or has_sysroot)
         )

--- a/conda_forge_tick/migrators/dep_updates.py
+++ b/conda_forge_tick/migrators/dep_updates.py
@@ -2,7 +2,7 @@ import logging
 import typing
 from typing import Any
 
-from conda_forge_tick.migrators.core import MiniMigrator, _skip_due_to_schema
+from conda_forge_tick.migrators.core import MiniMigrator, skip_migrator_due_to_schema
 from conda_forge_tick.update_deps import apply_dep_update, get_dep_updates_and_hints
 from conda_forge_tick.utils import get_keys_default
 
@@ -32,7 +32,9 @@ class DependencyUpdateMigrator(MiniMigrator):
             "hint",
         )
         if update_deps in ["update-all", "update-source", "update-grayskull"]:
-            return False or _skip_due_to_schema(attrs, self.allowed_schema_versions)
+            return False or skip_migrator_due_to_schema(
+                attrs, self.allowed_schema_versions
+            )
 
         return True
 

--- a/conda_forge_tick/migrators/duplicate_lines.py
+++ b/conda_forge_tick/migrators/duplicate_lines.py
@@ -2,7 +2,7 @@ import re
 import typing
 from typing import Any
 
-from conda_forge_tick.migrators.core import MiniMigrator, _skip_due_to_schema
+from conda_forge_tick.migrators.core import MiniMigrator, skip_migrator_due_to_schema
 from conda_forge_tick.os_utils import pushd
 
 if typing.TYPE_CHECKING:
@@ -23,7 +23,9 @@ class DuplicateLinesCleanup(MiniMigrator):
         raw_yaml = attrs.get("raw_meta_yaml", "")
         for line in raw_yaml.splitlines():
             if any(r.match(line) for r in self.regex_to_check.values()):
-                return False or _skip_due_to_schema(attrs, self.allowed_schema_versions)
+                return False or skip_migrator_due_to_schema(
+                    attrs, self.allowed_schema_versions
+                )
 
         return True
 

--- a/conda_forge_tick/migrators/extra_jinj2a_keys_cleanup.py
+++ b/conda_forge_tick/migrators/extra_jinj2a_keys_cleanup.py
@@ -2,7 +2,7 @@ import re
 import typing
 from typing import Any
 
-from conda_forge_tick.migrators.core import MiniMigrator, _skip_due_to_schema
+from conda_forge_tick.migrators.core import MiniMigrator, skip_migrator_due_to_schema
 from conda_forge_tick.os_utils import pushd
 
 if typing.TYPE_CHECKING:
@@ -34,7 +34,9 @@ class ExtraJinja2KeysCleanup(MiniMigrator):
         raw_yaml = attrs["raw_meta_yaml"]
         for var_name in self.vars_to_remove:
             if f"{{% set {var_name}" in raw_yaml:
-                return False or _skip_due_to_schema(attrs, self.allowed_schema_versions)
+                return False or skip_migrator_due_to_schema(
+                    attrs, self.allowed_schema_versions
+                )
         return True
 
     def _replace_jinja_key(self, key_name, lines):

--- a/conda_forge_tick/migrators/flang.py
+++ b/conda_forge_tick/migrators/flang.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-from conda_forge_tick.migrators.core import MiniMigrator, _skip_due_to_schema
+from conda_forge_tick.migrators.core import MiniMigrator, skip_migrator_due_to_schema
 from conda_forge_tick.migrators.libboost import _replacer, _slice_into_output_sections
 
 # compiler("m2w64_fortran")
@@ -66,7 +66,7 @@ class FlangMigrator(MiniMigrator):
         lines = attrs["raw_meta_yaml"].splitlines()
         has_m2f = any(pat_m2f.search(line) or pat_fws.search(line) for line in lines)
         # filter() returns True if we _don't_ want to migrate
-        return (not (has_m2f)) or _skip_due_to_schema(
+        return (not (has_m2f)) or skip_migrator_due_to_schema(
             attrs, self.allowed_schema_versions
         )
 

--- a/conda_forge_tick/migrators/jinja2_vars_cleanup.py
+++ b/conda_forge_tick/migrators/jinja2_vars_cleanup.py
@@ -2,7 +2,7 @@ import re
 import typing
 from typing import Any
 
-from conda_forge_tick.migrators.core import MiniMigrator, _skip_due_to_schema
+from conda_forge_tick.migrators.core import MiniMigrator, skip_migrator_due_to_schema
 from conda_forge_tick.os_utils import pushd
 
 if typing.TYPE_CHECKING:
@@ -34,9 +34,9 @@ class Jinja2VarsCleanup(MiniMigrator):
     """Cleanup the jinja2 vars by replacing {{name}} with {{ name }} etc."""
 
     def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
-        return _should_filter(attrs.get("raw_meta_yaml", "")) or _skip_due_to_schema(
-            attrs, self.allowed_schema_versions
-        )
+        return _should_filter(
+            attrs.get("raw_meta_yaml", "")
+        ) or skip_migrator_due_to_schema(attrs, self.allowed_schema_versions)
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
         with pushd(recipe_dir):

--- a/conda_forge_tick/migrators/jpegturbo.py
+++ b/conda_forge_tick/migrators/jpegturbo.py
@@ -1,6 +1,6 @@
 import os
 
-from conda_forge_tick.migrators.core import MiniMigrator, _skip_due_to_schema
+from conda_forge_tick.migrators.core import MiniMigrator, skip_migrator_due_to_schema
 
 
 def _parse_jpeg(lines):
@@ -15,7 +15,7 @@ def _parse_jpeg(lines):
 class JpegTurboMigrator(MiniMigrator):
     def filter(self, attrs, not_bad_str_start=""):
         host_req = (attrs.get("requirements", {}) or {}).get("host", set()) or set()
-        return "jpeg" not in host_req or _skip_due_to_schema(
+        return "jpeg" not in host_req or skip_migrator_due_to_schema(
             attrs, self.allowed_schema_versions
         )
 

--- a/conda_forge_tick/migrators/libboost.py
+++ b/conda_forge_tick/migrators/libboost.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-from conda_forge_tick.migrators.core import MiniMigrator, _skip_due_to_schema
+from conda_forge_tick.migrators.core import MiniMigrator, skip_migrator_due_to_schema
 
 
 def _slice_into_output_sections(meta_yaml_lines, attrs):
@@ -214,9 +214,9 @@ class LibboostMigrator(MiniMigrator):
         run_req = (attrs.get("requirements", {}) or {}).get("run", set()) or set()
         all_req = set(host_req) | set(run_req)
         # filter() returns True if we _don't_ want to migrate
-        return (not bool({"boost", "boost-cpp"} & all_req)) or _skip_due_to_schema(
-            attrs, self.allowed_schema_versions
-        )
+        return (
+            not bool({"boost", "boost-cpp"} & all_req)
+        ) or skip_migrator_due_to_schema(attrs, self.allowed_schema_versions)
 
     def migrate(self, recipe_dir, attrs, **kwargs):
         fname = os.path.join(recipe_dir, "meta.yaml")

--- a/conda_forge_tick/migrators/license.py
+++ b/conda_forge_tick/migrators/license.py
@@ -6,7 +6,7 @@ import tempfile
 import typing
 from typing import Any
 
-from conda_forge_tick.migrators.core import MiniMigrator, _skip_due_to_schema
+from conda_forge_tick.migrators.core import MiniMigrator, skip_migrator_due_to_schema
 from conda_forge_tick.os_utils import pushd
 from conda_forge_tick.provide_source_code import provide_source_code
 from conda_forge_tick.recipe_parser import CondaMetaYAML
@@ -293,7 +293,9 @@ class LicenseMigrator(MiniMigrator):
             or any(n in license_fam for n in NEEDED_FAMILIES)
             or _is_r(attrs)
         ) and "license_file" not in attrs.get("meta_yaml", {}).get("about", {}):
-            return False or _skip_due_to_schema(attrs, self.allowed_schema_versions)
+            return False or skip_migrator_due_to_schema(
+                attrs, self.allowed_schema_versions
+            )
         return True
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:

--- a/conda_forge_tick/migrators/matplotlib_base.py
+++ b/conda_forge_tick/migrators/matplotlib_base.py
@@ -3,7 +3,7 @@ import os
 import typing
 from typing import Any
 
-from conda_forge_tick.migrators.core import _parse_bad_attr, _skip_due_to_schema
+from conda_forge_tick.migrators.core import _parse_bad_attr, skip_migrator_due_to_schema
 from conda_forge_tick.migrators.replacement import Replacement
 from conda_forge_tick.utils import frozen_to_json_friendly
 
@@ -54,7 +54,7 @@ class MatplotlibBase(Replacement):
             or _is_pred
             or _is_bad
             or _no_dep
-            or _skip_due_to_schema(attrs, self.allowed_schema_versions)
+            or skip_migrator_due_to_schema(attrs, self.allowed_schema_versions)
         )
 
     def migrate(

--- a/conda_forge_tick/migrators/noarch_python_min.py
+++ b/conda_forge_tick/migrators/noarch_python_min.py
@@ -11,7 +11,11 @@ from conda_build.config import Config
 from conda_build.variants import parse_config_file
 
 from conda_forge_tick.contexts import ClonedFeedstockContext
-from conda_forge_tick.migrators.core import Migrator, MiniMigrator, _skip_due_to_schema
+from conda_forge_tick.migrators.core import (
+    Migrator,
+    MiniMigrator,
+    skip_migrator_due_to_schema,
+)
 from conda_forge_tick.migrators.libboost import _slice_into_output_sections
 from conda_forge_tick.os_utils import pushd
 
@@ -451,7 +455,7 @@ class NoarchPythonMinMigrator(Migrator):
         return (
             super().filter(attrs)
             or (not has_noarch_python)
-            or _skip_due_to_schema(attrs, self.allowed_schema_versions)
+            or skip_migrator_due_to_schema(attrs, self.allowed_schema_versions)
         )
 
     def migrate(self, recipe_dir, attrs, **kwargs):

--- a/conda_forge_tick/migrators/numpy2.py
+++ b/conda_forge_tick/migrators/numpy2.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-from conda_forge_tick.migrators.core import MiniMigrator, _skip_due_to_schema
+from conda_forge_tick.migrators.core import MiniMigrator, skip_migrator_due_to_schema
 from conda_forge_tick.migrators.libboost import _replacer
 
 # pin_compatible("numpy"...)
@@ -16,7 +16,7 @@ class Numpy2Migrator(MiniMigrator):
         lines = attrs["raw_meta_yaml"].splitlines()
         has_pcn = any(pat_pcn.search(line) for line in lines)
         # filter() returns True if we _don't_ want to migrate
-        return (not (has_pcn)) or _skip_due_to_schema(
+        return (not (has_pcn)) or skip_migrator_due_to_schema(
             attrs, self.allowed_schema_versions
         )
 

--- a/conda_forge_tick/migrators/pip_check.py
+++ b/conda_forge_tick/migrators/pip_check.py
@@ -6,7 +6,7 @@ from typing import Any
 import ruamel.yaml
 from ruamel.yaml import YAML
 
-from conda_forge_tick.migrators.core import MiniMigrator, _skip_due_to_schema
+from conda_forge_tick.migrators.core import MiniMigrator, skip_migrator_due_to_schema
 from conda_forge_tick.os_utils import pushd
 
 if typing.TYPE_CHECKING:
@@ -153,7 +153,7 @@ class PipCheckMigrator(MiniMigrator):
             or attrs["requirements"].get("build", set())
             or set()
         )
-        return "python" not in build_host or _skip_due_to_schema(
+        return "python" not in build_host or skip_migrator_due_to_schema(
             attrs, self.allowed_schema_versions
         )
 

--- a/conda_forge_tick/migrators/pip_wheel_dep.py
+++ b/conda_forge_tick/migrators/pip_wheel_dep.py
@@ -9,7 +9,7 @@ import requests
 from ruamel.yaml import YAML
 
 from conda_forge_tick.lazy_json_backends import CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL
-from conda_forge_tick.migrators.core import MiniMigrator, _skip_due_to_schema
+from conda_forge_tick.migrators.core import MiniMigrator, skip_migrator_due_to_schema
 from conda_forge_tick.os_utils import pushd
 from conda_forge_tick.utils import get_keys_default
 
@@ -76,7 +76,7 @@ class PipWheelMigrator(MiniMigrator):
 
         if wheel_url is None:
             return True
-        return False or _skip_due_to_schema(attrs, self.allowed_schema_versions)
+        return False or skip_migrator_due_to_schema(attrs, self.allowed_schema_versions)
 
     def determine_wheel(self, source_url: str, version: str):
         pkg = source_url.split("/")[6]

--- a/conda_forge_tick/migrators/pypi_org.py
+++ b/conda_forge_tick/migrators/pypi_org.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-from conda_forge_tick.migrators.core import MiniMigrator, _skip_due_to_schema
+from conda_forge_tick.migrators.core import MiniMigrator, skip_migrator_due_to_schema
 from conda_forge_tick.migrators.libboost import _replacer
 
 # detect "url: https://pypi.io/packages/..."
@@ -14,7 +14,7 @@ class PyPIOrgMigrator(MiniMigrator):
         lines = attrs["raw_meta_yaml"].splitlines()
         has_pypi_io = any(pat_pypi_io.search(line) for line in lines)
         # filter() returns True if we _don't_ want to migrate
-        return (not has_pypi_io) or _skip_due_to_schema(
+        return (not has_pypi_io) or skip_migrator_due_to_schema(
             attrs, self.allowed_schema_versions
         )
 

--- a/conda_forge_tick/migrators/qt_to_qt_main.py
+++ b/conda_forge_tick/migrators/qt_to_qt_main.py
@@ -1,6 +1,6 @@
 import os
 
-from conda_forge_tick.migrators.core import MiniMigrator, _skip_due_to_schema
+from conda_forge_tick.migrators.core import MiniMigrator, skip_migrator_due_to_schema
 
 
 def _parse_qt(lines):
@@ -16,7 +16,7 @@ def _parse_qt(lines):
 class QtQtMainMigrator(MiniMigrator):
     def filter(self, attrs, not_bad_str_start=""):
         host_req = (attrs.get("requirements", {}) or {}).get("host", set()) or set()
-        return "qt" not in host_req or _skip_due_to_schema(
+        return "qt" not in host_req or skip_migrator_due_to_schema(
             attrs, self.allowed_schema_versions
         )
 

--- a/conda_forge_tick/migrators/r_ucrt.py
+++ b/conda_forge_tick/migrators/r_ucrt.py
@@ -2,7 +2,7 @@ import re
 import typing
 from typing import Any
 
-from conda_forge_tick.migrators.core import MiniMigrator, _skip_due_to_schema
+from conda_forge_tick.migrators.core import MiniMigrator, skip_migrator_due_to_schema
 from conda_forge_tick.os_utils import pushd
 
 if typing.TYPE_CHECKING:
@@ -49,7 +49,7 @@ class RUCRTCleanup(MiniMigrator):
                 w in attrs.get("raw_meta_yaml", "")
                 for w in ["native", "- posix", "- m2w64"]
             )
-        ) or _skip_due_to_schema(attrs, self.allowed_schema_versions)
+        ) or skip_migrator_due_to_schema(attrs, self.allowed_schema_versions)
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
         with pushd(recipe_dir):

--- a/conda_forge_tick/migrators/use_pip.py
+++ b/conda_forge_tick/migrators/use_pip.py
@@ -4,7 +4,7 @@ from typing import Any
 from conda_forge_tick.os_utils import pushd
 from conda_forge_tick.utils import as_iterable
 
-from .core import MiniMigrator, _skip_due_to_schema
+from .core import MiniMigrator, skip_migrator_due_to_schema
 
 if typing.TYPE_CHECKING:
     from ..migrators_types import AttrsTypedDict
@@ -20,9 +20,9 @@ class PipMigrator(MiniMigrator):
         scripts = as_iterable(
             attrs.get("meta_yaml", {}).get("build", {}).get("script", []),
         )
-        return (not bool(set(self.bad_install) & set(scripts))) or _skip_due_to_schema(
-            attrs, self.allowed_schema_versions
-        )
+        return (
+            not bool(set(self.bad_install) & set(scripts))
+        ) or skip_migrator_due_to_schema(attrs, self.allowed_schema_versions)
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
         with pushd(recipe_dir):


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR fixes another error in the status page for the `noarch: python` min migration.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
