### PR TITLE
refactor: move run exports adjustment to global op when making graph

### DIFF
--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -286,7 +286,7 @@ def _make_graph_metadata(gx: nx.DiGraph):
         attrs["strong_exports"] = strong_exports
 
 
-def _add_run_exports(gx: nx.DiGraph, nodes_to_update: set(str)):
+def _add_run_exports(gx: nx.DiGraph, nodes_to_update: set[str]):
     with LazyJson("graph_metadata.json") as attrs:
         outputs_lut = attrs.get("outputs_lut", None)
         strong_exports = attrs.get("strong_exports", None)


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR moves the run exports adjustment to the nodes to the global graph making stage. It is preparation for pushing updates to node metadata via events.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
