### PR TITLE
add tests for sources that depend on conda build config variants (recipe v0 & v1)

### DIFF
--- a/conda_forge_tick/update_recipe/version.py
+++ b/conda_forge_tick/update_recipe/version.py
@@ -307,6 +307,7 @@ def _get_new_url_tmpl_and_hash(
         logger.info("initial rendered URL: %s", url)
     except jinja2.UndefinedError:
         logger.info("initial URL template does not render")
+        url = None
         pass
 
     if url != url_tmpl:

--- a/tests/test_v1_yaml/version_polars.yaml
+++ b/tests/test_v1_yaml/version_polars.yaml
@@ -1,0 +1,105 @@
+context:
+  version: '1.17.1'
+
+# Note: This recipe is specifically designed to work well with the autotick bot.
+# Also refer to https://github.com/conda-forge/rust-feedstock/blob/main/recipe/meta.yaml.
+package:
+  name: ${{ polars_variant }}
+  version: ${{ version }}
+
+source:
+  - if: polars_variant == 'polars'
+    then:
+      url: https://pypi.org/packages/source/p/polars/${{ polars_variant | replace('-', '_') }}-${{ version }}.tar.gz
+      sha256: 5a3dac3cb7cbe174d1fa898cba9afbede0c08e8728feeeab515554d762127019
+  - if: polars_variant == 'polars-lts-cpu'
+    then:
+      url: https://pypi.org/packages/source/p/${{ polars_variant }}/${{ polars_variant | replace('-', '_') }}-${{ version }}.tar.gz
+      sha256: d2717d17cd764223ea01e35ada2e3235327bc08040ecd41c71c803c7aad874fb
+  - if: polars_variant == 'polars-u64-idx'
+    then:
+      url: https://pypi.org/packages/source/p/${{ polars_variant }}/${{ polars_variant | replace('-', '_') }}-${{ version }}.tar.gz
+      sha256: 5b47e993d3a73e40f674bc856dbac0e93eaf26c10bc7b1d6768f71faa6e023fe
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - if: build_platform != target_platform
+      then:
+        - python
+        # there is no cross-python for linux-64 -> win-64
+        - if: target_platform != 'win-64'
+          then: cross-python_${{ target_platform }}
+        - crossenv
+        - maturin >=1.3.2,<2
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    # clang_win-64 already adds all required run_exports for the windows build
+    - if: not (build_platform != target_platform and target_platform == "win-64")
+      then:
+        - ${{ stdlib('c') }}
+      else:
+        - cargo-feature
+    - if: build_platform == 'win-64'
+      then:
+        - posix
+    - ${{ compiler('rust') }}
+    - cmake
+    - if: unix
+      then:
+        - make
+    - cargo-bundle-licenses
+  host:
+    - python
+    - pip
+    - maturin >=1.3.2,<2
+    - if: build_platform != target_platform and target_platform == "win-64"
+      then:
+        - mingw-w64-ucrt-x86_64-headers-git
+  run:
+    - python
+    - numpy >=1.16.0
+    - if: python<3.11
+      then:
+        - typing_extensions >=4.0.0
+    - if: python >=3.10
+      then:
+        - packaging
+
+tests:
+  - python:
+      pip_check: true
+      imports:
+        - polars
+  - script:
+      - python -c "from polars import DataFrame"
+  - package_contents:
+      site_packages:
+        - polars/polars.abi3.so
+        - polars/dataframe/__init__.py
+        - ${{ polars_variant | replace('-', '_') }}-${{ version }}.dist-info/METADATA
+
+about:
+  homepage: https://github.com/pola-rs/polars
+  license: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: Dataframes powered by a multithreaded, vectorized query engine, written in Rust
+  description: Polars is a DataFrame interface on top of an OLAP Query Engine implemented in Rust using Apache Arrow Columnar Format as the memory model.
+  documentation: https://docs.pola.rs
+  repository: https://github.com/pola-rs/polars
+
+extra:
+  recipe-maintainers:
+    - borchero
+    - Maxyme
+    - timkpaine
+    - ritchie46
+    - sugatoray
+    - xhochy
+    - dhirschfeld
+    - pavelzw
+    - '0xbe7a'

--- a/tests/test_v1_yaml/version_polars.yaml
+++ b/tests/test_v1_yaml/version_polars.yaml
@@ -1,5 +1,5 @@
 context:
-  version: '1.17.1'
+  version: "1.17.1"
 
 # Note: This recipe is specifically designed to work well with the autotick bot.
 # Also refer to https://github.com/conda-forge/rust-feedstock/blob/main/recipe/meta.yaml.
@@ -10,15 +10,15 @@ package:
 source:
   - if: polars_variant == 'polars'
     then:
-      url: https://pypi.org/packages/source/p/polars/${{ polars_variant | replace('-', '_') }}-${{ version }}.tar.gz
+      url: https://pypi.org/packages/source/p/polars/polars-${{ version }}.tar.gz
       sha256: 5a3dac3cb7cbe174d1fa898cba9afbede0c08e8728feeeab515554d762127019
   - if: polars_variant == 'polars-lts-cpu'
     then:
-      url: https://pypi.org/packages/source/p/${{ polars_variant }}/${{ polars_variant | replace('-', '_') }}-${{ version }}.tar.gz
+      url: https://pypi.org/packages/source/p/polars-lts-cpu/polars_lts_cpu-${{ version }}.tar.gz
       sha256: d2717d17cd764223ea01e35ada2e3235327bc08040ecd41c71c803c7aad874fb
   - if: polars_variant == 'polars-u64-idx'
     then:
-      url: https://pypi.org/packages/source/p/${{ polars_variant }}/${{ polars_variant | replace('-', '_') }}-${{ version }}.tar.gz
+      url: https://pypi.org/packages/source/p/polars-u64-idx/polars_u64_idx-${{ version }}.tar.gz
       sha256: 5b47e993d3a73e40f674bc856dbac0e93eaf26c10bc7b1d6768f71faa6e023fe
 
 build:

--- a/tests/test_v1_yaml/version_polars_correct.yaml
+++ b/tests/test_v1_yaml/version_polars_correct.yaml
@@ -1,5 +1,5 @@
 context:
-  version: '1.20.0'
+  version: "1.20.0"
 
 # Note: This recipe is specifically designed to work well with the autotick bot.
 # Also refer to https://github.com/conda-forge/rust-feedstock/blob/main/recipe/meta.yaml.
@@ -10,15 +10,15 @@ package:
 source:
   - if: polars_variant == 'polars'
     then:
-      url: https://pypi.org/packages/source/p/polars/${{ polars_variant | replace('-', '_') }}-${{ version }}.tar.gz
+      url: https://pypi.org/packages/source/p/polars/polars-${{ version }}.tar.gz
       sha256: e8e9e3156fae02b58e276e5f2c16a5907a79b38617a9e2d731b533d87798f451
   - if: polars_variant == 'polars-lts-cpu'
     then:
-      url: https://pypi.org/packages/source/p/${{ polars_variant }}/${{ polars_variant | replace('-', '_') }}-${{ version }}.tar.gz
+      url: https://pypi.org/packages/source/p/polars-lts-cpu/polars_lts_cpu-${{ version }}.tar.gz
       sha256: f8770fe1a752f60828ec73e6215c7dadcb2badd1f34dcb1def7a0f4ca0ac36f8
   - if: polars_variant == 'polars-u64-idx'
     then:
-      url: https://pypi.org/packages/source/p/${{ polars_variant }}/${{ polars_variant | replace('-', '_') }}-${{ version }}.tar.gz
+      url: https://pypi.org/packages/source/p/polars-u64-idx/polars_u64_idx-${{ version }}.tar.gz
       sha256: a92fadacf59776bef2d777f99345c4d089cf4f8b3fd61f5728087bab27a46a75
 
 build:

--- a/tests/test_v1_yaml/version_polars_correct.yaml
+++ b/tests/test_v1_yaml/version_polars_correct.yaml
@@ -1,0 +1,105 @@
+context:
+  version: '1.20.0'
+
+# Note: This recipe is specifically designed to work well with the autotick bot.
+# Also refer to https://github.com/conda-forge/rust-feedstock/blob/main/recipe/meta.yaml.
+package:
+  name: ${{ polars_variant }}
+  version: ${{ version }}
+
+source:
+  - if: polars_variant == 'polars'
+    then:
+      url: https://pypi.org/packages/source/p/polars/${{ polars_variant | replace('-', '_') }}-${{ version }}.tar.gz
+      sha256: e8e9e3156fae02b58e276e5f2c16a5907a79b38617a9e2d731b533d87798f451
+  - if: polars_variant == 'polars-lts-cpu'
+    then:
+      url: https://pypi.org/packages/source/p/${{ polars_variant }}/${{ polars_variant | replace('-', '_') }}-${{ version }}.tar.gz
+      sha256: f8770fe1a752f60828ec73e6215c7dadcb2badd1f34dcb1def7a0f4ca0ac36f8
+  - if: polars_variant == 'polars-u64-idx'
+    then:
+      url: https://pypi.org/packages/source/p/${{ polars_variant }}/${{ polars_variant | replace('-', '_') }}-${{ version }}.tar.gz
+      sha256: a92fadacf59776bef2d777f99345c4d089cf4f8b3fd61f5728087bab27a46a75
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - if: build_platform != target_platform
+      then:
+        - python
+        # there is no cross-python for linux-64 -> win-64
+        - if: target_platform != 'win-64'
+          then: cross-python_${{ target_platform }}
+        - crossenv
+        - maturin >=1.3.2,<2
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    # clang_win-64 already adds all required run_exports for the windows build
+    - if: not (build_platform != target_platform and target_platform == "win-64")
+      then:
+        - ${{ stdlib('c') }}
+      else:
+        - cargo-feature
+    - if: build_platform == 'win-64'
+      then:
+        - posix
+    - ${{ compiler('rust') }}
+    - cmake
+    - if: unix
+      then:
+        - make
+    - cargo-bundle-licenses
+  host:
+    - python
+    - pip
+    - maturin >=1.3.2,<2
+    - if: build_platform != target_platform and target_platform == "win-64"
+      then:
+        - mingw-w64-ucrt-x86_64-headers-git
+  run:
+    - python
+    - numpy >=1.16.0
+    - if: python<3.11
+      then:
+        - typing_extensions >=4.0.0
+    - if: python >=3.10
+      then:
+        - packaging
+
+tests:
+  - python:
+      pip_check: true
+      imports:
+        - polars
+  - script:
+      - python -c "from polars import DataFrame"
+  - package_contents:
+      site_packages:
+        - polars/polars.abi3.so
+        - polars/dataframe/__init__.py
+        - ${{ polars_variant | replace('-', '_') }}-${{ version }}.dist-info/METADATA
+
+about:
+  homepage: https://github.com/pola-rs/polars
+  license: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: Dataframes powered by a multithreaded, vectorized query engine, written in Rust
+  description: Polars is a DataFrame interface on top of an OLAP Query Engine implemented in Rust using Apache Arrow Columnar Format as the memory model.
+  documentation: https://docs.pola.rs
+  repository: https://github.com/pola-rs/polars
+
+extra:
+  recipe-maintainers:
+    - borchero
+    - Maxyme
+    - timkpaine
+    - ritchie46
+    - sugatoray
+    - xhochy
+    - dhirschfeld
+    - pavelzw
+    - '0xbe7a'

--- a/tests/test_v1_yaml/version_polars_variants.yaml
+++ b/tests/test_v1_yaml/version_polars_variants.yaml
@@ -1,0 +1,17 @@
+channel_sources:
+  - conda-forge/label/rust_dev,conda-forge/label/cargo-patch-dev,conda-forge
+channel_targets:
+  - conda-forge main
+c_compiler:
+  - clang  # [win]
+c_compiler_version:
+  - 17  # [win]
+cxx_compiler:
+  - clangxx  # [win]
+cxx_compiler_version:
+  - 17  # [win]
+
+polars_variant:
+  - polars  # [not ppc64le]
+  - polars-lts-cpu
+  - polars-u64-idx  # [not ppc64le]

--- a/tests/test_version_migrator.py
+++ b/tests/test_version_migrator.py
@@ -129,6 +129,7 @@ def test_version_up(case, new_ver, tmpdir, caplog):
         ("event_stream", "1.6.3"),
         ("selshaurl", "3.7.0"),
         ("libssh", "0.11.1"),
+        ("polars", "1.20.0"),
     ],
 )
 @flaky
