### PR TITLE
Support recipe v1 in Build2HostMigrator

### DIFF
--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -40,7 +40,6 @@ from conda_forge_tick.lazy_json_backends import (
 )
 from conda_forge_tick.migrators import (
     ArchRebuild,
-    Build2HostMigrator,
     CondaForgeYAMLCleanup,
     CrossCompilationForARMAndPower,
     CrossPythonMigrator,
@@ -284,7 +283,6 @@ def add_arch_migrate(migrators: MutableSequence[Migrator], gx: nx.DiGraph) -> No
                 pr_limit=PR_LIMIT,
                 name="arm osx addition",
                 piggy_back_migrations=[
-                    Build2HostMigrator(),
                     UpdateConfigSubGuessMigrator(),
                     CondaForgeYAMLCleanup(),
                     UpdateCMakeArgsMigrator(),

--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -110,7 +110,6 @@ DEFAULT_MINI_MIGRATORS = [
     LicenseMigrator,
     CondaForgeYAMLCleanup,
     ExtraJinja2KeysCleanup,
-    Build2HostMigrator,
     NoCondaInspectMigrator,
     MPIPinRunAsBuildCleanup,
     PyPIOrgMigrator,

--- a/conda_forge_tick/migrators/cross_compile.py
+++ b/conda_forge_tick/migrators/cross_compile.py
@@ -270,12 +270,8 @@ class Build2HostMigrator(MiniMigrator):
             return True
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
-        recipe_file = (
-            "recipe.yaml"
-            if attrs["meta_yaml"].get("schema_version", 0) == 1
-            else "meta.yaml"
-        )
         with pushd(recipe_dir):
+            recipe_file = next(filter(os.path.exists, ("recipe.yaml", "meta.yaml")))
             with open(recipe_file) as fp:
                 meta_yaml = fp.readlines()
 

--- a/tests/test_cross_compile.py
+++ b/tests/test_cross_compile.py
@@ -225,8 +225,8 @@ def test_cross_python_no_build(tmp_path):
     )
 
 
-@flaky
 @pytest.mark.parametrize("recipe_version", [0, 1])
+@flaky
 def test_build2host(recipe_version, tmp_path):
     run_test_migration(
         m=version_migrator_b2h,
@@ -246,8 +246,8 @@ def test_build2host(recipe_version, tmp_path):
     )
 
 
-@flaky
 @pytest.mark.parametrize("recipe_version", [0, 1])
+@flaky
 def test_build2host_buildok(recipe_version, tmp_path):
     run_test_migration(
         m=version_migrator_b2h,
@@ -269,8 +269,8 @@ def test_build2host_buildok(recipe_version, tmp_path):
     )
 
 
-@flaky
 @pytest.mark.parametrize("recipe_version", [0, 1])
+@flaky
 def test_build2host_bhskip(recipe_version, tmp_path):
     run_test_migration(
         m=version_migrator_b2h,

--- a/tests/test_cross_compile.py
+++ b/tests/test_cross_compile.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 from flaky import flaky
 from test_migrators import run_test_migration
 
@@ -14,7 +15,11 @@ from conda_forge_tick.migrators import (
     Version,
 )
 
-YAML_PATH = Path(__file__).parent / "test_yaml/cross_compile"
+YAML_PATHS = [
+    Path(__file__).parent / "test_yaml/cross_compile",
+    Path(__file__).parent / "test_v1_yaml/cross_compile",
+]
+YAML_PATH = YAML_PATHS[0]
 
 config_migrator = UpdateConfigSubGuessMigrator()
 guard_testing_migrator = GuardTestingMigrator()
@@ -221,11 +226,14 @@ def test_cross_python_no_build(tmp_path):
 
 
 @flaky
-def test_build2host(tmp_path):
+@pytest.mark.parametrize("recipe_version", [0, 1])
+def test_build2host(recipe_version, tmp_path):
     run_test_migration(
         m=version_migrator_b2h,
-        inp=YAML_PATH.joinpath("python_recipe_b2h.yaml").read_text(),
-        output=YAML_PATH.joinpath("python_recipe_b2h_correct.yaml").read_text(),
+        inp=YAML_PATHS[recipe_version].joinpath("python_recipe_b2h.yaml").read_text(),
+        output=YAML_PATHS[recipe_version]
+        .joinpath("python_recipe_b2h_correct.yaml")
+        .read_text(),
         prb="Dependencies have been updated if changed",
         kwargs={"new_version": "1.19.1"},
         mr_out={
@@ -234,15 +242,21 @@ def test_build2host(tmp_path):
             "version": "1.19.1",
         },
         tmp_path=tmp_path,
+        recipe_version=recipe_version,
     )
 
 
 @flaky
-def test_build2host_buildok(tmp_path):
+@pytest.mark.parametrize("recipe_version", [0, 1])
+def test_build2host_buildok(recipe_version, tmp_path):
     run_test_migration(
         m=version_migrator_b2h,
-        inp=YAML_PATH.joinpath("python_recipe_b2h_buildok.yaml").read_text(),
-        output=YAML_PATH.joinpath("python_recipe_b2h_buildok_correct.yaml").read_text(),
+        inp=YAML_PATHS[recipe_version]
+        .joinpath("python_recipe_b2h_buildok.yaml")
+        .read_text(),
+        output=YAML_PATHS[recipe_version]
+        .joinpath("python_recipe_b2h_buildok_correct.yaml")
+        .read_text(),
         prb="Dependencies have been updated if changed",
         kwargs={"new_version": "1.19.1"},
         mr_out={
@@ -251,15 +265,21 @@ def test_build2host_buildok(tmp_path):
             "version": "1.19.1",
         },
         tmp_path=tmp_path,
+        recipe_version=recipe_version,
     )
 
 
 @flaky
-def test_build2host_bhskip(tmp_path):
+@pytest.mark.parametrize("recipe_version", [0, 1])
+def test_build2host_bhskip(recipe_version, tmp_path):
     run_test_migration(
         m=version_migrator_b2h,
-        inp=YAML_PATH.joinpath("python_recipe_b2h_bhskip.yaml").read_text(),
-        output=YAML_PATH.joinpath("python_recipe_b2h_bhskip_correct.yaml").read_text(),
+        inp=YAML_PATHS[recipe_version]
+        .joinpath("python_recipe_b2h_bhskip.yaml")
+        .read_text(),
+        output=YAML_PATHS[recipe_version]
+        .joinpath("python_recipe_b2h_bhskip_correct.yaml")
+        .read_text(),
         prb="Dependencies have been updated if changed",
         kwargs={"new_version": "1.19.1"},
         mr_out={
@@ -268,6 +288,7 @@ def test_build2host_bhskip(tmp_path):
             "version": "1.19.1",
         },
         tmp_path=tmp_path,
+        recipe_version=recipe_version,
     )
 
 

--- a/tests/test_v1_yaml/cross_compile/python_recipe_b2h.yaml
+++ b/tests/test_v1_yaml/cross_compile/python_recipe_b2h.yaml
@@ -1,0 +1,62 @@
+schema_version: 1
+
+context:
+  version: 1.19.0
+
+package:
+  name: numpy
+  version: ${{ version }}
+
+source:
+  url: https://github.com/numpy/numpy/releases/download/v${{ version }}/numpy-${{ version }}.tar.gz
+  sha256: 153cf8b0176e57a611931981acfe093d2f7fef623b48f91176efa199798a6b90
+
+build:
+  number: 0
+  python:
+    entry_points:
+      - if: win
+        then: f2py = numpy.f2py.f2py2e:main
+
+requirements:
+  build:
+    - python
+    - pip
+    - cython
+    - libblas
+    - libcblas
+    - liblapack
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - numpy
+        - numpy.linalg.lapack_lite
+  - requirements:
+      run:
+        - pytest
+        - hypothesis
+    script:
+      - f2py -h
+      - if: unix
+        then: export OPENBLAS_NUM_THREADS=1
+      - if: win
+        then: set OPENBLAS_NUM_THREADS=1
+
+about:
+  license: BSD-3-Clause
+  license_file: LICENSE.txt
+  summary: Array processing for numbers, strings, records, and objects.
+  homepage: http://numpy.scipy.org/
+  repository: https://github.com/numpy/numpy
+  documentation: https://docs.scipy.org/doc/numpy/reference/
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - msarahan
+    - pelson
+    - rgommers
+    - ocefpaf

--- a/tests/test_v1_yaml/cross_compile/python_recipe_b2h_bhskip.yaml
+++ b/tests/test_v1_yaml/cross_compile/python_recipe_b2h_bhskip.yaml
@@ -1,0 +1,58 @@
+schema_version: 1
+
+context:
+  version: 1.19.0
+
+package:
+  name: numpy
+  version: ${{ version }}
+
+source:
+  url: https://github.com/numpy/numpy/releases/download/v${{ version }}/numpy-${{ version }}.tar.gz
+  sha256: 153cf8b0176e57a611931981acfe093d2f7fef623b48f91176efa199798a6b90
+
+build:
+  number: 0
+  python:
+    entry_points:
+      - if: win
+        then: f2py = numpy.f2py.f2py2e:main
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+  host:
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - numpy
+        - numpy.linalg.lapack_lite
+  - requirements:
+      run:
+        - pytest
+        - hypothesis
+    script:
+      - f2py -h
+      - if: unix
+        then: export OPENBLAS_NUM_THREADS=1
+      - if: win
+        then: set OPENBLAS_NUM_THREADS=1
+
+about:
+  license: BSD-3-Clause
+  license_file: LICENSE.txt
+  summary: Array processing for numbers, strings, records, and objects.
+  homepage: http://numpy.scipy.org/
+  repository: https://github.com/numpy/numpy
+  documentation: https://docs.scipy.org/doc/numpy/reference/
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - msarahan
+    - pelson
+    - rgommers
+    - ocefpaf

--- a/tests/test_v1_yaml/cross_compile/python_recipe_b2h_bhskip_correct.yaml
+++ b/tests/test_v1_yaml/cross_compile/python_recipe_b2h_bhskip_correct.yaml
@@ -1,0 +1,58 @@
+schema_version: 1
+
+context:
+  version: "1.19.1"
+
+package:
+  name: numpy
+  version: ${{ version }}
+
+source:
+  url: https://github.com/numpy/numpy/releases/download/v${{ version }}/numpy-${{ version }}.tar.gz
+  sha256: 1396e6c3d20cbfc119195303b0272e749610b7042cc498be4134f013e9a3215c
+
+build:
+  number: 0
+  python:
+    entry_points:
+      - if: win
+        then: f2py = numpy.f2py.f2py2e:main
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+  host:
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - numpy
+        - numpy.linalg.lapack_lite
+  - requirements:
+      run:
+        - pytest
+        - hypothesis
+    script:
+      - f2py -h
+      - if: unix
+        then: export OPENBLAS_NUM_THREADS=1
+      - if: win
+        then: set OPENBLAS_NUM_THREADS=1
+
+about:
+  license: BSD-3-Clause
+  license_file: LICENSE.txt
+  summary: Array processing for numbers, strings, records, and objects.
+  homepage: http://numpy.scipy.org/
+  repository: https://github.com/numpy/numpy
+  documentation: https://docs.scipy.org/doc/numpy/reference/
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - msarahan
+    - pelson
+    - rgommers
+    - ocefpaf

--- a/tests/test_v1_yaml/cross_compile/python_recipe_b2h_buildok.yaml
+++ b/tests/test_v1_yaml/cross_compile/python_recipe_b2h_buildok.yaml
@@ -1,0 +1,63 @@
+schema_version: 1
+
+context:
+  version: 1.19.0
+
+package:
+  name: numpy
+  version: ${{ version }}
+
+source:
+  url: https://github.com/numpy/numpy/releases/download/v${{ version }}/numpy-${{ version }}.tar.gz
+  sha256: 153cf8b0176e57a611931981acfe093d2f7fef623b48f91176efa199798a6b90
+
+build:
+  number: 0
+  python:
+    entry_points:
+      - if: win
+        then: f2py = numpy.f2py.f2py2e:main
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - python
+    - pip
+    - cython
+    - libblas
+    - libcblas
+    - liblapack
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - numpy
+        - numpy.linalg.lapack_lite
+  - requirements:
+      run:
+        - pytest
+        - hypothesis
+    script:
+      - f2py -h
+      - if: unix
+        then: export OPENBLAS_NUM_THREADS=1
+      - if: win
+        then: set OPENBLAS_NUM_THREADS=1
+
+about:
+  license: BSD-3-Clause
+  license_file: LICENSE.txt
+  summary: Array processing for numbers, strings, records, and objects.
+  homepage: http://numpy.scipy.org/
+  repository: https://github.com/numpy/numpy
+  documentation: https://docs.scipy.org/doc/numpy/reference/
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - msarahan
+    - pelson
+    - rgommers
+    - ocefpaf

--- a/tests/test_v1_yaml/cross_compile/python_recipe_b2h_buildok_correct.yaml
+++ b/tests/test_v1_yaml/cross_compile/python_recipe_b2h_buildok_correct.yaml
@@ -1,0 +1,63 @@
+schema_version: 1
+
+context:
+  version: "1.19.1"
+
+package:
+  name: numpy
+  version: ${{ version }}
+
+source:
+  url: https://github.com/numpy/numpy/releases/download/v${{ version }}/numpy-${{ version }}.tar.gz
+  sha256: 1396e6c3d20cbfc119195303b0272e749610b7042cc498be4134f013e9a3215c
+
+build:
+  number: 0
+  python:
+    entry_points:
+      - if: win
+        then: f2py = numpy.f2py.f2py2e:main
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - python
+    - pip
+    - cython
+    - libblas
+    - libcblas
+    - liblapack
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - numpy
+        - numpy.linalg.lapack_lite
+  - requirements:
+      run:
+        - pytest
+        - hypothesis
+    script:
+      - f2py -h
+      - if: unix
+        then: export OPENBLAS_NUM_THREADS=1
+      - if: win
+        then: set OPENBLAS_NUM_THREADS=1
+
+about:
+  license: BSD-3-Clause
+  license_file: LICENSE.txt
+  summary: Array processing for numbers, strings, records, and objects.
+  homepage: http://numpy.scipy.org/
+  repository: https://github.com/numpy/numpy
+  documentation: https://docs.scipy.org/doc/numpy/reference/
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - msarahan
+    - pelson
+    - rgommers
+    - ocefpaf

--- a/tests/test_v1_yaml/cross_compile/python_recipe_b2h_correct.yaml
+++ b/tests/test_v1_yaml/cross_compile/python_recipe_b2h_correct.yaml
@@ -1,0 +1,62 @@
+schema_version: 1
+
+context:
+  version: "1.19.1"
+
+package:
+  name: numpy
+  version: ${{ version }}
+
+source:
+  url: https://github.com/numpy/numpy/releases/download/v${{ version }}/numpy-${{ version }}.tar.gz
+  sha256: 1396e6c3d20cbfc119195303b0272e749610b7042cc498be4134f013e9a3215c
+
+build:
+  number: 0
+  python:
+    entry_points:
+      - if: win
+        then: f2py = numpy.f2py.f2py2e:main
+
+requirements:
+  host:
+    - python
+    - pip
+    - cython
+    - libblas
+    - libcblas
+    - liblapack
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - numpy
+        - numpy.linalg.lapack_lite
+  - requirements:
+      run:
+        - pytest
+        - hypothesis
+    script:
+      - f2py -h
+      - if: unix
+        then: export OPENBLAS_NUM_THREADS=1
+      - if: win
+        then: set OPENBLAS_NUM_THREADS=1
+
+about:
+  license: BSD-3-Clause
+  license_file: LICENSE.txt
+  summary: Array processing for numbers, strings, records, and objects.
+  homepage: http://numpy.scipy.org/
+  repository: https://github.com/numpy/numpy
+  documentation: https://docs.scipy.org/doc/numpy/reference/
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - msarahan
+    - pelson
+    - rgommers
+    - ocefpaf


### PR DESCRIPTION
#### Description:

Add support for v1 recipes in `Build2HostMigrator`, and extend the relevant tests. I've also replaced the explicit schema version check with a `super()` call.

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

From the list on #3642
