### PR TITLE
fix: use secrets random numbers to get true random numbers and update only a fraction of versions

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -3,7 +3,6 @@ import glob
 import json
 import logging
 import os
-import random
 import textwrap
 import time
 import traceback
@@ -78,9 +77,6 @@ logger = logging.getLogger(__name__)
 BOT_HOME_DIR: str = os.getcwd()
 START_TIME = None
 TIMEOUT = int(os.environ.get("TIMEOUT", 600))
-
-# migrator runs on loop so avoid any seeds at current time should that happen
-random.seed(os.urandom(64))
 
 
 def _set_pre_pr_migrator_error(attrs, migrator_name, error_str, *, is_version):

--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -1,8 +1,7 @@
 import hashlib
 import logging
-import os
-import random
 import re
+import secrets
 import time
 import typing
 from collections import defaultdict
@@ -33,7 +32,7 @@ from .utils import as_iterable, dump_graph, load_graph, sanitize_string
 logger = logging.getLogger(__name__)
 
 pin_sep_pat = re.compile(r" |>|<|=|\[")
-random.seed(os.urandom(64))
+RNG = secrets.SystemRandom()
 
 RANDOM_FRAC_TO_UPDATE = 0.1
 
@@ -190,7 +189,7 @@ def _build_graph_process_pool(
         futures = {
             pool.submit(get_attrs, name, mark_not_archived=mark_not_archived): name
             for name in names
-            if random.uniform(0, 1) < RANDOM_FRAC_TO_UPDATE
+            if RNG.random() < RANDOM_FRAC_TO_UPDATE
         }
         logger.info("submitted all nodes")
 
@@ -221,7 +220,7 @@ def _build_graph_sequential(
     mark_not_archived=False,
 ) -> None:
     for name in names:
-        if random.uniform(0, 1) >= RANDOM_FRAC_TO_UPDATE:
+        if RNG.random() >= RANDOM_FRAC_TO_UPDATE:
             continue
 
         try:

--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -3,8 +3,8 @@ import glob
 import logging
 import os
 import pprint
-import random
 import re
+import secrets
 import time
 import typing
 from concurrent.futures import as_completed
@@ -90,10 +90,9 @@ from conda_forge_tick.utils import (
     yaml_safe_load,
 )
 
-# migrator runs on loop so avoid any seeds at current time should that happen
-random.seed(os.urandom(64))
-
 logger = logging.getLogger(__name__)
+
+RNG = secrets.SystemRandom()
 
 PR_LIMIT = 2
 MAX_PR_LIMIT = 20
@@ -820,7 +819,7 @@ def initialize_migrators(
             ),
         )
 
-        random.shuffle(pinning_migrators)
+        RNG.shuffle(pinning_migrators)
         migrators = [version_migrator] + migrators + pinning_migrators
 
     return migrators
@@ -875,8 +874,8 @@ def load_migrators(skip_paused: bool = True) -> MutableSequence[Migrator]:
     if version_migrator is None:
         raise RuntimeError("No version migrator found in the migrators directory!")
 
-    random.shuffle(pinning_migrators)
-    random.shuffle(longterm_migrators)
+    RNG.shuffle(pinning_migrators)
+    RNG.shuffle(longterm_migrators)
     migrators = [version_migrator] + migrators + pinning_migrators + longterm_migrators
 
     return migrators

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -3,8 +3,8 @@
 import copy
 import datetime
 import logging
-import random
 import re
+import secrets
 import typing
 from pathlib import Path
 from typing import Any, List, Sequence, Set
