### PR TITLE
fix: add conflicts when pull fails

### DIFF
--- a/autotick-bot/bump_bot_team.py
+++ b/autotick-bot/bump_bot_team.py
@@ -17,7 +17,7 @@ issue = None
 tried = 0
 for _issue in repo.get_issues():
     tried += 1
-    if issue.title == issue_title:
+    if _issue.title == issue_title:
         issue = _issue
         break
     if tried > max_try:

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -225,6 +225,8 @@ class Migrator:
 
     rerender = True
 
+    max_solver_attempts = 3
+
     # bump this if the migrator object needs a change mid migration
     migrator_version = 0
 


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR fixes an issue where conflicts happen that can be resolved if the files are committed. It is due to the batching.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

closes #3276 