@@ -140,6 +141,13 @@ def test_version_up_v1(case, new_ver, tmpdir, caplog):
 
     in_yaml = (YAML_V1_PATH / f"version_{case}.yaml").read_text()
     out_yaml = (YAML_V1_PATH / f"version_{case}_correct.yaml").read_text()
+
+    try:
+        conda_build_config = (
+            YAML_V1_PATH / f"version_{case}_variants.yaml"
+        ).read_text()
+    except FileNotFoundError:
+        conda_build_config = None
 
     kwargs = {"new_version": new_ver}
     if case == "sha1":
@@ -158,6 +166,7 @@ def test_version_up_v1(case, new_ver, tmpdir, caplog):
         },
         tmpdir=tmpdir,
         recipe_version=1,
+        conda_build_config=conda_build_config,
     )
 
 

--- a/tests/test_version_migrator.py
+++ b/tests/test_version_migrator.py
@@ -81,6 +81,8 @@ VARIANT_SOURCES_NOT_IMPLEMENTED = (
             "1.1.0",
             marks=pytest.mark.xfail(reason=VARIANT_SOURCES_NOT_IMPLEMENTED),
         ),
+        # use conda build config variants directly to select source
+        ("polars_by_variant", "1.20.0"),
         # upstream is not available
         # ("mumps", "5.2.1"),
         # ("cb3multi", "6.0.0"),

