### PR TITLE
fix: use ordering of PRs ignoring bad ones

### DIFF
--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -1,7 +1,6 @@
 import copy
 import logging
 import os
-import random
 import re
 import time
 import typing
@@ -388,54 +387,6 @@ class MigrationYaml(GraphMigrator):
         n = super().migrator_uid(attrs)
         n["name"] = self.name
         return n
-
-    def order(
-        self,
-        graph: nx.DiGraph,
-        total_graph: nx.DiGraph,
-    ) -> Sequence["PackageName"]:
-        """Run the order by number of decedents, ties are resolved by package name"""
-
-        if hasattr(self, "name"):
-            assert isinstance(self.name, str)
-            migrator_name = self.name.lower().replace(" ", "")
-        else:
-            migrator_name = self.__class__.__name__.lower()
-
-        def _not_has_error(node):
-            if migrator_name in total_graph.nodes[node]["payload"].get(
-                "pr_info",
-                {},
-            ).get("pre_pr_migrator_status", {}) and (
-                total_graph.nodes[node]["payload"]
-                .get("pr_info", {})
-                .get(
-                    "pre_pr_migrator_attempts",
-                    {},
-                )
-                .get(
-                    migrator_name,
-                    3,
-                )
-                >= self.max_solver_attempts
-            ):
-                return 0
-            else:
-                return 1
-
-        return sorted(
-            graph,
-            key=lambda x: (
-                _not_has_error(x),
-                (
-                    random.uniform(0, 1)
-                    if not _not_has_error(x)
-                    else len(nx.descendants(total_graph, x))
-                ),
-                x,
-            ),
-            reverse=True,
-        )
 
 
 class MigrationYamlCreator(Migrator):

--- a/conda_forge_tick/migrators/replacement.py
+++ b/conda_forge_tick/migrators/replacement.py
@@ -2,7 +2,7 @@ import logging
 import os
 import re
 import typing
-from typing import Any, Sequence
+from typing import Any
 
 import networkx as nx
 
@@ -77,25 +77,6 @@ class Replacement(Migrator):
         self.name = f"{old_pkg}-to-{new_pkg}"
 
         self._reset_effective_graph()
-
-    def order(
-        self,
-        graph: nx.DiGraph,
-        total_graph: nx.DiGraph,
-    ) -> Sequence["PackageName"]:
-        """Order to run migrations in
-
-        Parameters
-        ----------
-        graph : nx.DiGraph
-            The graph of migratable PRs
-
-        Returns
-        -------
-        graph : nx.DiGraph
-            The ordered graph.
-        """
-        return graph
 
     def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
         requirements = attrs.get("requirements", {})


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR ensures that all migrations ignore bad PRs when issuing things.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

fixes #3272 
