### PR TITLE
feat: always use deploy step and rely on GH API push there

### DIFF
--- a/.github/workflows/bot-feedstocks.yml
+++ b/.github/workflows/bot-feedstocks.yml
@@ -58,18 +58,16 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
-      # NOTE: this is disabled for now, as it is not needed when using the GH API
-      # and a github repo as the primary data store
-      # - name: deploy
-      #   if: github.ref == 'refs/heads/main' && ! cancelled() && ! env.CI_SKIP
-      #   run: |
-      #     pushd cf-graph
+      - name: deploy
+        if: github.ref == 'refs/heads/main' && ! cancelled() && ! env.CI_SKIP
+        run: |
+          pushd cf-graph
 
-      #     export RUN_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
-      #     conda-forge-tick deploy-to-github
-      #   env:
-      #     BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
-      #     RUN_ID: ${{ github.run_id }}
+          export RUN_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
+          conda-forge-tick deploy-to-github
+        env:
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
 
       - name: bump on fail
         if: github.ref == 'refs/heads/main' && failure() && ! env.CI_SKIP

--- a/.github/workflows/bot-make-graph.yml
+++ b/.github/workflows/bot-make-graph.yml
@@ -61,18 +61,16 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
 
-      # NOTE: this is disabled for now, as it is not needed when using the GH API
-      # and a github repo as the primary data store
-      # - name: deploy
-      #   if: github.ref == 'refs/heads/main' && always() && ! env.CI_SKIP
-      #   run: |
-      #     pushd cf-graph
+      - name: deploy
+        if: github.ref == 'refs/heads/main' && always() && ! env.CI_SKIP
+        run: |
+          pushd cf-graph
 
-      #     export RUN_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
-      #     conda-forge-tick deploy-to-github
-      #   env:
-      #     BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
-      #     RUN_ID: ${{ github.run_id }}
+          export RUN_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
+          conda-forge-tick deploy-to-github
+        env:
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
 
       - name: trigger next job
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4

--- a/.github/workflows/bot-make-migrators.yml
+++ b/.github/workflows/bot-make-migrators.yml
@@ -61,18 +61,16 @@ jobs:
           BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
 
-      # NOTE: this is disabled for now, as it is not needed when using the GH API
-      # and a github repo as the primary data store
-      # - name: deploy
-      #   if: github.ref == 'refs/heads/main' && always() && ! env.CI_SKIP
-      #   run: |
-      #     pushd cf-graph
+      - name: deploy
+        if: github.ref == 'refs/heads/main' && always() && ! env.CI_SKIP
+        run: |
+          pushd cf-graph
 
-      #     export RUN_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
-      #     conda-forge-tick deploy-to-github
-      #   env:
-      #     BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
-      #     RUN_ID: ${{ github.run_id }}
+          export RUN_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
+          conda-forge-tick deploy-to-github
+        env:
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
 
       - name: trigger next job
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4

--- a/conda_forge_tick/all_feedstocks.py
+++ b/conda_forge_tick/all_feedstocks.py
@@ -5,7 +5,7 @@ import tqdm
 
 from conda_forge_tick.git_utils import github_client
 
-from .lazy_json_backends import dump, load, sync_lazy_json_hashmap_key
+from .lazy_json_backends import dump, load
 
 logger = logging.getLogger(__name__)
 
@@ -68,4 +68,3 @@ def main() -> None:
     data = get_all_feedstocks_from_github()
     with open("all_feedstocks.json", "w") as fp:
         dump(data, fp)
-    sync_lazy_json_hashmap_key("lazy_json", "all_feedstocks", "file", ["github_api"])

--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -19,7 +19,6 @@ from conda_forge_tick.lazy_json_backends import (
     get_lazy_json_backends,
     lazy_json_override_backends,
     lazy_json_transaction,
-    sync_lazy_json_hashmap_key,
 )
 
 from .all_feedstocks import get_all_feedstocks, get_archived_feedstocks
@@ -379,7 +378,6 @@ def main(
 
         dump_graph(gx)
 
-        sync_lazy_json_hashmap_key("lazy_json", "graph", "file", ["github_api"])
     else:
         gx = load_graph()
 

--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -37,7 +37,6 @@ from conda_forge_tick.lazy_json_backends import (
     get_all_keys_for_hashmap,
     lazy_json_override_backends,
     remove_key_for_hashmap,
-    sync_lazy_json_hashmap_key,
 )
 from conda_forge_tick.migrators import (
     ArchRebuild,
@@ -945,10 +944,6 @@ def main(ctx: CliContext) -> None:
 
                 with LazyJson(f"migrators/{data['name']}.json") as lzj:
                     lzj.update(data)
-
-                sync_lazy_json_hashmap_key(
-                    "migrators", data["name"], "file", ["github_api"]
-                )
 
             except Exception as e:
                 logger.error(f"Error dumping migrator {migrator} to JSON!", exc_info=e)


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR moves the code back to always using the deploy step and relying on the GH API there. If we ever run out of token requests, the bot should default to its normal git CLI pull and push.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