--- a/tests/test_yaml/version_polars_by_variant.yaml
+++ b/tests/test_yaml/version_polars_by_variant.yaml
@@ -1,0 +1,79 @@
+{% set version = "1.17.1" %}
+
+# Note: This recipe is specifically designed to work well with the autotick bot.
+# Also refer to https://github.com/conda-forge/rust-feedstock/blob/main/recipe/meta.yaml.
+package:
+  name: {{ polars_variant }}
+  version: {{ version }}
+
+source:
+  - url: https://pypi.org/packages/source/p/polars/polars-{{ version }}.tar.gz  # [polars_variant == "polars"]
+    sha256: 5a3dac3cb7cbe174d1fa898cba9afbede0c08e8728feeeab515554d762127019  # [polars_variant == "polars"]
+  - url: https://pypi.org/packages/source/p/polars-lts-cpu/polars_lts_cpu-{{ version }}.tar.gz  # [polars_variant == "polars-lts-cpu"]
+    sha256: d2717d17cd764223ea01e35ada2e3235327bc08040ecd41c71c803c7aad874fb  # [polars_variant == "polars-lts-cpu"]
+  - url: https://pypi.org/packages/source/p/polars-u64-idx/polars_u64_idx-{{ version }}.tar.gz  # [polars_variant == "polars-u64-idx"]
+    sha256: 5b47e993d3a73e40f674bc856dbac0e93eaf26c10bc7b1d6768f71faa6e023fe  # [polars_variant == "polars-u64-idx"]
+    patches:
+      - 0001-Patch-libz-ng-sys.patch  # [target_platform == "win-64"]
+
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python                              # [build_platform != target_platform]
+    # there is no cross-python for linux-64 -> win-64
+    - cross-python_{{ target_platform }}  # [build_platform != target_platform and not target_platform == "win-64"]
+    - crossenv                            # [build_platform != target_platform]
+    - maturin >=1.3.2,<2                  # [build_platform != target_platform]
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}               # [win]
+    # clang_win-64 already adds all required run_exports for the windows build
+    - {{ stdlib("c") }}  # [not (build_platform != target_platform and target_platform == "win-64")]
+    - {{ compiler('rust') }}
+    - posix                               # [build_platform == "win-64"]
+    - cmake
+    - make                                # [unix]
+    - cargo-feature                       # [build_platform != target_platform and target_platform == "win-64"]
+    - cargo-patch                         # [build_platform != target_platform and target_platform == "win-64"]
+    - cargo-bundle-licenses
+  host:
+    - python
+    - pip
+    - maturin >=1.3.2,<2
+  run:
+    - python
+    - numpy >=1.16.0
+    - backports.zoneinfo                   # [py<39]
+    - typing_extensions >=4.0.0            # [py<311]
+    - packaging                            # [py>=310]
+test:
+  imports:
+    - polars
+  commands:
+    - pip check
+    - python -c "from polars import DataFrame"
+  requires:
+    - pip
+about:
+  home: https://github.com/pola-rs/polars
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: Polars is a blazingly fast DataFrames library implemented in Rust using Apache Arrow(2) as memory model.
+  doc_url: https://pola-rs.github.io/polars-book/user-guide/index.html
+  dev_url: https://github.com/pola-rs/polars
+extra:
+  recipe-maintainers:
+    - borchero
+    - Maxyme
+    - timkpaine
+    - ritchie46
+    - sugatoray
+    - xhochy
+    - dhirschfeld
+    - pavelzw
+    - '0xbe7a'

