### PR TITLE
fix: allow migrators to mark a PR as already done

### DIFF
--- a/conda_forge_tick/migrators/noarch_python_min.py
+++ b/conda_forge_tick/migrators/noarch_python_min.py
@@ -462,11 +462,13 @@ class NoarchPythonMinMigrator(Migrator):
     def migrate(self, recipe_dir, attrs, **kwargs):
         # if the feedstock has already been updated, return a migration ID
         # and make no changes.
-        self.set_build_number(os.path.join(recipe_dir, "meta.yaml"))
-
         for line in attrs.get("raw_meta_yaml", "").splitlines():
             if "{{ python_min }}" in line:
-                return super().migrate(recipe_dir, attrs)
+                muid = super().migrate(recipe_dir, attrs)
+                muid["already_done"] = True
+                return muid
+
+        self.set_build_number(os.path.join(recipe_dir, "meta.yaml"))
 
         _apply_noarch_python_min(
             recipe_dir,

--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -25,6 +25,7 @@ from conda_forge_tick.migrators import (
     ArchRebuild,
     GraphMigrator,
     MatplotlibBase,
+    MigrationYamlCreator,
     Migrator,
     OSXArm,
     Replacement,
@@ -409,6 +410,11 @@ def main() -> None:
     paused_status = {}
 
     for migrator in migrators:
+        # we do not show these on the status page since they are used to
+        # open and close migrations
+        if isinstance(migrator, MigrationYamlCreator):
+            continue
+
         if hasattr(migrator, "name"):
             assert isinstance(migrator.name, str)
             migrator_name = migrator.name.lower().replace(" ", "")


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR monkey patches the migration return value to mark a PR as already done.

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

closes #3415 

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
