### PR TITLE
fix: use concurrency group to prevent same-time updates to bot-data a…

### DIFF
--- a/.github/workflows/bot-events.yml
+++ b/.github/workflows/bot-events.yml
@@ -2,6 +2,10 @@ name: bot-events
 
 run-name: 'event: ${{ inputs.event }} ${{ inputs.uid }}'
 
+concurrency:
+  group: 'event: ${{ inputs.event }} ${{ inputs.uid }}'
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
     inputs:

--- a/tests/test_upstream_versions.py
+++ b/tests/test_upstream_versions.py
@@ -1287,9 +1287,6 @@ def test_update_upstream_versions_run_sequential(
         ("testpackage3", {"payload": {"dummy": "1.2.5"}}),
     ]
 
-    # swaps the packages
-    random.seed(1)
-
     def custom_include_node(name: str, _: Mapping) -> bool:
         return name in ("testpackage", "testpackage2")
 
@@ -1307,10 +1304,11 @@ def test_update_upstream_versions_run_sequential(
     )
 
     update_sequential_mock.assert_called_once()
-    assert update_sequential_mock.call_args.args[0] == [
+    for pkg in [
         ("testpackage2", {"dummy": "1.2.4"}),
         ("testpackage", {"dummy": "1.2.3"}),
-    ]
+    ]:
+        assert pkg in update_sequential_mock.call_args.args[0]
     assert (
         tuple(source.name for source in update_sequential_mock.call_args.args[1])
         == default_sources


### PR DESCRIPTION
…nd fix flaky tests

<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

As it says in the title. The concurrency group might have the side effect of some update events getting skipped if a bunch come in back to back. Hopefully the bot can sort it out later with its cleanup cron jobs.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
