### PR TITLE
prod: add rattler-build-conda-compat to deps

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -47,6 +47,7 @@ dependencies:
   - python-graphviz
   - python-rapidjson
   - rattler-build
+  - rattler-build-conda-compat >=1.3.0,<2
   - requests
   - ruamel.yaml
   - ruamel.yaml.jinja2


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

Fixes the env relocking which doesn't work for forks.

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
