### PR TITLE
fix: change url in readline recipe tests to a stable url

### DIFF
--- a/tests/test_cross_compile.py
+++ b/tests/test_cross_compile.py
@@ -109,7 +109,7 @@ def test_make_check(tmp_path):
     expected = [
         "#!/bin/bash\n",
         "# Get an updated config.sub and config.guess\n",
-        "cp $BUILD_PREFIX/share/gnuconfig/config.* ./support\n",
+        "cp $BUILD_PREFIX/share/gnuconfig/config.* ./config\n",
         'if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" || "${CROSSCOMPILING_EMULATOR}" != "" ]]; then\n',
         "make check\n",
         "fi\n",

--- a/tests/test_cross_compile.py
+++ b/tests/test_cross_compile.py
@@ -76,11 +76,11 @@ def test_correct_config_sub(tmp_path):
         inp=YAML_PATH.joinpath("config_recipe.yaml").read_text(),
         output=YAML_PATH.joinpath("config_recipe_correct.yaml").read_text(),
         prb="Dependencies have been updated if changed",
-        kwargs={"new_version": "2025.3.50"},
+        kwargs={"new_version": "4.5.0"},
         mr_out={
             "migrator_name": Version.name,
             "migrator_version": Version.migrator_version,
-            "version": "2025.3.50",
+            "version": "4.5.0",
         },
         tmp_path=tmp_path,
     )
@@ -98,11 +98,11 @@ def test_make_check(tmp_path):
         inp=YAML_PATH.joinpath("config_recipe.yaml").read_text(),
         output=YAML_PATH.joinpath("config_recipe_correct_make_check.yaml").read_text(),
         prb="Dependencies have been updated if changed",
-        kwargs={"new_version": "2025.3.50"},
+        kwargs={"new_version": "4.5.0"},
         mr_out={
             "migrator_name": Version.name,
             "migrator_version": Version.migrator_version,
-            "version": "2025.3.50",
+            "version": "4.5.0",
         },
         tmp_path=tmp_path,
     )
@@ -129,11 +129,11 @@ def test_cmake(tmp_path):
         inp=YAML_PATH.joinpath("config_recipe.yaml").read_text(),
         output=YAML_PATH.joinpath("config_recipe_correct_cmake.yaml").read_text(),
         prb="Dependencies have been updated if changed",
-        kwargs={"new_version": "2025.3.50"},
+        kwargs={"new_version": "4.5.0"},
         mr_out={
             "migrator_name": Version.name,
             "migrator_version": Version.migrator_version,
-            "version": "2025.3.50",
+            "version": "4.5.0",
         },
         tmp_path=tmp_path,
     )

--- a/tests/test_cross_compile.py
+++ b/tests/test_cross_compile.py
@@ -76,7 +76,7 @@ def test_correct_config_sub(tmp_path):
         inp=YAML_PATH.joinpath("config_recipe.yaml").read_text(),
         output=YAML_PATH.joinpath("config_recipe_correct.yaml").read_text(),
         prb="Dependencies have been updated if changed",
