### PR TITLE
Separate Bot User GitHub Tokens from regro GitHub Tokens

### DIFF
--- a/.github/workflows/bot-bot.yml
+++ b/.github/workflows/bot-bot.yml
@@ -58,6 +58,7 @@ jobs:
           conda-forge-tick auto-tick
         env:
           BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           MEMORY_LIMIT_GB: 7
           CF_TICK_GRAPH_DATA_BACKENDS: "${{ vars.CF_TICK_GRAPH_DATA_BACKENDS }}"
@@ -79,7 +80,7 @@ jobs:
           export RUN_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           conda-forge-tick deploy-to-github
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
 
       - name: bump on fail
@@ -88,7 +89,7 @@ jobs:
           export ACTION_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           python cf-scripts/autotick-bot/bump_bot_team.py
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           ACTION_NAME: ${{ github.workflow }}
 

--- a/.github/workflows/bot-bot.yml
+++ b/.github/workflows/bot-bot.yml
@@ -45,8 +45,6 @@ jobs:
         if: success() && ! env.CI_SKIP
         run: |
           source cf-scripts/autotick-bot/install_bot_code.sh
-        env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: run migrations
         if: success() && ! env.CI_SKIP

--- a/.github/workflows/bot-events.yml
+++ b/.github/workflows/bot-events.yml
@@ -83,6 +83,7 @@ jobs:
             --event='${{ inputs.event }}' \
             --uid='${{ inputs.uid }}'
         env:
+          BOT_TOKEN : ${{ secrets.AUTOTICK_BOT_TOKEN }}
           REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           # emptied at the beginning and end of each run, used by Python tempdir

--- a/.github/workflows/bot-events.yml
+++ b/.github/workflows/bot-events.yml
@@ -65,8 +65,6 @@ jobs:
             --no-clone-graph \
             --no-clean-disk-space \
             --no-pull-container
-        env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: react to event
         if: success() && ! env.CI_SKIP

--- a/.github/workflows/bot-events.yml
+++ b/.github/workflows/bot-events.yml
@@ -83,7 +83,7 @@ jobs:
             --event='${{ inputs.event }}' \
             --uid='${{ inputs.uid }}'
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           # emptied at the beginning and end of each run, used by Python tempdir
           TMPDIR: ${{ runner.temp }}

--- a/.github/workflows/bot-feedstocks.yml
+++ b/.github/workflows/bot-feedstocks.yml
@@ -52,7 +52,7 @@ jobs:
 
           conda-forge-tick gather-all-feedstocks
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: deploy
         if: github.ref == 'refs/heads/main' && ! cancelled() && ! env.CI_SKIP
@@ -62,7 +62,7 @@ jobs:
           export RUN_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           conda-forge-tick deploy-to-github
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
 
       - name: bump on fail
@@ -71,6 +71,6 @@ jobs:
           export ACTION_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           python cf-scripts/autotick-bot/bump_bot_team.py
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           ACTION_NAME: ${{ github.workflow }}

--- a/.github/workflows/bot-feedstocks.yml
+++ b/.github/workflows/bot-feedstocks.yml
@@ -44,8 +44,6 @@ jobs:
         if: success() && ! env.CI_SKIP
         run: |
           source cf-scripts/autotick-bot/install_bot_code.sh
-        env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: feedstocks
         if: success() && ! env.CI_SKIP

--- a/.github/workflows/bot-feedstocks.yml
+++ b/.github/workflows/bot-feedstocks.yml
@@ -52,7 +52,7 @@ jobs:
 
           conda-forge-tick gather-all-feedstocks
         env:
-          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: deploy
         if: github.ref == 'refs/heads/main' && ! cancelled() && ! env.CI_SKIP

--- a/.github/workflows/bot-make-graph.yml
+++ b/.github/workflows/bot-make-graph.yml
@@ -45,8 +45,6 @@ jobs:
         if: success() && ! env.CI_SKIP
         run: |
           source cf-scripts/autotick-bot/install_bot_code.sh
