### PR TITLE
Enable `CondaForgeYAMLCleanup` migrator for v1 recipes

### DIFF
--- a/conda_forge_tick/migrators/conda_forge_yaml_cleanup.py
+++ b/conda_forge_tick/migrators/conda_forge_yaml_cleanup.py
@@ -26,6 +26,9 @@ class CondaForgeYAMLCleanup(MiniMigrator):
 
     def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
         """remove recipes without a conda-forge.yml file that has the keys to remove or change"""
+        if super().filter(attrs):
+            return True
+
         cfy = attrs.get("conda-forge.yml", {})
         if any(key in cfy for key in (self.keys_to_remove + self.keys_to_change)):
             return False

--- a/conda_forge_tick/migrators/conda_forge_yaml_cleanup.py
+++ b/conda_forge_tick/migrators/conda_forge_yaml_cleanup.py
@@ -12,6 +12,7 @@ if typing.TYPE_CHECKING:
 
 
 class CondaForgeYAMLCleanup(MiniMigrator):
+    allowed_schema_versions = {0, 1}
     keys_to_remove = [
         "min_r_ver",
         "max_r_ver",

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -187,7 +187,7 @@ class MiniMigrator:
         bool :
             True if node is to be skipped
         """
-        return True
+        return skip_migrator_due_to_schema(attrs, self.allowed_schema_versions)
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
         """Perform the migration, updating the ``meta.yaml``

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -535,7 +535,7 @@ def _parse_recipes(
             "home": about.get("homepage"),
             "license": about.get("license"),
             "license_family": about.get("license"),
-            "license_file": about.get("license_file")[0],
+            "license_file": about.get("license_file", [None])[0],
             "summary": about.get("summary"),
         }
     )

--- a/tests/test_cfyaml_cleanup_migrator.py
+++ b/tests/test_cfyaml_cleanup_migrator.py
@@ -34,11 +34,15 @@ YAML_PATHS = [
 def test_version_cfyaml_cleanup(cases, recipe_version, tmpdir):
     yaml = YAML()
 
-    with open(os.path.join(YAML_PATHS[recipe_version], "version_cfyaml_cleanup_simple.yaml")) as fp:
+    with open(
+        os.path.join(YAML_PATHS[recipe_version], "version_cfyaml_cleanup_simple.yaml")
+    ) as fp:
         in_yaml = fp.read()
 
     with open(
-        os.path.join(YAML_PATHS[recipe_version], "version_cfyaml_cleanup_simple_correct.yaml"),
+        os.path.join(
+            YAML_PATHS[recipe_version], "version_cfyaml_cleanup_simple_correct.yaml"
+        ),
     ) as fp:
         out_yaml = fp.read()
 

--- a/tests/test_cfyaml_cleanup_migrator.py
+++ b/tests/test_cfyaml_cleanup_migrator.py
@@ -11,7 +11,10 @@ VERSION_CF = Version(
     piggy_back_migrations=[CondaForgeYAMLCleanup()],
 )
 
-YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")
+YAML_PATHS = [
+    os.path.join(os.path.dirname(__file__), "test_yaml"),
+    os.path.join(os.path.dirname(__file__), "test_v1_yaml"),
+]
 
 
 @pytest.mark.parametrize(
@@ -27,14 +30,15 @@ YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")
         ("compiler_stack"),
     ],
 )
-def test_version_cfyaml_cleanup(cases, tmpdir):
+@pytest.mark.parametrize("recipe_version", [0, 1])
+def test_version_cfyaml_cleanup(cases, recipe_version, tmpdir):
     yaml = YAML()
 
-    with open(os.path.join(YAML_PATH, "version_cfyaml_cleanup_simple.yaml")) as fp:
+    with open(os.path.join(YAML_PATHS[recipe_version], "version_cfyaml_cleanup_simple.yaml")) as fp:
         in_yaml = fp.read()
 
     with open(
-        os.path.join(YAML_PATH, "version_cfyaml_cleanup_simple_correct.yaml"),
+        os.path.join(YAML_PATHS[recipe_version], "version_cfyaml_cleanup_simple_correct.yaml"),
     ) as fp:
         out_yaml = fp.read()
 
