### PR TITLE
fix: find the last version tag as the max to fix a race condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         id: version
         if: ${{ ! env.CI_SKIP }}
         run: |
-          echo "current version: "$(git tag --sort=committerdate | tail -1)
+          echo "recent version tags: "$(git tag --sort=committerdate | tail -4)
           NEXT=$(python autotick-bot/compute_next_version.py)
           echo "next version: ${NEXT}"
           echo "NEXT=${NEXT}" >> "$GITHUB_OUTPUT"

--- a/autotick-bot/compute_next_version.py
+++ b/autotick-bot/compute_next_version.py
@@ -38,7 +38,7 @@ else:
                 curr_version = _version
                 curr_version_line = line
     assert curr_version is not None
-    print("found current version: %s" % curr_version_line, file=sys.stderr, flush=True)
+    print(f"found current version: {curr_version_line}", file=sys.stderr, flush=True)
 
     # figure out if we bump the major, minor or patch version
     major_minor, patch = curr_version_line.rsplit(".", 1)

--- a/autotick-bot/compute_next_version.py
+++ b/autotick-bot/compute_next_version.py
@@ -2,6 +2,8 @@ import datetime
 import subprocess
 import sys
 
+from conda.models.version import VersionOrder
+
 # get the current date for tagging below
 now = datetime.datetime.utcnow()
 
@@ -18,15 +20,19 @@ if res.returncode != 0 or (not res.stdout.strip()):
 else:
     # we have a tag so bump
     curr_version = None
+    curr_version_line = None
     for line in res.stdout.splitlines():
         line = line.strip()
         if line:
-            curr_version = line
+            _version = VersionOrder(line)
+            if curr_version is None or _version > curr_version:
+                curr_version = _version
+                curr_version_line = line
     assert curr_version is not None
-    print("found current version: %s" % line, file=sys.stderr, flush=True)
+    print("found current version: %s" % curr_version_line, file=sys.stderr, flush=True)
 
     # figure out if we bump the major, minor or patch version
-    major_minor, patch = curr_version.rsplit(".", 1)
+    major_minor, patch = curr_version_line.rsplit(".", 1)
     now_major_minor = f"{now.year}.{now.month}"
     if major_minor == now_major_minor:
         new_version = f"{major_minor}.{int(patch) + 1}"

--- a/autotick-bot/compute_next_version.py
+++ b/autotick-bot/compute_next_version.py
@@ -28,7 +28,7 @@ else:
                 _version = VersionOrder(line)
             except Exception:
                 print(
-                    "skipping tag that is not a version: {line}",
+                    f"skipping tag that is not a version: {line}",
                     file=sys.stderr,
                     flush=True,
                 )

--- a/autotick-bot/compute_next_version.py
+++ b/autotick-bot/compute_next_version.py
@@ -24,7 +24,16 @@ else:
     for line in res.stdout.splitlines():
         line = line.strip()
         if line:
-            _version = VersionOrder(line)
+            try:
+                _version = VersionOrder(line)
+            except Exception:
+                print(
+                    "skipping tag that is not a version: {line}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                continue
+
             if curr_version is None or _version > curr_version:
                 curr_version = _version
                 curr_version_line = line


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

Somehow the release workflow got out of order, as reported in #3864.

this PR fixes that by properly computing the maximum version tag instead of using the most recent tag.

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->


Closes #3864 