--- a/tests/test_yaml/version_polars_by_variant_correct.yaml
+++ b/tests/test_yaml/version_polars_by_variant_correct.yaml
@@ -1,0 +1,79 @@
+{% set version = "1.20.0" %}
+
+# Note: This recipe is specifically designed to work well with the autotick bot.
+# Also refer to https://github.com/conda-forge/rust-feedstock/blob/main/recipe/meta.yaml.
+package:
+  name: {{ polars_variant }}
+  version: {{ version }}
+
+source:
+  - url: https://pypi.org/packages/source/p/polars/polars-{{ version }}.tar.gz  # [polars_variant == "polars"]
+    sha256: e8e9e3156fae02b58e276e5f2c16a5907a79b38617a9e2d731b533d87798f451  # [polars_variant == "polars"]
+  - url: https://pypi.org/packages/source/p/polars-lts-cpu/polars_lts_cpu-{{ version }}.tar.gz  # [polars_variant == "polars-lts-cpu"]
+    sha256: f8770fe1a752f60828ec73e6215c7dadcb2badd1f34dcb1def7a0f4ca0ac36f8  # [polars_variant == "polars-lts-cpu"]
+  - url: https://pypi.org/packages/source/p/polars-u64-idx/polars_u64_idx-{{ version }}.tar.gz  # [polars_variant == "polars-u64-idx"]
+    sha256: a92fadacf59776bef2d777f99345c4d089cf4f8b3fd61f5728087bab27a46a75  # [polars_variant == "polars-u64-idx"]
+    patches:
+      - 0001-Patch-libz-ng-sys.patch  # [target_platform == "win-64"]
+
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python                              # [build_platform != target_platform]
+    # there is no cross-python for linux-64 -> win-64
+    - cross-python_{{ target_platform }}  # [build_platform != target_platform and not target_platform == "win-64"]
+    - crossenv                            # [build_platform != target_platform]
+    - maturin >=1.3.2,<2                  # [build_platform != target_platform]
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}               # [win]
+    # clang_win-64 already adds all required run_exports for the windows build
+    - {{ stdlib("c") }}  # [not (build_platform != target_platform and target_platform == "win-64")]
+    - {{ compiler('rust') }}
+    - posix                               # [build_platform == "win-64"]
+    - cmake
+    - make                                # [unix]
+    - cargo-feature                       # [build_platform != target_platform and target_platform == "win-64"]
+    - cargo-patch                         # [build_platform != target_platform and target_platform == "win-64"]
+    - cargo-bundle-licenses
+  host:
+    - python
+    - pip
+    - maturin >=1.3.2,<2
+  run:
+    - python
+    - numpy >=1.16.0
+    - backports.zoneinfo                   # [py<39]
+    - typing_extensions >=4.0.0            # [py<311]
+    - packaging                            # [py>=310]
+test:
+  imports:
+    - polars
+  commands:
+    - pip check
+    - python -c "from polars import DataFrame"
+  requires:
+    - pip
+about:
+  home: https://github.com/pola-rs/polars
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: Polars is a blazingly fast DataFrames library implemented in Rust using Apache Arrow(2) as memory model.
+  doc_url: https://pola-rs.github.io/polars-book/user-guide/index.html
+  dev_url: https://github.com/pola-rs/polars
+extra:
+  recipe-maintainers:
+    - borchero
+    - Maxyme
+    - timkpaine
+    - ritchie46
+    - sugatoray
+    - xhochy
+    - dhirschfeld
+    - pavelzw
+    - '0xbe7a'


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

This PR adds tests for sources that conditionally depend on conda-build-config variants. The feature is used by popular feedstocks (rust-feedstock, polars-feedstock).

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
