### PR TITLE
fix: catch other GH exceptions for no object

### DIFF
--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -1448,7 +1448,7 @@ def _get_pth_blob_sha_and_content(
         # so I switched to doing the decoding by hand.
         data = base64.b64decode(cnt.content.encode("utf-8")).decode("utf-8")
         return cnt.sha, data
-    except (github.UnknownObjectException, github.GithubException) as e:
+    except (github.GithubException) as e:
         _test_and_raise_besides_file_not_exists(e)
         return None, None
 

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -1448,7 +1448,7 @@ def _get_pth_blob_sha_and_content(
         # so I switched to doing the decoding by hand.
         data = base64.b64decode(cnt.content.encode("utf-8")).decode("utf-8")
         return cnt.sha, data
-    except (github.GithubException) as e:
+    except github.GithubException as e:
         _test_and_raise_besides_file_not_exists(e)
         return None, None
 

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -29,7 +29,10 @@ from requests.exceptions import RequestException, Timeout
 from requests.structures import CaseInsensitiveDict
 
 from conda_forge_tick import sensitive_env
-from conda_forge_tick.lazy_json_backends import LazyJson
+from conda_forge_tick.lazy_json_backends import (
+    LazyJson,
+    _test_and_raise_besides_file_not_exists,
+)
 
 from .executors import lock_git_operation
 from .models.pr_json import (
@@ -1445,7 +1448,8 @@ def _get_pth_blob_sha_and_content(
         # so I switched to doing the decoding by hand.
         data = base64.b64decode(cnt.content.encode("utf-8")).decode("utf-8")
         return cnt.sha, data
-    except github.UnknownObjectException:
+    except (github.UnknownObjectException, github.GithubException) as e:
+        _test_and_raise_besides_file_not_exists(e)
         return None, None
 
 

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -310,14 +310,10 @@ class GithubLazyJsonBackend(LazyJsonBackend):
 
 def _test_and_raise_besides_file_not_exists(e):
     if isinstance(e, github.UnknownObjectException):
-        pass
-    elif isinstance(e, github.GithubException):
-        if e.status == 404 and "No object found" in e.data["message"]:
-            pass
-        else:
-            raise e
-    else:
-        raise e
+        return
+    if isinstance(e, github.GithubException) and e.status == 404 and "No object found" in e.data["message"]:
+        return
+    raise e
 
 
 class GithubAPILazyJsonBackend(LazyJsonBackend):

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -311,7 +311,11 @@ class GithubLazyJsonBackend(LazyJsonBackend):
 def _test_and_raise_besides_file_not_exists(e):
     if isinstance(e, github.UnknownObjectException):
         return
-    if isinstance(e, github.GithubException) and e.status == 404 and "No object found" in e.data["message"]:
+    if (
+        isinstance(e, github.GithubException)
+        and e.status == 404
+        and "No object found" in e.data["message"]
+    ):
         return
     raise e
 

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -335,7 +335,9 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
         pth = get_sharded_path(f"{name}/{key}.json")
         try:
             self._repo.get_contents(pth)
-        except github.UnknownObjectException:
+        except (github.UnknownObjectException, github.GithubException) as e:
+            if isinstance(e, github.GithubException) and (e.status != 404 or "No object found" not in e.data["message"]):
+                raise e
             return False
         else:
             return True
@@ -366,7 +368,12 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
                         "utf-8"
                     )
                     sha = _cnts.sha
-                except github.UnknownObjectException:
+                except (github.UnknownObjectException, github.GithubException) as e:
+                    if (
+                        isinstance(e, github.GithubException)
+                        and (e.status != 404 or "No object found" not in e.data["message"])
+                    ):
+                        raise e
                     sha = None
                     cnt = None
 
@@ -435,7 +442,12 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
                 try:
                     _cnts = self._repo.get_contents(pth)
                     sha = _cnts.sha
-                except github.UnknownObjectException:
+                except (github.UnknownObjectException, github.GithubException) as e:
+                    if (
+                        isinstance(e, github.GithubException)
+                        and (e.status != 404 or "No object found" not in e.data["message"])
+                    ):
+                        raise e
                     sha = None
 
                 if sha is not None:

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -308,6 +308,18 @@ class GithubLazyJsonBackend(LazyJsonBackend):
         )
 
 
+def _test_and_raise_besides_file_not_exists(e):
+    if isinstance(e, github.UnknownObjectException):
+        pass
+    elif isinstance(e, github.GithubException):
+        if e.status == 404 and "No object found" in e.data["message"]:
+            pass
+        else:
+            raise e
+    else:
+        raise e
+
+
 class GithubAPILazyJsonBackend(LazyJsonBackend):
     """LazyJsonBackend that uses the GitHub API to store and retrieve JSON files.
 
@@ -336,8 +348,7 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
         try:
             self._repo.get_contents(pth)
         except (github.UnknownObjectException, github.GithubException) as e:
-            if isinstance(e, github.GithubException) and (e.status != 404 or "No object found" not in e.data["message"]):
-                raise e
+            _test_and_raise_besides_file_not_exists(e)
             return False
         else:
             return True
@@ -369,11 +380,7 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
                     )
                     sha = _cnts.sha
                 except (github.UnknownObjectException, github.GithubException) as e:
-                    if (
-                        isinstance(e, github.GithubException)
-                        and (e.status != 404 or "No object found" not in e.data["message"])
-                    ):
-                        raise e
+                    _test_and_raise_besides_file_not_exists(e)
                     sha = None
                     cnt = None
 
@@ -443,11 +450,7 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
                     _cnts = self._repo.get_contents(pth)
                     sha = _cnts.sha
                 except (github.UnknownObjectException, github.GithubException) as e:
-                    if (
-                        isinstance(e, github.GithubException)
-                        and (e.status != 404 or "No object found" not in e.data["message"])
-                    ):
-                        raise e
+                    _test_and_raise_besides_file_not_exists(e)
                     sha = None
 
                 if sha is not None:

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -308,7 +308,7 @@ class GithubLazyJsonBackend(LazyJsonBackend):
         )
 
 
-def _test_and_raise_besides_file_not_exists(e):
+def _test_and_raise_besides_file_not_exists(e: github.GithubException):
     if isinstance(e, github.UnknownObjectException):
         return
     if (
@@ -347,7 +347,7 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
         pth = get_sharded_path(f"{name}/{key}.json")
         try:
             self._repo.get_contents(pth)
-        except (github.UnknownObjectException, github.GithubException) as e:
+        except (github.GithubException) as e:
             _test_and_raise_besides_file_not_exists(e)
             return False
         else:
@@ -379,7 +379,7 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
                         "utf-8"
                     )
                     sha = _cnts.sha
-                except (github.UnknownObjectException, github.GithubException) as e:
+                except (github.GithubException) as e:
                     _test_and_raise_besides_file_not_exists(e)
                     sha = None
                     cnt = None
@@ -449,7 +449,7 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
                 try:
                     _cnts = self._repo.get_contents(pth)
                     sha = _cnts.sha
-                except (github.UnknownObjectException, github.GithubException) as e:
+                except (github.GithubException) as e:
                     _test_and_raise_besides_file_not_exists(e)
                     sha = None
 

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -311,11 +311,7 @@ class GithubLazyJsonBackend(LazyJsonBackend):
 def _test_and_raise_besides_file_not_exists(e: github.GithubException):
     if isinstance(e, github.UnknownObjectException):
         return
-    if (
-        isinstance(e, github.GithubException)
-        and e.status == 404
-        and "No object found" in e.data["message"]
-    ):
+    if e.status == 404 and "No object found" in e.data["message"]:
         return
     raise e
 

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -347,7 +347,7 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
         pth = get_sharded_path(f"{name}/{key}.json")
         try:
             self._repo.get_contents(pth)
-        except (github.GithubException) as e:
+        except github.GithubException as e:
             _test_and_raise_besides_file_not_exists(e)
             return False
         else:
@@ -379,7 +379,7 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
                         "utf-8"
                     )
                     sha = _cnts.sha
-                except (github.GithubException) as e:
+                except github.GithubException as e:
                     _test_and_raise_besides_file_not_exists(e)
                     sha = None
                     cnt = None
@@ -449,7 +449,7 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
                 try:
                     _cnts = self._repo.get_contents(pth)
                     sha = _cnts.sha
-                except (github.GithubException) as e:
+                except github.GithubException as e:
                     _test_and_raise_besides_file_not_exists(e)
                     sha = None
 


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

The GH API changed and we need to catch an additional set of exceptions for testing if files exist.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