@@ -29,6 +29,8 @@ if typing.TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+RNG = secrets.SystemRandom()
 
 
 def skip_migrator_due_to_schema(
@@ -610,7 +612,7 @@ class Migrator:
             key=lambda x: (
                 _not_has_error(x),
                 (
-                    random.uniform(0, 1)
+                    RNG.random()
                     if not _not_has_error(x)
                     else len(nx.descendants(total_graph, x))
                 ),

--- a/conda_forge_tick/migrators/version.py
+++ b/conda_forge_tick/migrators/version.py
@@ -3,6 +3,7 @@ import functools
 import logging
 import os
 import random
+import secrets
 import typing
 import warnings
 from typing import Any, List, Sequence
@@ -31,6 +32,8 @@ SKIP_DEPS_NODES = [
 ]
 
 logger = logging.getLogger(__name__)
+
+RNG = secrets.SystemRandom()
 
 
 class VersionMigrationError(Exception):
@@ -454,11 +457,10 @@ class Version(Migrator):
             else:
                 return 0
 
-        random.seed()
         nodes_to_sort = list(graph.nodes)
         return sorted(
             sorted(
-                sorted(nodes_to_sort, key=lambda x: random.uniform(0, 1)),
+                sorted(nodes_to_sort, key=lambda x: RNG.random()),
                 key=_get_attempts,
             ),
             key=functools.cmp_to_key(_desc_cmp),

--- a/conda_forge_tick/update_prs.py
+++ b/conda_forge_tick/update_prs.py
@@ -1,7 +1,7 @@
 import copy
 import hashlib
 import logging
-import random
+import secrets
 from concurrent.futures._base import as_completed
 
 import github
@@ -24,6 +24,8 @@ from .utils import load_existing_graph
 
 logger = logging.getLogger(__name__)
 
+RNG = secrets.SystemRandom()
+
 NUM_GITHUB_THREADS = 2
 KEEP_PR_FRACTION = 0.5
 
@@ -42,7 +44,7 @@ def _update_pr(update_function, dry_run, gx, job, n_jobs):
     ]
 
     # this makes sure that github rate limits are dispersed
-    random.shuffle(node_ids)
+    RNG.shuffle(node_ids)
 
     with executor("thread", NUM_GITHUB_THREADS) as pool:
         for node_id in tqdm.tqdm(
@@ -56,7 +58,7 @@ def _update_pr(update_function, dry_run, gx, job, n_jobs):
                 continue
             prs = node.get("pr_info", {}).get("PRed", [])
             for i, migration in enumerate(prs):
-                if random.uniform(0, 1) >= KEEP_PR_FRACTION:
+                if RNG.random() >= KEEP_PR_FRACTION:
                     continue
 
                 pr_json = migration.get("PR", None)

--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -2,7 +2,7 @@ import functools
 import hashlib
 import logging
 import os
-import random
+import secrets
 import time
 from concurrent.futures import as_completed
 from typing import (
@@ -49,6 +49,10 @@ T = TypeVar("T")
 
 # conda_forge_tick :: cft
 logger = logging.getLogger(__name__)
+
+RNG = secrets.SystemRandom()
+
+RANDOM_FRAC_TO_UPDATE = 0.1
 
 
 def ignore_version(attrs: Mapping[str, Any], version: str) -> bool:
@@ -321,6 +325,9 @@ def _update_upstream_versions_sequential(
 ) -> None:
     node_count = 0
     for node, attrs in to_update:
+        if RNG.random() >= RANDOM_FRAC_TO_UPDATE:
+            continue
+
         # checking each node
         version_data: Dict[str, Union[Literal[False], str]] = {}
 
@@ -361,6 +368,9 @@ def _update_upstream_versions_process_pool(
             ncols=80,
             desc="submitting version update jobs",
         ):
+            if RNG.random() >= RANDOM_FRAC_TO_UPDATE:
+                continue
+
             futures.update(
                 {
                     pool.submit(get_latest_version, node, attrs, sources): (
@@ -475,7 +485,7 @@ def update_upstream_versions(
         ),
     )
 
-    random.shuffle(to_update)
+    RNG.shuffle(to_update)
 
     sources = all_version_sources() if sources is None else sources
 

--- a/tests/test_upstream_versions.py
+++ b/tests/test_upstream_versions.py
@@ -1356,6 +1356,7 @@ def test_update_upstream_versions_run_parallel_custom_sources(
     ) == ("source a", "source b")
 
 
+@mock.patch("conda_forge_tick.update_upstream_versions.RANDOM_FRAC_TO_UPDATE", new=1.1)
 @mock.patch("conda_forge_tick.update_upstream_versions.get_latest_version")
 @mock.patch("conda_forge_tick.update_upstream_versions.LazyJson")
 def test_update_upstream_versions_sequential_error(
@@ -1393,6 +1394,7 @@ class BrokenException(Exception):
         raise Exception("broken exception")
 
 
+@mock.patch("conda_forge_tick.update_upstream_versions.RANDOM_FRAC_TO_UPDATE", new=1.1)
 @mock.patch("conda_forge_tick.update_upstream_versions.get_latest_version")
 @mock.patch("conda_forge_tick.update_upstream_versions.LazyJson")
 def test_update_upstream_versions_sequential_exception_repr_exception(
@@ -1427,6 +1429,7 @@ def test_update_upstream_versions_sequential_exception_repr_exception(
     )
 
 
+@mock.patch("conda_forge_tick.update_upstream_versions.RANDOM_FRAC_TO_UPDATE", new=1.1)
 @mock.patch("conda_forge_tick.update_upstream_versions.get_latest_version")
 @mock.patch("conda_forge_tick.update_upstream_versions.LazyJson")
 def test_update_upstream_versions_sequential(
@@ -1477,6 +1480,7 @@ def test_update_upstream_versions_sequential(
     assert "# 1     - testpackage2 - 1.2.4 -> 1.2.5" in caplog.text
 
 
+@mock.patch("conda_forge_tick.update_upstream_versions.RANDOM_FRAC_TO_UPDATE", new=1.1)
 @mock.patch("conda_forge_tick.update_upstream_versions.executor")
 @mock.patch("conda_forge_tick.update_upstream_versions.LazyJson")
 def test_update_upstream_versions_process_pool(
@@ -1537,6 +1541,7 @@ def test_update_upstream_versions_process_pool(
     assert "testpackage - 2.2.3 -> 2.2.4" in caplog.text
 
 
+@mock.patch("conda_forge_tick.update_upstream_versions.RANDOM_FRAC_TO_UPDATE", new=1.1)
 @mock.patch("conda_forge_tick.update_upstream_versions.executor")
 @mock.patch("conda_forge_tick.update_upstream_versions.LazyJson")
 def test_update_upstream_versions_process_pool_exception(
@@ -1580,6 +1585,7 @@ def test_update_upstream_versions_process_pool_exception(
     assert "source a error" in caplog.text
 
 
+@mock.patch("conda_forge_tick.update_upstream_versions.RANDOM_FRAC_TO_UPDATE", new=1.1)
 @mock.patch("conda_forge_tick.update_upstream_versions.executor")
 @mock.patch("conda_forge_tick.update_upstream_versions.LazyJson")
 def test_update_upstream_versions_process_pool_exception_repr_exception(


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR switches to the `secrets` module in order to generate true random numbers. The bot relies on randomly selecting items to update and we need true randomness to ensure everything gets an update eventually. The code was using a true random set of bytes to seed a deterministic RNG, but this scheme should be better and easier to manage since there is no global state to keep track of. I also added updates to only a random fraction of nodes to the version update job to help prevent failures.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
