### PR TITLE
Add mini-migrator for xz->liblzma-devel

### DIFF
--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -73,6 +73,7 @@ from conda_forge_tick.migrators import (
     UpdateCMakeArgsMigrator,
     UpdateConfigSubGuessMigrator,
     Version,
+    XzLibLzmaDevelMigrator,
     make_from_lazy_json_data,
     skip_migrator_due_to_schema,
 )
@@ -385,6 +386,8 @@ def add_rebuild_migration_yaml(
         piggy_back_migrations.append(RUCRTCleanup())
     if migration_name.startswith("flang19"):
         piggy_back_migrations.append(FlangMigrator())
+    if migration_name.startswith("xz_to_liblzma_devel"):
+        piggy_back_migrations.append(XzLibLzmaDevelMigrator())
     piggy_back_migrations = _make_mini_migrators_with_defaults(
         extra_mini_migrators=piggy_back_migrations
     )

--- a/conda_forge_tick/migrators/__init__.py
+++ b/conda_forge_tick/migrators/__init__.py
@@ -41,4 +41,5 @@ from .r_ucrt import RUCRTCleanup
 from .replacement import Replacement
 from .use_pip import PipMigrator
 from .version import Version
+from .xz_to_liblzma_devel import XzLibLzmaDevelMigrator
 from .noarch_python_min import NoarchPythonMinMigrator

--- a/conda_forge_tick/migrators/xz_to_liblzma_devel.py
+++ b/conda_forge_tick/migrators/xz_to_liblzma_devel.py
@@ -1,0 +1,31 @@
+import os
+
+from conda_forge_tick.migrators.core import MiniMigrator, skip_migrator_due_to_schema
+
+
+def _parse_xz(lines):
+    new_lines = []
+    for line in lines:
+        if line.endswith(" xz\n"):
+            line = line.replace(" xz", " liblzma-devel")
+        line = line.replace(" xz ", " liblzma-devel ")
+        new_lines.append(line)
+    return new_lines
+
+
+class XzLibLzmaDevelMigrator(MiniMigrator):
+    def filter(self, attrs, not_bad_str_start=""):
+        host_req = (attrs.get("requirements", {}) or {}).get("host", set()) or set()
+        return "xz" not in host_req or skip_migrator_due_to_schema(
+            attrs, self.allowed_schema_versions
+        )
+
+    def migrate(self, recipe_dir, attrs, **kwargs):
+        fname = os.path.join(recipe_dir, "meta.yaml")
+        if os.path.exists(fname):
+            with open(fname) as fp:
+                lines = fp.readlines()
+
+            new_lines = _parse_xz(lines)
+            with open(fname, "w") as fp:
+                fp.write("".join(new_lines))

--- a/tests/test_xz_liblzma_devel.py
+++ b/tests/test_xz_liblzma_devel.py
@@ -1,0 +1,47 @@
+import os
+
+import pytest
+from test_migrators import run_test_migration
+
+from conda_forge_tick.migrators import Version, XzLibLzmaDevelMigrator
+
+XZLIBLZMADEVEL = XzLibLzmaDevelMigrator()
+VERSION_WITH_XZLIBLZMADEVEL = Version(
+    set(),
+    piggy_back_migrations=[XZLIBLZMADEVEL],
+)
+
+YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")
+
+
+@pytest.mark.parametrize(
+    "old_meta,new_meta,new_ver",
+    [
+        (
+            "libtiff_with_xz.yaml",
+            "libtiff_with_liblzma_devel.yaml",
+            "4.7.0",
+        ),
+    ],
+)
+def test_liblzma_devel(old_meta, new_meta, new_ver, tmpdir):
+    with open(os.path.join(YAML_PATH, old_meta)) as fp:
+        in_yaml = fp.read()
+
+    with open(os.path.join(YAML_PATH, new_meta)) as fp:
+        out_yaml = fp.read()
+
+    run_test_migration(
+        m=VERSION_WITH_XZLIBLZMADEVEL,
+        inp=in_yaml,
+        output=out_yaml,
+        kwargs={"new_version": new_ver},
+        prb="Dependencies have been updated if changed",
+        mr_out={
+            "migrator_name": Version.name,
+            "migrator_version": VERSION_WITH_XZLIBLZMADEVEL.migrator_version,
+            "version": new_ver,
+        },
+        tmpdir=tmpdir,
+        should_filter=False,
+    )

--- a/tests/test_yaml/libtiff_with_liblzma_devel.yaml
+++ b/tests/test_yaml/libtiff_with_liblzma_devel.yaml
@@ -1,0 +1,82 @@
+{% set version = "4.7.0" %}
+
+package:
+  name: libtiff
+  version: {{ version }}
+
+source:
+  url: https://download.osgeo.org/libtiff/tiff-{{ version }}.tar.gz
+  sha256: 67160e3457365ab96c5b3286a0903aa6e78bdc44c4bc737d2e486bcecb6ba976
+  patches:
+    # It seems that a recent patch in tifffile 4.1 may have broken
+    # binary compatibility on windows.
+    # https://gitlab.com/libtiff/libtiff/issues/173
+    # https://github.com/python-pillow/Pillow/issues/4237
+    - patches/use_unix_io.patch
+
+build:
+  number: 0
+  # Does a very good job of maintaining compatibility.
+  # Except broke abi between 4.4 and 4.5.0
+  #    https://github.com/conda-forge/libtiff-feedstock/issues/77
+  #    https://abi-laboratory.pro/tracker/timeline/libtiff/
+  run_exports:
+    - {{ pin_subpackage('libtiff', max_pin='x.x') }}
+  missing_dso_whitelist:
+    # Only used by libtiff,bin/tiffgt (a viewer), which is ok.
+    - /opt/X11/lib/libGL.1.dylib
+    - /opt/X11/lib/libglut.3.dylib
+
+requirements:
+  build:
+    - libtool  # [unix]
+    - {{ compiler('c') }}
+    - {{ stdlib("c") }}
+    - {{ compiler('cxx') }}
+    - cmake  # [win]
+    - ninja  # [win]
+    - make      # [unix]
+  host:
+    - zlib
+    - libjpeg-turbo
+    - liblzma-devel
+    - zstd
+    - lerc
+    - libdeflate
+    - libwebp-base  # [linux or osx]
+
+test:
+  # TODO: enable this after the release. The ABI broke
+  # downstreams:
+  #   - pillow >=8
+  #   - py-opencv >=4
+  #   - tifffile
+  commands:
+    - test ! -f ${PREFIX}/lib/libtiff.a  # [not win]
+    - test ! -f ${PREFIX}/lib/libtiffxx.a  # [not win]
+    - test -f ${PREFIX}/lib/libtiff{{ SHLIB_EXT }}  # [not win]
+    - test -f ${PREFIX}/lib/libtiffxx{{ SHLIB_EXT }}  # [not win]
+    - if not exist %PREFIX%\\Library\\bin\\tiff.dll exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\bin\\libtiff.dll exit 1  # [win]
+    # It seems that libtiffxx does not have a dll on windows
+    # https://gitlab.com/libtiff/libtiff/-/merge_requests/338
+    - if not exist %PREFIX%\\Library\\lib\\tiffxx.lib exit 1  # [win]
+
+about:
+  home: http://www.libtiff.org/
+  license: HPND
+  license_file: LICENSE.md
+  summary: Support for the Tag Image File Format (TIFF).
+  description: |
+    This software provides support for the Tag Image File Format (TIFF), a
+    widely used format for storing image data.
+  doc_url: http://www.libtiff.org/document.html
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - mingwandroid
+    - msarahan
+    - ocefpaf
+    - stuarteberg
+    - hmaarrfk

--- a/tests/test_yaml/libtiff_with_xz.yaml
+++ b/tests/test_yaml/libtiff_with_xz.yaml
@@ -1,0 +1,82 @@
+{% set version = "4.6.9" %}
+
+package:
+  name: libtiff
+  version: {{ version }}
+
+source:
+  url: https://download.osgeo.org/libtiff/tiff-{{ version }}.tar.gz
+  sha256: 67160e3457365ab96c5b3286a0903aa6e78bdc44c4bc737d2e486bcecb6ba97
+  patches:
+    # It seems that a recent patch in tifffile 4.1 may have broken
+    # binary compatibility on windows.
+    # https://gitlab.com/libtiff/libtiff/issues/173
+    # https://github.com/python-pillow/Pillow/issues/4237
+    - patches/use_unix_io.patch
+
+build:
+  number: 2
+  # Does a very good job of maintaining compatibility.
+  # Except broke abi between 4.4 and 4.5.0
+  #    https://github.com/conda-forge/libtiff-feedstock/issues/77
+  #    https://abi-laboratory.pro/tracker/timeline/libtiff/
+  run_exports:
+    - {{ pin_subpackage('libtiff', max_pin='x.x') }}
+  missing_dso_whitelist:
+    # Only used by libtiff,bin/tiffgt (a viewer), which is ok.
+    - /opt/X11/lib/libGL.1.dylib
+    - /opt/X11/lib/libglut.3.dylib
+
+requirements:
+  build:
+    - libtool  # [unix]
+    - {{ compiler('c') }}
+    - {{ stdlib("c") }}
+    - {{ compiler('cxx') }}
+    - cmake  # [win]
+    - ninja  # [win]
+    - make      # [unix]
+  host:
+    - zlib
+    - libjpeg-turbo
+    - xz
+    - zstd
+    - lerc
+    - libdeflate
+    - libwebp-base  # [linux or osx]
+
+test:
+  # TODO: enable this after the release. The ABI broke
+  # downstreams:
+  #   - pillow >=8
+  #   - py-opencv >=4
+  #   - tifffile
+  commands:
+    - test ! -f ${PREFIX}/lib/libtiff.a  # [not win]
+    - test ! -f ${PREFIX}/lib/libtiffxx.a  # [not win]
+    - test -f ${PREFIX}/lib/libtiff{{ SHLIB_EXT }}  # [not win]
+    - test -f ${PREFIX}/lib/libtiffxx{{ SHLIB_EXT }}  # [not win]
+    - if not exist %PREFIX%\\Library\\bin\\tiff.dll exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\bin\\libtiff.dll exit 1  # [win]
+    # It seems that libtiffxx does not have a dll on windows
+    # https://gitlab.com/libtiff/libtiff/-/merge_requests/338
+    - if not exist %PREFIX%\\Library\\lib\\tiffxx.lib exit 1  # [win]
+
+about:
+  home: http://www.libtiff.org/
+  license: HPND
+  license_file: LICENSE.md
+  summary: Support for the Tag Image File Format (TIFF).
+  description: |
+    This software provides support for the Tag Image File Format (TIFF), a
+    widely used format for storing image data.
+  doc_url: http://www.libtiff.org/document.html
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - mingwandroid
+    - msarahan
+    - ocefpaf
+    - stuarteberg
+    - hmaarrfk


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

Mini-Migrator to rename `xz` to `liblzma-devel` if `xz` is listed in `host`.

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

Fixes #3318 