### PR TITLE
fix: only update PR if needed

### DIFF
--- a/conda_forge_tick/events/pr_events.py
+++ b/conda_forge_tick/events/pr_events.py
@@ -39,19 +39,19 @@ def react_to_pr(uid: str, dry_run: bool = False) -> None:
 
             with pr_json:
                 pr_data = close_out_labels(pr_json, dry_run=dry_run)
-                if not dry_run and pr_data is not None:
+                if not dry_run and pr_data is not None and pr_data != pr_json.data:
                     updated_pr = True
                     pr_json.update(pr_data)
 
             with pr_json:
                 pr_data = refresh_pr(pr_json, dry_run=dry_run)
-                if not dry_run and pr_data is not None:
+                if not dry_run and pr_data is not None and pr_data != pr_json.data:
                     updated_pr = True
                     pr_json.update(pr_data)
 
             with pr_json:
                 pr_data = close_out_dirty_prs(pr_json, dry_run=dry_run)
-                if not dry_run and pr_data is not None:
+                if not dry_run and pr_data is not None and pr_data != pr_json.data:
                     updated_pr = True
                     pr_json.update(pr_data)
 


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR only updates the event if the data has changed.

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