-        env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: make graph
         if: success() && ! env.CI_SKIP

--- a/.github/workflows/bot-make-graph.yml
+++ b/.github/workflows/bot-make-graph.yml
@@ -66,7 +66,7 @@ jobs:
           export RUN_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           conda-forge-tick deploy-to-github
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
 
       - name: trigger next job
@@ -83,6 +83,6 @@ jobs:
           export ACTION_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           python cf-scripts/autotick-bot/bump_bot_team.py
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           ACTION_NAME: ${{ github.workflow }}

--- a/.github/workflows/bot-make-migrators.yml
+++ b/.github/workflows/bot-make-migrators.yml
@@ -64,7 +64,7 @@ jobs:
           export RUN_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           conda-forge-tick deploy-to-github
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
 
       - name: trigger next job
@@ -81,6 +81,6 @@ jobs:
           export ACTION_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           python cf-scripts/autotick-bot/bump_bot_team.py
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           ACTION_NAME: ${{ github.workflow }}

--- a/.github/workflows/bot-make-migrators.yml
+++ b/.github/workflows/bot-make-migrators.yml
@@ -45,8 +45,6 @@ jobs:
         if: success() && ! env.CI_SKIP
         run: |
           source cf-scripts/autotick-bot/install_bot_code.sh
-        env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: make migrators
         if: success() && ! env.CI_SKIP

--- a/.github/workflows/bot-migrate-schema.yml
+++ b/.github/workflows/bot-migrate-schema.yml
@@ -74,7 +74,7 @@ jobs:
           export RUN_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           conda-forge-tick deploy-to-github
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
 
       - name: bump on fail
@@ -83,6 +83,6 @@ jobs:
           export ACTION_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           python cf-scripts/autotick-bot/bump_bot_team.py
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           ACTION_NAME: ${{ github.workflow }}

--- a/.github/workflows/bot-migrate-schema.yml
+++ b/.github/workflows/bot-migrate-schema.yml
@@ -49,8 +49,6 @@ jobs:
         if: success() && ! env.CI_SKIP
         run: |
           source cf-scripts/autotick-bot/install_bot_code.sh
-        env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: update nodes
         if: success() && ! env.CI_SKIP

--- a/.github/workflows/bot-prs.yml
+++ b/.github/workflows/bot-prs.yml
@@ -51,8 +51,6 @@ jobs:
         if: success() && ! env.CI_SKIP
         run: |
           source cf-scripts/autotick-bot/install_bot_code.sh
-        env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: update prs
         if: success() && ! env.CI_SKIP

--- a/.github/workflows/bot-prs.yml
+++ b/.github/workflows/bot-prs.yml
@@ -61,6 +61,7 @@ jobs:
           conda-forge-tick update-prs --job=${BOT_JOB} --n-jobs=${NUM_BOT_JOBS}
         env:
           BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           BOT_JOB: ${{ matrix.job_num }}
           CF_TICK_GRAPH_DATA_BACKENDS: "${{ vars.CF_TICK_GRAPH_DATA_BACKENDS }}"
@@ -74,7 +75,7 @@ jobs:
           export RUN_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           conda-forge-tick deploy-to-github
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
 
       - name: bump on fail
@@ -83,7 +84,7 @@ jobs:
           export ACTION_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           python cf-scripts/autotick-bot/bump_bot_team.py
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           ACTION_NAME: ${{ github.workflow }}
 
@@ -127,6 +128,6 @@ jobs:
           export ACTION_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           python cf-scripts/autotick-bot/bump_bot_team.py
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           ACTION_NAME: ${{ github.workflow }}

--- a/.github/workflows/bot-pypi-mapping.yml
+++ b/.github/workflows/bot-pypi-mapping.yml
@@ -52,8 +52,6 @@ jobs:
           pushd cf-graph
 
           conda-forge-tick make-import-to-package-mapping
-        env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: build pypi mapping
         if: success() && ! env.CI_SKIP
