### PR TITLE
fix: need to allow schema version 1 for yaml migrations

### DIFF
--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -121,6 +121,7 @@ class MigrationYaml(GraphMigrator):
 
     migrator_version = 0
     rerender = True
+    allowed_schema_versions = [0, 1]
 
     # TODO: add a description kwarg for the status page at some point.
     # TODO: make yaml_contents an arg?


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

Some how we missed enabling v1 recipes for regular YAML ABI migrations. :/

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

closes #3716

This might solve some of the other incorrect "awaiting parents" feedstocks on the status page as well. I checked pytorch explicitly.
