### PR TITLE
fix: use special api call for large files

### DIFF
--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -452,9 +452,19 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
         )
 
     def hget(self, name: str, key: str) -> str:
+        from conda_forge_tick.git_utils import get_bot_token
+
         pth = get_sharded_path(f"{name}/{key}.json")
-        cnts = self._repo.get_contents(pth)
-        return base64.b64decode(cnts.content.encode("utf-8")).decode("utf-8")
+        hrds = {
+            "Accept": "application/vnd.github.raw+json",
+            "Authorization": f"Bearer {get_bot_token()}",
+        }
+        cnts = requests.get(
+            f"https://api.github.com/repos/{CF_TICK_GRAPH_GITHUB_BACKEND_REPO}/contents/{pth}",
+            headers=hrds,
+        )
+        cnts.raise_for_status()
+        return cnts.text
 
 
 @functools.lru_cache(maxsize=128)


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

The github api needs this call to pull large files.

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