@@ -61,8 +59,6 @@ jobs:
           pushd cf-graph
 
           conda-forge-tick make-mappings
-        env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: deploy
         if: github.ref == 'refs/heads/main' && ! cancelled() && ! env.CI_SKIP
@@ -72,7 +68,7 @@ jobs:
           export RUN_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           conda-forge-tick deploy-to-github
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
 
       - name: bump on fail
@@ -81,6 +77,6 @@ jobs:
           export ACTION_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           python cf-scripts/autotick-bot/bump_bot_team.py
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           ACTION_NAME: ${{ github.workflow }}

--- a/.github/workflows/bot-pypi-mapping.yml
+++ b/.github/workflows/bot-pypi-mapping.yml
@@ -45,8 +45,6 @@ jobs:
         if: success() && ! env.CI_SKIP
         run: |
           source cf-scripts/autotick-bot/install_bot_code.sh
-        env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: build import to package mapping
         if: success() && ! env.CI_SKIP

--- a/.github/workflows/bot-update-nodes.yml
+++ b/.github/workflows/bot-update-nodes.yml
@@ -75,7 +75,7 @@ jobs:
           export RUN_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           conda-forge-tick deploy-to-github
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
 
       - name: bump on fail
@@ -84,6 +84,6 @@ jobs:
           export ACTION_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           python cf-scripts/autotick-bot/bump_bot_team.py
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           ACTION_NAME: ${{ github.workflow }}

--- a/.github/workflows/bot-update-nodes.yml
+++ b/.github/workflows/bot-update-nodes.yml
@@ -51,8 +51,6 @@ jobs:
         if: success() && ! env.CI_SKIP
         run: |
           source cf-scripts/autotick-bot/install_bot_code.sh
-        env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: update nodes
         if: success() && ! env.CI_SKIP

--- a/.github/workflows/bot-update-status-page.yml
+++ b/.github/workflows/bot-update-status-page.yml
@@ -44,8 +44,6 @@ jobs:
         if: success() && ! env.CI_SKIP
         run: |
           source cf-scripts/autotick-bot/install_bot_code.sh
-        env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: update status page
         if: success() && ! env.CI_SKIP

--- a/.github/workflows/bot-update-status-page.yml
+++ b/.github/workflows/bot-update-status-page.yml
@@ -51,8 +51,6 @@ jobs:
           pushd cf-graph
 
           conda-forge-tick make-status-report
-        env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: deploy
         if: github.ref == 'refs/heads/main' && ! cancelled() && ! env.CI_SKIP
@@ -62,7 +60,7 @@ jobs:
           export RUN_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           conda-forge-tick deploy-to-github
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
 
       - name: trigger status page
@@ -79,6 +77,6 @@ jobs:
           export ACTION_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           python cf-scripts/autotick-bot/bump_bot_team.py
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           ACTION_NAME: ${{ github.workflow }}

--- a/.github/workflows/bot-versions.yml
+++ b/.github/workflows/bot-versions.yml
@@ -49,8 +49,6 @@ jobs:
         if: success() && ! env.CI_SKIP
         run: |
           source cf-scripts/autotick-bot/install_bot_code.sh
-        env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
       - name: get versions
         if: success() && ! env.CI_SKIP

--- a/.github/workflows/bot-versions.yml
+++ b/.github/workflows/bot-versions.yml
@@ -69,7 +69,7 @@ jobs:
           export RUN_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           conda-forge-tick deploy-to-github
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
 
       - name: bump on fail
@@ -78,6 +78,6 @@ jobs:
           export ACTION_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
           python cf-scripts/autotick-bot/bump_bot_team.py
         env:
-          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          REGRO_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           ACTION_NAME: ${{ github.workflow }}

--- a/.github/workflows/tests-reusable.yml
+++ b/.github/workflows/tests-reusable.yml
@@ -129,6 +129,7 @@ jobs:
         run: |
           export TEST_BOT_TOKEN_VAL=unpassword
           export BOT_TOKEN=${TEST_BOT_TOKEN_VAL}
