### PR TITLE
fix: do not set pr_info bad for version migration errors

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -838,9 +838,11 @@ def _run_migrator_on_feedstock_branch(
         logger.exception("NON GITHUB ERROR", exc_info=e)
 
         # we don't set bad for rerendering errors
-        if "conda smithy rerender -c auto --no-check-uptodate" not in str(
-            e
-        ) and "Failed to rerender" not in str(e):
+        if (
+            "conda smithy rerender -c auto --no-check-uptodate" not in str(e)
+            and "Failed to rerender" not in str(e)
+            and "VersionMigrationError" not in str(e)
+        ):
             with attrs["pr_info"] as pri:
                 pri["bad"] = {
                     "exception": str(e),


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

As it says...

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