-        kwargs={"new_version": "8.0"},
+        kwargs={"new_version": "2025.3.50"},
         mr_out={
             "migrator_name": Version.name,
             "migrator_version": Version.migrator_version,
@@ -98,7 +98,7 @@ def test_make_check(tmp_path):
         inp=YAML_PATH.joinpath("config_recipe.yaml").read_text(),
         output=YAML_PATH.joinpath("config_recipe_correct_make_check.yaml").read_text(),
         prb="Dependencies have been updated if changed",
-        kwargs={"new_version": "8.0"},
+        kwargs={"new_version": "2025.3.50"},
         mr_out={
             "migrator_name": Version.name,
             "migrator_version": Version.migrator_version,
@@ -129,7 +129,7 @@ def test_cmake(tmp_path):
         inp=YAML_PATH.joinpath("config_recipe.yaml").read_text(),
         output=YAML_PATH.joinpath("config_recipe_correct_cmake.yaml").read_text(),
         prb="Dependencies have been updated if changed",
-        kwargs={"new_version": "8.0"},
+        kwargs={"new_version": "2025.3.50"},
         mr_out={
             "migrator_name": Version.name,
             "migrator_version": Version.migrator_version,

--- a/tests/test_cross_compile.py
+++ b/tests/test_cross_compile.py
@@ -80,7 +80,7 @@ def test_correct_config_sub(tmp_path):
         mr_out={
             "migrator_name": Version.name,
             "migrator_version": Version.migrator_version,
-            "version": "8.0",
+            "version": "2025.3.50",
         },
         tmp_path=tmp_path,
     )
@@ -102,7 +102,7 @@ def test_make_check(tmp_path):
         mr_out={
             "migrator_name": Version.name,
             "migrator_version": Version.migrator_version,
-            "version": "8.0",
+            "version": "2025.3.50",
         },
         tmp_path=tmp_path,
     )
@@ -133,7 +133,7 @@ def test_cmake(tmp_path):
         mr_out={
             "migrator_name": Version.name,
             "migrator_version": Version.migrator_version,
-            "version": "8.0",
+            "version": "2025.3.50",
         },
         tmp_path=tmp_path,
     )

--- a/tests/test_yaml/cross_compile/config_recipe.yaml
+++ b/tests/test_yaml/cross_compile/config_recipe.yaml
@@ -1,11 +1,11 @@
-{% set version = "2025.3.49" %}
+{% set version = "4.4.1" %}
 
 package:
   name: readline
   version: {{ version }}
 
 source:
-  url: https://github.com/regro/cf-scripts/archive/refs/tags/{{ version }}.tar.gz
+  url: https://github.com/HEASARC/cfitsio/archive/refs/tags/cfitsio-{{ version }}.tar.gz
   sha256: 750d437185286f40a369e1e4f4764eda932b9459b5ec9a731628393dd3d32334
 
 build:

--- a/tests/test_yaml/cross_compile/config_recipe.yaml
+++ b/tests/test_yaml/cross_compile/config_recipe.yaml
@@ -1,11 +1,11 @@
-{% set version = "7.0" %}
+{% set version = "2025.3.49" %}
 
 package:
   name: readline
   version: {{ version }}
 
 source:
-  url: https://ftp.gnu.org/gnu/readline/readline-{{ version }}.tar.gz
+  url: https://github.com/regro/cf-scripts/archive/refs/tags/{{ version }}.tar.gz
   sha256: 750d437185286f40a369e1e4f4764eda932b9459b5ec9a731628393dd3d32334
 
 build:

--- a/tests/test_yaml/cross_compile/config_recipe_correct.yaml
+++ b/tests/test_yaml/cross_compile/config_recipe_correct.yaml
@@ -1,12 +1,12 @@
-{% set version = "2025.3.50" %}
+{% set version = "4.5.0" %}
 
 package:
   name: readline
   version: {{ version }}
 
 source:
-  url: https://github.com/regro/cf-scripts/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 18f6510c0e482eb385b9afe3d25482c42804a7fe6e6e9dda9b7375231ceaa0e6
+  url: https://github.com/HEASARC/cfitsio/archive/refs/tags/cfitsio-{{ version }}.tar.gz
+  sha256: 93db9e519efe372657d97e96e68c888aa65696b0ee31408780efa6388563989b
 
 build:
   skip: true  # [win]

--- a/tests/test_yaml/cross_compile/config_recipe_correct.yaml
+++ b/tests/test_yaml/cross_compile/config_recipe_correct.yaml
@@ -1,11 +1,11 @@
-{% set version = "8.0" %}
+{% set version = "2025.3.50" %}
 
 package:
   name: readline
   version: {{ version }}
 
 source:
-  url: https://ftp.gnu.org/gnu/readline/readline-{{ version }}.tar.gz
+  url: https://github.com/regro/cf-scripts/archive/refs/tags/{{ version }}.tar.gz
   sha256: e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461
 
 build:

--- a/tests/test_yaml/cross_compile/config_recipe_correct.yaml
+++ b/tests/test_yaml/cross_compile/config_recipe_correct.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/regro/cf-scripts/archive/refs/tags/{{ version }}.tar.gz
-  sha256: e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461
+  sha256: 18f6510c0e482eb385b9afe3d25482c42804a7fe6e6e9dda9b7375231ceaa0e6
 
 build:
   skip: true  # [win]