+          export REGRO_TOKEN=${TEST_REGRO_TOKEN_VAL}
           # note: we do not use pytest-xdist (-n auto) here for now because they interfere with hiding the
           # MONGODB_CONNECTION_STRING sensitive environment variable
           if [[ -f .test_durations ]]; then

--- a/README.md
+++ b/README.md
@@ -234,7 +234,8 @@ If your migrator needs special configuration, you should write a new factory fun
 - `TIMEOUT`: set to the number of seconds to wait before timing out the bot
 - `RUN_URL`: set to the URL of the CI build (now set to a GHA run URL)
 - `MEMORY_LIMIT_GB`: set to the memory limit in GB for the bot
-- `BOT_TOKEN`: a GitHub token for the bot user
+- `BOT_TOKEN`: a GitHub token for the bot user, having access to the `regro-cf-autotick-bot` GitHub account
+- `REGRO_TOKEN`: a GitHub token that has permission to access the `regro` organization (currently identical with `BOT_TOKEN` in production but needed to use fine-grained tokens)
 - `CF_FEEDSTOCK_OPS_CONTAINER_NAME`: the name of the container to use in the bot, otherwise defaults to `ghcr.io/regro/conda-forge-tick`
 - `CF_FEEDSTOCK_OPS_CONTAINER_TAG`: set this to override the default container tag used in production runs, otherwise the value of `__version__` is used
 - `CF_TICK_LIVE_TEST`: set to `true` to enable tests of the bot that require a working GitHub API token for `BOT_TOKEN`

--- a/autotick-bot/bump_bot_team.py
+++ b/autotick-bot/bump_bot_team.py
@@ -8,7 +8,7 @@ import github
 today = datetime.today().strftime("%Y-%m-%d")
 issue_title = f"[{today}] failed job {os.environ['ACTION_NAME']}"
 
-gh = github.Github(os.environ["BOT_TOKEN"])
+gh = github.Github(os.environ["REGRO_TOKEN"])
 repo = gh.get_repo("regro/cf-scripts")
 
 # find any issues from today, if any

--- a/conda_forge_tick/all_feedstocks.py
+++ b/conda_forge_tick/all_feedstocks.py
@@ -3,7 +3,7 @@ from typing import List
 
 import tqdm
 
-from conda_forge_tick.git_utils import github_client
+from conda_forge_tick.git_utils import pygithub_client_bot_user
 
 from .lazy_json_backends import dump, load
 
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_all_feedstocks_from_github():
-    gh = github_client()
+    gh = pygithub_client_bot_user()
 
     org = gh.get_organization("conda-forge")
     archived = set()

--- a/conda_forge_tick/deploy.py
+++ b/conda_forge_tick/deploy.py
@@ -138,12 +138,12 @@ def _deploy_batch(*, files_to_add, batch, n_added, max_per_batch=200):
                         "git",
                         "push",
                         "https://{token}@github.com/{deploy_repo}.git".format(
-                            token=env.get("BOT_TOKEN", ""),
+                            token=env.get("REGRO_TOKEN", ""),
                             deploy_repo="regro/cf-graph-countyfair",
                         ),
                         "master",
                     ],
-                    token=env.get("BOT_TOKEN", ""),
+                    token=env.get("REGRO_TOKEN", ""),
                 )
                 _flush_io()
             num_try += 1

--- a/conda_forge_tick/env_management.py
+++ b/conda_forge_tick/env_management.py
@@ -7,6 +7,7 @@ class SensitiveEnv:
         "GITHUB_TOKEN",
         "GH_TOKEN",
         "BOT_TOKEN",
+        "REGRO_TOKEN",
         "MONGODB_CONNECTION_STRING",
     ]
 

--- a/conda_forge_tick/events/push_events.py
+++ b/conda_forge_tick/events/push_events.py
@@ -4,7 +4,7 @@ import tempfile
 import networkx as nx
 import requests
 