@@ -59,7 +63,8 @@ def test_version_cfyaml_cleanup(cases, tmpdir):
             "migrator_version": Version.migrator_version,
             "version": "0.9",
         },
-        tmpdir=os.path.join(tmpdir, "recipe"),
+        tmpdir=os.path.join(tmpdir, "recipe" if recipe_version == 0 else "."),
+        recipe_version=recipe_version,
     )
 
     with open(cf_yml_pth) as fp:

--- a/tests/test_migrators.py
+++ b/tests/test_migrators.py
@@ -488,7 +488,7 @@ def run_test_migration(
         recipe_dir_p = tmpdir_p
     elif recipe_version == 1:
         tmpdir_p.joinpath(".ci_support").mkdir()
-        tmpdir_p.joinpath("recipe").mkdir()
+        tmpdir_p.joinpath("recipe").mkdir(exist_ok=True)
         tmpdir_p.joinpath("recipe", "recipe.yaml").write_text(inp)
 
         build_variants = (
@@ -527,7 +527,7 @@ def run_test_migration(
     recipe_dir = str(recipe_dir_p)
 
     # read the conda-forge.yml
-    cf_yml_path = Path(tmpdir).parent / "conda-forge.yml"
+    cf_yml_path = recipe_dir_p.parent / "conda-forge.yml"
     cf_yml = cf_yml_path.read_text() if cf_yml_path.exists() else "{}"
 
     # Load the meta.yaml (this is done in the graph)

--- a/tests/test_v1_yaml/version_cfyaml_cleanup_simple.yaml
+++ b/tests/test_v1_yaml/version_cfyaml_cleanup_simple.yaml
@@ -1,0 +1,45 @@
+schema_version: 1
+
+context:
+  version: 0.8
+
+package:
+  name: viscm
+  version: ${{ version }}
+
+source:
+  url: https://pypi.io/packages/source/v/viscm/viscm-v${{ version }}.zip
+  sha256: 5a9677fa4751c6dd18a5a74e7ec06848e4973d0ac0af3e4d795753b15a30c759
+
+build:
+  number: 0
+  skip: win
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - python
+    - pip
+    - numpy
+  run:
+    - python
+    - numpy
+    - matplotlib
+    - colorspacious
+
+tests:
+  - python:
+      imports:
+        - viscm
+      pip_check: false
+
+about:
+  license: MIT
+  # license_file: '' we need to an issue upstream to get a license in the source dist.
+  summary: A colormap tool
+  homepage: https://github.com/bids/viscm
+
+extra:
+  recipe-maintainers:
+    - kthyng

--- a/tests/test_v1_yaml/version_cfyaml_cleanup_simple_correct.yaml
+++ b/tests/test_v1_yaml/version_cfyaml_cleanup_simple_correct.yaml
@@ -1,0 +1,45 @@
+schema_version: 1
+
+context:
+  version: "0.9"
+
+package:
+  name: viscm
+  version: ${{ version }}
+
+source:
+  url: https://pypi.io/packages/source/v/viscm/viscm-${{ version }}.tar.gz
+  sha256: c770e4b76f726e653d2b7c2c73f71941a88de6eb47ccf8fb8e984b55562d05a2
+
+build:
+  number: 0
+  skip: win
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - python
+    - pip
+    - numpy
+  run:
+    - python
+    - numpy
+    - matplotlib
+    - colorspacious
+
+tests:
+  - python:
+      imports:
+        - viscm
+      pip_check: false
+
+about:
+  license: MIT
+  # license_file: '' we need to an issue upstream to get a license in the source dist.
+  summary: A colormap tool
+  homepage: https://github.com/bids/viscm
+
+extra:
+  recipe-maintainers:
+    - kthyng


### PR DESCRIPTION
#### Description:

Enable `CondaForgeYAMLCleanup` migrator for v1 recipes.  Since it works on `conda-forge.yml` only, it does not require any changes.  So the most of the changes are related to extending the test.

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