--- a/tests/test_yaml/cross_compile/config_recipe_correct_cmake.yaml
+++ b/tests/test_yaml/cross_compile/config_recipe_correct_cmake.yaml
@@ -1,12 +1,12 @@
-{% set version = "2025.3.50" %}
+{% set version = "4.5.0" %}
 
 package:
   name: readline
   version: {{ version }}
 
 source:
-  url: https://github.com/regro/cf-scripts/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 18f6510c0e482eb385b9afe3d25482c42804a7fe6e6e9dda9b7375231ceaa0e6
+  url: https://github.com/HEASARC/cfitsio/archive/refs/tags/cfitsio-{{ version }}.tar.gz
+  sha256: 93db9e519efe372657d97e96e68c888aa65696b0ee31408780efa6388563989b
 
 build:
   skip: true  # [win]

--- a/tests/test_yaml/cross_compile/config_recipe_correct_cmake.yaml
+++ b/tests/test_yaml/cross_compile/config_recipe_correct_cmake.yaml
@@ -1,11 +1,11 @@
-{% set version = "8.0" %}
+{% set version = "2025.3.50" %}
 
 package:
   name: readline
   version: {{ version }}
 
 source:
-  url: https://ftp.gnu.org/gnu/readline/readline-{{ version }}.tar.gz
+  url: https://github.com/regro/cf-scripts/archive/refs/tags/{{ version }}.tar.gz
   sha256: e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461
 
 build:

--- a/tests/test_yaml/cross_compile/config_recipe_correct_cmake.yaml
+++ b/tests/test_yaml/cross_compile/config_recipe_correct_cmake.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/regro/cf-scripts/archive/refs/tags/{{ version }}.tar.gz
-  sha256: e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461
+  sha256: 18f6510c0e482eb385b9afe3d25482c42804a7fe6e6e9dda9b7375231ceaa0e6
 
 build:
   skip: true  # [win]

--- a/tests/test_yaml/cross_compile/config_recipe_correct_make_check.yaml
+++ b/tests/test_yaml/cross_compile/config_recipe_correct_make_check.yaml
@@ -1,12 +1,12 @@
-{% set version = "2025.3.50" %}
+{% set version = "4.5.0" %}
 
 package:
   name: readline
   version: {{ version }}
 
 source:
-  url: https://github.com/regro/cf-scripts/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 18f6510c0e482eb385b9afe3d25482c42804a7fe6e6e9dda9b7375231ceaa0e6
+  url: https://github.com/HEASARC/cfitsio/archive/refs/tags/cfitsio-{{ version }}.tar.gz
+  sha256: 93db9e519efe372657d97e96e68c888aa65696b0ee31408780efa6388563989b
 
 build:
   skip: true  # [win]

--- a/tests/test_yaml/cross_compile/config_recipe_correct_make_check.yaml
+++ b/tests/test_yaml/cross_compile/config_recipe_correct_make_check.yaml
@@ -1,11 +1,11 @@
-{% set version = "8.0" %}
+{% set version = "2025.3.50" %}
 
 package:
   name: readline
   version: {{ version }}
 
 source:
-  url: https://ftp.gnu.org/gnu/readline/readline-{{ version }}.tar.gz
+  url: https://github.com/regro/cf-scripts/archive/refs/tags/{{ version }}.tar.gz
   sha256: e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461
 
 build:

--- a/tests/test_yaml/cross_compile/config_recipe_correct_make_check.yaml
+++ b/tests/test_yaml/cross_compile/config_recipe_correct_make_check.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/regro/cf-scripts/archive/refs/tags/{{ version }}.tar.gz
-  sha256: e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461
+  sha256: 18f6510c0e482eb385b9afe3d25482c42804a7fe6e6e9dda9b7375231ceaa0e6
 
 build:
   skip: true  # [win]


### PR DESCRIPTION
This PR should fix some of the flaky readline cross-compile tests.