-from conda_forge_tick.git_utils import github_client
+from conda_forge_tick.git_utils import pygithub_client_bot_user
 from conda_forge_tick.lazy_json_backends import (
     LazyJson,
     lazy_json_override_backends,
@@ -33,7 +33,7 @@ def _get_archived_feedstocks():
 def _update_feedstocks(name: str) -> None:
     feedstocks = copy.deepcopy(_get_feedstocks())
 
-    gh = github_client()
+    gh = pygithub_client_bot_user()
     repo = gh.get_repo(f"conda-forge/{name}-feedstock")
     changed = False
     if repo.archived:

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -953,7 +953,7 @@ def _get_pth_blob_sha_and_content(pth, gh):
 
 
 def _push_lazy_json_via_gh_api(lzj: LazyJson):
-    from conda_forge_tick.git_utils import github_client
+    from conda_forge_tick.git_utils import pygithub_client_regro
     from conda_forge_tick.utils import get_bot_run_url
 
     json_data = lzj.data
@@ -969,7 +969,7 @@ def _push_lazy_json_via_gh_api(lzj: LazyJson):
     ntries = 10
     for tr in range(ntries):
         try:
-            gh = github_client()
+            gh = pygithub_client_regro()
             repo = gh.get_repo("regro/cf-graph-countyfair")
 
             sha, cnt = _get_pth_blob_sha_and_content(pth, gh)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,10 @@ from conda_forge_tick import global_sensitive_env
 @pytest.fixture
 def env_setup():
     if "TEST_BOT_TOKEN_VAL" not in os.environ:
-        old_pwd = os.environ.pop("BOT_TOKEN", None)
+        old_bot_token = os.environ.pop("BOT_TOKEN", None)
+        old_regro_token = os.environ.pop("REGRO_TOKEN", None)
         os.environ["BOT_TOKEN"] = "unpassword"
+        os.environ["REGRO_TOKEN"] = "unpassword"
         global_sensitive_env.hide_env_vars()
 
     old_pwd2 = os.environ.pop("pwd", None)
@@ -21,8 +23,10 @@ def env_setup():
 
     if "TEST_BOT_TOKEN_VAL" not in os.environ:
         global_sensitive_env.reveal_env_vars()
-        if old_pwd:
-            os.environ["BOT_TOKEN"] = old_pwd
+        if old_bot_token:
+            os.environ["BOT_TOKEN"] = old_bot_token
+        if old_regro_token:
+            os.environ["REGRO_TOKEN"] = old_regro_token
 
     if old_pwd2:
         os.environ["pwd"] = old_pwd2

--- a/tests/test_env_management.py
+++ b/tests/test_env_management.py
@@ -5,24 +5,32 @@ from conda_forge_tick.env_management import SensitiveEnv
 
 def test_simple_sensitive_env(env_setup):
     os.environ["BOT_TOKEN"] = "hi"
+    os.environ["REGRO_TOKEN"] = "there"
     s = SensitiveEnv()
 
     s.hide_env_vars()
     assert "BOT_TOKEN" not in os.environ
+    assert "REGRO_TOKEN" not in os.environ
 
     s.reveal_env_vars()
     assert "BOT_TOKEN" in os.environ
+    assert "REGRO_TOKEN" in os.environ
     assert os.environ["BOT_TOKEN"] == "hi"
+    assert os.environ["REGRO_TOKEN"] == "there"
 
 
 def test_ctx_sensitive_env(env_setup):
     os.environ["BOT_TOKEN"] = "hi"
+    os.environ["REGRO_TOKEN"] = "there"
     s = SensitiveEnv()
 
     with s.sensitive_env():
         assert "BOT_TOKEN" in os.environ
+        assert "REGRO_TOKEN" in os.environ
         assert os.environ["BOT_TOKEN"] == "hi"
+        assert os.environ["REGRO_TOKEN"] == "there"
     assert "BOT_TOKEN" not in os.environ
+    assert "REGRO_TOKEN" not in os.environ
 
 
 def test_double_sensitive_env(env_setup):

--- a/tests/test_lazy_json_backends.py
+++ b/tests/test_lazy_json_backends.py
@@ -14,7 +14,7 @@ import pytest
 
 import conda_forge_tick
 import conda_forge_tick.utils
-from conda_forge_tick.git_utils import github_client
+from conda_forge_tick.git_utils import pygithub_client_regro
 from conda_forge_tick.lazy_json_backends import (
     CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL,
     LAZY_JSON_BACKENDS,
@@ -805,7 +805,7 @@ def test_push_lazy_json_via_gh_api(recursive):
                 lzj["uid"] = uid
                 lzj["sub_lzj"] = lzj_sub
 
-            gh = github_client()
+            gh = pygithub_client_regro()
             repo = gh.get_repo("regro/cf-graph-countyfair")
 
             push_lazy_json_via_gh_api(lzj, recursive=recursive)
@@ -885,7 +885,7 @@ def test_push_lazy_json_via_gh_api_nopush():
             with lzj:
                 lzj["uid"] = uid
 
-            gh = github_client()
+            gh = pygithub_client_regro()
             repo = gh.get_repo("regro/cf-graph-countyfair")
 
             push_lazy_json_via_gh_api(lzj)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,8 +1,13 @@
 import os
 import subprocess
 
+import pytest
 
-def test_env_is_protected_against_malicious_recipes(tmpdir, caplog, env_setup):
+
+@pytest.mark.parametrize("token_env_variable", ["BOT_TOKEN", "REGRO_TOKEN"])
+def test_env_is_protected_against_malicious_recipes(
+    tmpdir, caplog, env_setup, token_env_variable: str
+):
     import logging
 
     from conda_forge_tick.feedstock_parser import populate_feedstock_attributes
@@ -16,7 +21,7 @@ def test_env_is_protected_against_malicious_recipes(tmpdir, caplog, env_setup):
 
     source:
       url:
-        - https://{{ os.environ["BOT_TOKEN"][0] }}/{{ os.environ["BOT_TOKEN"][1:] }}
+        - https://{{ os.environ["*TOKEN_ENV_VARIABLE*"][0] }}/{{ os.environ["*TOKEN_ENV_VARIABLE*"][1:] }}
         - {{ os.environ['pwd'] }}
       sha256: dca77e463c56d42bbf915197c9b95e98913c85bef150d2e1dd18626b8c2c9c32
     build:
@@ -49,8 +54,8 @@ def test_env_is_protected_against_malicious_recipes(tmpdir, caplog, env_setup):
     extra:
       recipe-maintainers:
         - kthyng
-        - {{ os.environ["BOT_TOKEN"] }}
-    """  # noqa
+        - {{ os.environ["*TOKEN_ENV_VARIABLE*"] }}
+    """.replace("*TOKEN_ENV_VARIABLE*", token_env_variable)  # noqa
     caplog.set_level(
         logging.DEBUG,
         logger="conda_forge_tick.migrators.version",


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->
Our proposed integration tests for #261 need to interact with the GitHub API with multiple different identities in a staging environment. Since nowadays, fine-grained personal access tokens are [recommended by GitHub whenever possible](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#types-of-personal-access-tokens), they clearly separate access to different GitHub users/organizations.

This means the bot needs to support using different access tokens depending on which GitHub user/org it is interacting with. This PR contributes the necessary changes.

Essentially, `BOT_TOKEN` can now be filled with a fine-grained access token for `regro-cf-autotick-bot` and `REGRO_TOKEN` with a fine-grained token for `regro`.

Note that these changes do not prevent from continuing to run the bot with a classic access token in production.

I carefully reviewed the source code to verify that the correct tokens are available and used everywhere. It would be helpful if you, @beckermr, could double-check.

I leave it up to you if you also want to update the production tokens to fine-grained tokens together with these changes. It involves more risk of breaking the bot but would ensure that future source code changes correctly differentiate between the two tokens. We can also wait for the integration tests to have more assurance here. 

@pavelzw

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
