### PR TITLE
fix: try last-modified instead of etag to avoid oo updates

### DIFF
--- a/conda_forge_tick/events/pr_events.py
+++ b/conda_forge_tick/events/pr_events.py
@@ -20,9 +20,9 @@ def _react_to_pr(uid: str, dry_run: bool = False) -> None:
                 pr_data = close_out_labels(copy.deepcopy(pr_json.data), dry_run=dry_run)
                 if pr_data is not None:
                     if (
-                        "ETag" in pr_json
-                        and "ETag" in pr_data
-                        and pr_json["ETag"] != pr_data["ETag"]
+                        "Last-Modified" in pr_json
+                        and "Last-Modified" in pr_data
+                        and pr_json["Last-Modified"] != pr_data["Last-Modified"]
                     ):
                         print("closed PR due to bot-rerun label", flush=True)
                     pr_json.update(pr_data)
@@ -31,9 +31,9 @@ def _react_to_pr(uid: str, dry_run: bool = False) -> None:
                 pr_data = refresh_pr(copy.deepcopy(pr_json.data), dry_run=dry_run)
                 if pr_data is not None:
                     if (
-                        "ETag" in pr_json
-                        and "ETag" in pr_data
-                        and pr_json["ETag"] != pr_data["ETag"]
+                        "Last-Modified" in pr_json
+                        and "Last-Modified" in pr_data
+                        and pr_json["Last-Modified"] != pr_data["Last-Modified"]
                     ):
                         print("refreshed PR data", flush=True)
                     pr_json.update(pr_data)
@@ -44,9 +44,9 @@ def _react_to_pr(uid: str, dry_run: bool = False) -> None:
                 )
                 if pr_data is not None:
                     if (
-                        "ETag" in pr_json
-                        and "ETag" in pr_data
-                        and pr_json["ETag"] != pr_data["ETag"]
+                        "Last-Modified" in pr_json
+                        and "Last-Modified" in pr_data
+                        and pr_json["Last-Modified"] != pr_data["Last-Modified"]
                     ):
                         print("closed PR due to merge conflicts", flush=True)
                     pr_json.update(pr_data)

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -1233,9 +1233,10 @@ def lazy_update_pr_json(
 ) -> Union[Dict, LazyJson]:
     """Lazily update a GitHub PR.
 
-    This function will use the ETag in the GitHub API to update PR information
-    lazily. It sends the ETag to github properly and if nothing is changed on their
-    end, it simply returns the PR. Otherwise the information is refreshed.
+    This function will use the Last-Modified field in the GitHub API to update
+    PR information lazily. It sends the Last-Modified to github properly and
+    if nothing is changed on their end, it simply returns the PR. Otherwise
+    the information is refreshed.
 
     Parameters
     ----------
@@ -1243,7 +1244,7 @@ def lazy_update_pr_json(
         A dict-like object with the current PR information.
     force : bool, optional
         If True, forcibly update the PR json even if it is not out of date
-        according to the ETag. Default is False.
+        according to the Last-Modified. Default is False.
 
     Returns
     -------
@@ -1256,8 +1257,8 @@ def lazy_update_pr_json(
         "Authorization": f"token {get_bot_token()}",
         "Accept": "application/vnd.github.v3+json",
     }
-    if not force and "ETag" in pr_json:
-        hdrs["If-None-Match"] = pr_json["ETag"]
+    if not force and "Last-Modified" in pr_json:
+        hdrs["if-modified-since"] = pr_json["Last-Modified"]
 
     if "repo" not in pr_json["base"] or (
         "repo" in pr_json["base"] and "name" not in pr_json["base"]["repo"]

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -10,7 +10,7 @@ import textwrap
 import threading
 import time
 from abc import ABC, abstractmethod
-from datetime import datetime, timezone
+from datetime import datetime
 from email import utils
 from functools import cached_property
 from pathlib import Path

--- a/conda_forge_tick/update_prs.py
+++ b/conda_forge_tick/update_prs.py
@@ -81,9 +81,9 @@ def _update_pr(update_function, dry_run, gx, job, n_jobs):
                 if res:
                     succeeded_refresh += 1
                     if (
-                        "ETag" in pr_json
-                        and "ETag" in res
-                        and pr_json["ETag"] != res["ETag"]
+                        "Last-Modified" in pr_json
+                        and "Last-Modified" in res
+                        and pr_json["Last-Modified"] != res["Last-Modified"]
                     ):
                         tqdm.tqdm.write(f"Updated PR json for {name}: {res['id']}")
                     with pr_json as attrs:


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

Trying more fixes for out of order updates.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
