### PR TITLE
feat: update PR jobs to run once a day and put status page on a loop

### DIFF
--- a/.github/workflows/bot-prs.yml
+++ b/.github/workflows/bot-prs.yml
@@ -3,7 +3,7 @@ name: bot-prs
 on:
   workflow_dispatch: null
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '15 12 * * *'
 
 concurrency: prs
 
@@ -119,22 +119,6 @@ jobs:
         run: |
           cd cf-scripts
           python autotick-bot/stop_me_if_needed.py
-
-      - name: trigger next job
-        uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
-        if: github.ref == 'refs/heads/main' && ! cancelled() && ! failure() && ! env.CI_SKIP
-        with:
-          workflow: bot-prs
-          ref: ${{ github.event.ref }}
-          token: ${{ secrets.AUTOTICK_BOT_TOKEN }}
-
-      - name: trigger status page
-        uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
-        if: github.ref == 'refs/heads/main' && ! cancelled() && ! failure() && ! env.CI_SKIP
-        with:
-          workflow: bot-update-status-page
-          ref: ${{ github.event.ref }}
-          token: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: bump on fail
         if: github.ref == 'refs/heads/main' && failure() && ! env.CI_SKIP

--- a/.github/workflows/bot-update-status-page.yml
+++ b/.github/workflows/bot-update-status-page.yml
@@ -2,6 +2,8 @@ name: bot-update-status-page
 
 on:
   workflow_dispatch: null
+  schedule:
+    - cron: '*/15 * * * *'
 
 concurrency: update-status-page
 
@@ -64,6 +66,14 @@ jobs:
         env:
           BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
+
+      - name: trigger status page
+        uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
+        if: github.ref == 'refs/heads/main' && ! cancelled() && ! failure() && ! env.CI_SKIP
+        with:
+          workflow: bot-update-status-page
+          ref: ${{ github.event.ref }}
+          token: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: bump on fail
         if: github.ref == 'refs/heads/main' && failure() && ! env.CI_SKIP


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR updates the PR jobs to run once a day and puts the status page on a loop.

It is the counterpart to https://github.com/conda-forge/conda-forge-webservices/pull/794 and should be merged after that one. With both changes, the bot should react to PR events and has a once-a-day loop to cleanup any missed events.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
