### PR TITLE
NEW: Migrate NVIDIA redist feedstocks to use cf-nvidia-tools AGAIN

### DIFF
--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -39,6 +39,7 @@ from conda_forge_tick.lazy_json_backends import (
     remove_key_for_hashmap,
 )
 from conda_forge_tick.migrators import (
+    AddNVIDIATools,
     ArchRebuild,
     CondaForgeYAMLCleanup,
     CrossCompilationForARMAndPower,
@@ -859,6 +860,12 @@ def initialize_migrators(
     )
 
     add_noarch_python_min_migrator(migrators, gx)
+
+    migrators.append(
+        AddNVIDIATools(
+            check_solvable=False,
+        )
+    )
 
     add_static_lib_migrator(migrators, gx)
 

--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -833,6 +833,27 @@ def add_static_lib_migrator(migrators: MutableSequence[Migrator], gx: nx.DiGraph
         migrators[-1].pr_limit = pr_limit
 
 
+def add_nvtools_migrator(
+    migrators: MutableSequence[Migrator],
+    gx: nx.DiGraph,
+):
+    migrators.append(
+        AddNVIDIATools(
+            check_solvable=False,
+            graph=copy.deepcopy(gx),
+            pr_limit=PR_LIMIT,
+            piggy_back_migrations=_make_mini_migrators_with_defaults(
+                extra_mini_migrators=[YAMLRoundTrip()],
+            ),
+        )
+    )
+    pr_limit, _, _ = _compute_migrator_pr_limit(
+        migrators[-1],
+        PR_LIMIT,
+    )
+    migrators[-1].pr_limit = pr_limit
+
+
 def initialize_migrators(
     gx: nx.DiGraph,
     dry_run: bool = False,
@@ -861,13 +882,9 @@ def initialize_migrators(
 
     add_noarch_python_min_migrator(migrators, gx)
 
-    migrators.append(
-        AddNVIDIATools(
-            check_solvable=False,
-        )
-    )
-
     add_static_lib_migrator(migrators, gx)
+
+    add_nvtools_migrator(migrators, gx)
 
     pinning_migrators: List[Migrator] = []
     migration_factory(pinning_migrators, gx)

--- a/conda_forge_tick/migrators/__init__.py
+++ b/conda_forge_tick/migrators/__init__.py
@@ -40,5 +40,6 @@ from .replacement import Replacement, MiniReplacement
 from .use_pip import PipMigrator
 from .version import Version
 from .noarch_python_min import NoarchPythonMinMigrator
+from .nvtools import AddNVIDIATools
 from .round_trip import YAMLRoundTrip
 from .staticlib import StaticLibMigrator

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -219,7 +219,19 @@ class MiniMigrator:
 
 
 class Migrator:
-    """Base class for Migrators"""
+    """Base class for Migrators
+
+    Inheritors
+    ----------
+    Subclasses of Migrator should have at least the following in their __init__ function:
+    
+    ```python
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._reset_effective_graph()
+    ```
+    
+    """
 
     name: str
 

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -224,13 +224,13 @@ class Migrator:
     Inheritors
     ----------
     Subclasses of Migrator should have at least the following in their __init__ function:
-    
+
     ```python
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._reset_effective_graph()
     ```
-    
+
     """
 
     name: str

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -231,6 +231,17 @@ class Migrator:
         self._reset_effective_graph()
     ```
 
+    Initialization of Instances
+    ---------------------------
+    When a migrator is initialized, you need to supply at least the following items
+
+    - pr_limit: The number of PRs the migrator can open in a given run of the bot.
+    - graph: The graph of feedstocks to be migrated.
+
+    The graph you feed the migrator should be the entire graph of feedstocks the
+    migrator could ever run on. If a migrator skips a feedstock because that migrator
+    does not apply to that feedstock, then it should not be in the graph passed to the
+    migrator. If you do not do this, the status page statistics will be incorrect.
     """
 
     name: str

--- a/conda_forge_tick/migrators/nvtools.py
+++ b/conda_forge_tick/migrators/nvtools.py
@@ -1,0 +1,245 @@
+import copy
+import logging
+import os.path
+from typing import Any
+
+from conda_forge_tick.contexts import ClonedFeedstockContext
+from conda_forge_tick.migrators_types import AttrsTypedDict, MigrationUidTypedDict
+from conda_forge_tick.utils import (
+    get_bot_run_url,
+    yaml_safe_dump,
+    yaml_safe_load,
+)
+
+from .core import Migrator
+
+
+def _file_contains(filename: str, string: str) -> bool:
+    """Return whether the given file contains the given string."""
+    with open(filename) as f:
+        return string in f.read()
+
+
+def _insert_subsection(
+    filename: str,
+    section: str,
+    subsection: str,
+    new_item: str,
+) -> None:
+    """Append a new item onto the end of the section.subsection of a recipe."""
+    # Strategy: Read the file as a list of strings. Split the file in half at the end of the
+    # section.subsection section. Append the new_item to the first half. Combine the two
+    # file halves. Write the file back to disk.
+    first_half: list[str] = []
+    second_half: list[str] = []
+    break_located: bool = False
+    section_found: bool = False
+    subsection_found: bool = False
+    with open(filename) as f:
+        for line in f:
+            if break_located:
+                second_half.append(line)
+            else:
+                if line.startswith(section):
+                    section_found = True
+                elif section_found and line.lstrip().startswith(subsection):
+                    subsection_found = True
+                elif section_found and subsection_found:
+                    if line.lstrip().startswith("-"):
+                        # Inside section.subsection elements start with "-". We assume there
+                        # is at least one item under section.subsection already.
+                        first_half.append(line)
+                        continue
+                    else:
+                        break_located = True
+                        second_half.append(line)
+                        continue
+                first_half.append(line)
+
+    if not break_located:
+        # Don't overwrite file if we didn't find section.subsection
+        return
+
+    with open(filename, "w") as f:
+        f.writelines(first_half + [new_item] + second_half)
+
+
+class AddNVIDIATools(Migrator):
+    """Add the cf-nvidia-tools package to NVIDIA redist feedstocks.
+
+    In order to ensure that NVIDIA's redistributed binaries (redists) are being packaged
+    correctly, NVIDIA has created a package containing a collection of tools to perform
+    common actions for NVIDIA recipes.
+
+    At this time, the package may be used to check Linux binaries for their minimum glibc
+    requirement in order to ensure that the correct metadata is being used in the conda
+    package.
+
+    This migrator will attempt to add this glibc check to all feedstocks which download any
+    artifacts from https://developer.download.nvidia.com. The check involves adding
+    "cf-nvidia-tools" to the top-level build requirements and something like:
+
+    ```bash
+    check-glibc "$PREFIX"/lib/*.so.* "$PREFIX"/bin/*
+    ```
+
+    to the build script after the package artifacts have been installed.
+
+    > [!NOTE]
+    > A human needs to verify that the glob expression is checking all of the correct
+    > artifacts!
+
+    > [!NOTE]
+    > If the recipe does not have a top-level requirements.build section, it should be
+    > refactored so that the top-level package does not share a name with one of the
+    > outputs. i.e. The top-level package name should be something like "libcufoo-split".
+
+    More information about cf-nvidia-tools is available in the feedstock's
+    [README](https://github.com/conda-forge/cf-nvidia-tools-feedstock/tree/main/recipe).
+
+    Please ping carterbox for questions.
+    """
+
+    name = "NVIDIA Tools Migrator"
+
+    rerender = True
+
+    max_solver_attempts = 3
+
+    migrator_version = 0
+
+    allow_empty_commits = False
+
+    allowed_schema_versions = [0]
+
+    def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
+        """If true don't act upon node
+
+        Parameters
+        ----------
+        attrs : dict
+            The node attributes
+        not_bad_str_start : str, optional
+            If the 'bad' notice starts with the string then it is not
+            to be excluded. For example, rebuild migrations don't need
+            to worry about if the upstream can be fetched. Defaults to ``''``
+
+        Returns
+        -------
+        bool :
+            True if node is to be skipped
+        """
+        return (
+            super().filter(attrs)
+            or attrs["archived"]
+            or "https://developer.download.nvidia.com" not in attrs["source"]["url"]
+        )
+
+    def migrate(
+        self, recipe_dir: str, attrs: AttrsTypedDict, **kwargs: Any
+    ) -> MigrationUidTypedDict:
+        """Perform the migration, updating the ``meta.yaml``
+
+        Parameters
+        ----------
+        recipe_dir : str
+            The directory of the recipe
+        attrs : dict
+            The node attributes
+
+        Returns
+        -------
+        namedtuple or bool:
+            If namedtuple continue with PR, if False scrap local folder
+        """
+        meta = os.path.join(recipe_dir, "meta.yaml")
+
+        # STEP 0: Bump the build number
+        self.set_build_number(meta)
+
+        # STEP 1: Add cf-nvidia-tools to build requirements
+        if _file_contains(meta, "cf-nvidia-tools"):
+            logging.debug("cf-nvidia-tools already in meta.yaml; not adding again.")
+        else:
+            _insert_subsection(
+                meta,
+                "requirements",
+                "build",
+                "    - cf-nvidia-tools 1  # [linux]\n",
+            )
+            logging.debug("cf-nvidia-tools added to meta.yaml.")
+
+        # STEP 2: Add check-glibc to the build script
+        build = os.path.join(recipe_dir, "build.sh")
+        if os.path.isfile(build):
+            if _file_contains(build, "check-glibc"):
+                logging.debug(
+                    "build.sh already contains check-glibc; not adding again."
+                )
+            else:
+                with open(build, "a") as file:
+                    file.write(
+                        '\ncheck-glibc "$PREFIX"/lib*/*.so.* "$PREFIX"/bin/* "$PREFIX"/targets/*/lib*/*.so.* "$PREFIX"/targets/*/bin/*\n'
+                    )
+                logging.debug("Added check-glibc to build.sh")
+        else:
+            if _file_contains(meta, "check-glibc"):
+                logging.debug(
+                    "meta.yaml already contains check-glibc; not adding again."
+                )
+            else:
+                _insert_subsection(
+                    meta,
+                    "build",
+                    "script",
+                    '    - check-glibc "$PREFIX"/lib*/*.so.* "$PREFIX"/bin/* "$PREFIX"/targets/*/lib*/*.so.* "$PREFIX"/targets/*/bin/*  # [linux]\n',
+                )
+                logging.debug("Added check-glibc to meta.yaml")
+
+        # STEP 3: Remove os_version keys from conda-forge.yml
+        config = os.path.join(recipe_dir, "..", "conda-forge.yml")
+        with open(config) as f:
+            y = yaml_safe_load(f)
+        y_orig = copy.deepcopy(y)
+        y.pop("os_version", None)
+        if y_orig != y:
+            with open(config, "w") as f:
+                yaml_safe_dump(y, f)
+
+        return self.migrator_uid(attrs)
+
+    def pr_body(
+        self, feedstock_ctx: ClonedFeedstockContext, add_label_text=True
+    ) -> str:
+        """Create a PR message body
+
+        Returns
+        -------
+        body: str
+            The body of the PR message
+            :param feedstock_ctx:
+        """
+        body = f"{AddNVIDIATools.__doc__}\n\n"
+
+        if add_label_text:
+            body += (
+                "If this PR was opened in error or needs to be updated please add "
+                "the `bot-rerun` label to this PR. The bot will close this PR and "
+                "schedule another one. If you do not have permissions to add this "
+                "label, you can use the phrase "
+                "<code>@<space/>conda-forge-admin, please rerun bot</code> "
+                "in a PR comment to have the `conda-forge-admin` add it for you.\n\n"
+            )
+
+        body += (
+            "<sub>"
+            "This PR was created by the [regro-cf-autotick-bot](https://github.com/regro/cf-scripts). "
+            "The **regro-cf-autotick-bot** is a service to automatically "
+            "track the dependency graph, migrate packages, and "
+            "propose package version updates for conda-forge. "
+            "Feel free to drop us a line if there are any "
+            "[issues](https://github.com/regro/cf-scripts/issues)! "
+            + f"This PR was generated by {get_bot_run_url()} - please use this URL for debugging."
+            + "</sub>"
+        )
+        return body

--- a/conda_forge_tick/migrators/nvtools.py
+++ b/conda_forge_tick/migrators/nvtools.py
@@ -112,6 +112,10 @@ class AddNVIDIATools(Migrator):
 
     allowed_schema_versions = [0]
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._reset_effective_graph()
+
     def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
         """If true don't act upon node
 

--- a/tests/mock_nvtools_migrator_feedstock/conda-forge.yml
+++ b/tests/mock_nvtools_migrator_feedstock/conda-forge.yml
@@ -1,0 +1,16 @@
+build_platform:
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
+conda_build:
+  error_overlinking: true
+conda_forge_output_validation: true
+github:
+  branch_name: main
+  tooling_branch_name: main
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default
+os_version:
+  linux_64: cos7
+  linux_aarch64: cos7
+  linux_ppc64le: cos7

--- a/tests/mock_nvtools_migrator_feedstock/recipe/build.sh
+++ b/tests/mock_nvtools_migrator_feedstock/recipe/build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Install to conda style directories
+[[ -d lib64 ]] && mv lib64 lib
+mkdir -p ${PREFIX}/lib
+[[ -d pkg-config ]] && mv pkg-config ${PREFIX}/lib/pkgconfig
+[[ -d "$PREFIX/lib/pkgconfig" ]] && sed -E -i "s|cudaroot=.+|cudaroot=$PREFIX|g" $PREFIX/lib/pkgconfig/nvjpeg*.pc
+
+[[ ${target_platform} == "linux-64" ]] && targetsDir="targets/x86_64-linux"
+[[ ${target_platform} == "linux-ppc64le" ]] && targetsDir="targets/ppc64le-linux"
+[[ ${target_platform} == "linux-aarch64" ]] && targetsDir="targets/sbsa-linux"
+
+for i in `ls`; do
+    [[ $i == "build_env_setup.sh" ]] && continue
+    [[ $i == "conda_build.sh" ]] && continue
+    [[ $i == "metadata_conda_debug.yaml" ]] && continue
+    if [[ $i == "lib" ]] || [[ $i == "include" ]]; then
+        # Headers and libraries are installed to targetsDir
+        mkdir -p ${PREFIX}/${targetsDir}
+        mkdir -p ${PREFIX}/$i
+        cp -rv $i ${PREFIX}/${targetsDir}
+        if [[ $i == "lib" ]]; then
+            for j in "$i"/*.so*; do
+                # Shared libraries are symlinked in $PREFIX/lib
+                ln -s ${PREFIX}/${targetsDir}/$j ${PREFIX}/$j
+
+                if [[ $j =~ \.so\. ]]; then
+                    patchelf --set-rpath '$ORIGIN' --force-rpath ${PREFIX}/${targetsDir}/$j
+                fi
+            done
+        fi
+    else
+        # Put all other files in targetsDir
+        mkdir -p ${PREFIX}/${targetsDir}/${PKG_NAME}
+        cp -rv $i ${PREFIX}/${targetsDir}/${PKG_NAME}
+    fi
+done

--- a/tests/mock_nvtools_migrator_feedstock/recipe/meta.yaml
+++ b/tests/mock_nvtools_migrator_feedstock/recipe/meta.yaml
@@ -1,0 +1,155 @@
+{% set name = "libnvjpeg" %}
+{% set version = "12.3.3.54" %}
+{% set cuda_version = "12.6" %}
+{% set platform = "linux-x86_64" %}  # [linux64]
+{% set platform = "linux-ppc64le" %}  # [ppc64le]
+{% set platform = "linux-sbsa" %}  # [aarch64]
+{% set platform = "windows-x86_64" %}  # [win]
+{% set target_name = "x86_64-linux" %}  # [linux64]
+{% set target_name = "ppc64le-linux" %}  # [ppc64le]
+{% set target_name = "sbsa-linux" %}  # [aarch64]
+{% set target_name = "x64" %}  # [win]
+{% set extension = "tar.xz" %}  # [not win]
+{% set extension = "zip" %}  # [win]
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://developer.download.nvidia.com/compute/cuda/redist/{{ name }}/{{ platform }}/{{ name }}-{{ platform }}-{{ version }}-archive.{{ extension }}
+  sha256: f74f6aee35ef4fb1619bc2a67be943c3d1a84d6746b41788c44a7d3b0d9ae3b4  # [linux64]
+  sha256: 6970db1c9757f3ae30adba21d7c1306fd5afc4cb034b0739c711691a481d3ed4  # [aarch64]
+  sha256: 15c1b28e623598eb75f48d02bfd34efa83b35e3f8d1d5241c93a385d0bea9d18  # [win]
+
+build:
+  number: 1
+  binary_relocation: false
+  skip: true  # [osx or ppc64le]
+
+test:
+  requires:
+    - patchelf  # [linux]
+  files:
+    - test-rpath.sh
+  commands:
+    - test -L $PREFIX/lib/libnvjpeg.so.{{ version.split(".")[0] }}                            # [linux]
+    - test -L $PREFIX/lib/libnvjpeg.so.{{ version }}                                          # [linux]
+    - test -L $PREFIX/targets/{{ target_name }}/lib/libnvjpeg.so.{{ version.split(".")[0] }}  # [linux]
+    - test -f $PREFIX/targets/{{ target_name }}/lib/libnvjpeg.so.{{ version }}                # [linux]
+    - bash test-rpath.sh                                                                      # [linux]
+    - if not exist %LIBRARY_BIN%\nvjpeg64_{{ version.split(".")[0] }}.dll exit 1              # [win]
+
+outputs:
+  - name: libnvjpeg
+    files:
+      - lib/libnvjpeg.so.*            # [linux]
+      - targets/{{ target_name }}/lib/libnvjpeg.so.*  # [linux]
+      - Library\bin\nvjpeg*.dll       # [win]
+    requirements:
+      build:
+        - {{ compiler("c") }}
+        - {{ compiler("cxx") }}
+        - {{ stdlib("c") }}
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        - patchelf <0.18.0                      # [linux]
+      host:
+        - cuda-version {{ cuda_version }}
+      run:
+        - {{ pin_compatible("cuda-version", max_pin="x.x") }}
+      run_constrained:
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+    # Tests are defined at the top level, due to package/output name conflicts.
+    about:
+      home: https://developer.nvidia.com/nvjpeg
+      license_file: LICENSE
+      license: LicenseRef-NVIDIA-End-User-License-Agreement
+      license_url: https://docs.nvidia.com/cuda/eula/index.html
+      summary: nvJPEG native runtime libraries
+      description: |
+        nvJPEG native runtime libraries
+      doc_url: https://docs.nvidia.com/cuda/nvjpeg/index.html
+
+  - name: libnvjpeg-dev
+    build:
+      run_exports:
+        - {{ pin_subpackage("libnvjpeg", max_pin="x") }}
+    files:
+      - lib/libnvjpeg.so                                  # [linux]
+      - lib/pkgconfig/nvjpeg*.pc                          # [linux]
+      - targets/{{ target_name }}/lib/libnvjpeg.so        # [linux]
+      - targets/{{ target_name }}/lib/stubs/libnvjpeg.so  # [linux]
+      - targets/{{ target_name }}/include/nvjpeg*         # [linux]
+      - Library\include                                   # [win]
+      - Library\lib\nvjpeg.lib                            # [win]
+    requirements:
+      build:
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+      host:
+        - cuda-version {{ cuda_version }}
+      run:
+        - {{ pin_compatible("cuda-version", max_pin="x.x") }}
+        - {{ pin_subpackage("libnvjpeg", exact=True) }}
+        - cuda-cudart-dev
+      run_constrained:
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        - libnvjpeg-static >={{ version }}      # [linux]
+    test:
+      commands:
+        - test -L $PREFIX/lib/libnvjpeg.so                                    # [linux]
+        - test -f $PREFIX/lib/pkgconfig/nvjpeg*.pc                            # [linux]
+        - test -f $PREFIX/targets/{{ target_name }}/include/nvjpeg.h          # [linux]
+        - test -L $PREFIX/targets/{{ target_name }}/lib/libnvjpeg.so          # [linux]
+        - test -f $PREFIX/targets/{{ target_name }}/lib/stubs/libnvjpeg.so    # [linux]
+        - if not exist %LIBRARY_INC%\nvjpeg.h exit 1                          # [win]
+        - if not exist %LIBRARY_LIB%\nvjpeg.lib exit 1                        # [win]
+    about:
+      home: https://developer.nvidia.com/cuda-toolkit
+      license_file: LICENSE
+      license: LicenseRef-NVIDIA-End-User-License-Agreement
+      license_url: https://docs.nvidia.com/cuda/eula/index.html
+      summary: nvJPEG native runtime libraries
+      description: |
+        nvJPEG native runtime libraries
+      doc_url: https://docs.nvidia.com/cuda/nvjpeg/index.html
+
+  - name: libnvjpeg-static
+    build:
+      skip: True  # [not linux]
+    files:
+      - targets/{{ target_name }}/lib/libnvjpeg_static.a  # [linux]
+    requirements:
+      build:
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+      host:
+        - cuda-version {{ cuda_version }}
+      run:
+        - {{ pin_compatible("cuda-version", max_pin="x.x") }}
+      run_constrained:
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+    test:
+      commands:
+        - test -f $PREFIX/targets/{{ target_name }}/lib/libnvjpeg_static.a  # [linux]
+    about:
+      home: https://developer.nvidia.com/cuda-toolkit
+      license_file: LICENSE
+      license: LicenseRef-NVIDIA-End-User-License-Agreement
+      license_url: https://docs.nvidia.com/cuda/eula/index.html
+      summary: nvJPEG native runtime libraries
+      description: |
+        nvJPEG native runtime libraries
+      doc_url: https://docs.nvidia.com/cuda/nvjpeg/index.html
+
+about:
+  home: https://developer.nvidia.com/nvjpeg
+  license_file: LICENSE
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  license_url: https://docs.nvidia.com/cuda/eula/index.html
+  summary: nvJPEG native runtime libraries
+  description: |
+    nvJPEG native runtime libraries
+  doc_url: https://docs.nvidia.com/cuda/nvjpeg/index.html
+
+extra:
+  recipe-maintainers:
+    - conda-forge/cuda

--- a/tests/mock_nvtools_migrator_feedstock_ref/conda-forge.yml
+++ b/tests/mock_nvtools_migrator_feedstock_ref/conda-forge.yml
@@ -1,0 +1,12 @@
+build_platform:
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
+conda_build:
+  error_overlinking: true
+conda_forge_output_validation: true
+github:
+  branch_name: main
+  tooling_branch_name: main
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default

--- a/tests/mock_nvtools_migrator_feedstock_ref/recipe/build.sh
+++ b/tests/mock_nvtools_migrator_feedstock_ref/recipe/build.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Install to conda style directories
+[[ -d lib64 ]] && mv lib64 lib
+mkdir -p ${PREFIX}/lib
+[[ -d pkg-config ]] && mv pkg-config ${PREFIX}/lib/pkgconfig
+[[ -d "$PREFIX/lib/pkgconfig" ]] && sed -E -i "s|cudaroot=.+|cudaroot=$PREFIX|g" $PREFIX/lib/pkgconfig/nvjpeg*.pc
+
+[[ ${target_platform} == "linux-64" ]] && targetsDir="targets/x86_64-linux"
+[[ ${target_platform} == "linux-ppc64le" ]] && targetsDir="targets/ppc64le-linux"
+[[ ${target_platform} == "linux-aarch64" ]] && targetsDir="targets/sbsa-linux"
+
+for i in `ls`; do
+    [[ $i == "build_env_setup.sh" ]] && continue
+    [[ $i == "conda_build.sh" ]] && continue
+    [[ $i == "metadata_conda_debug.yaml" ]] && continue
+    if [[ $i == "lib" ]] || [[ $i == "include" ]]; then
+        # Headers and libraries are installed to targetsDir
+        mkdir -p ${PREFIX}/${targetsDir}
+        mkdir -p ${PREFIX}/$i
+        cp -rv $i ${PREFIX}/${targetsDir}
+        if [[ $i == "lib" ]]; then
+            for j in "$i"/*.so*; do
+                # Shared libraries are symlinked in $PREFIX/lib
+                ln -s ${PREFIX}/${targetsDir}/$j ${PREFIX}/$j
+
+                if [[ $j =~ \.so\. ]]; then
+                    patchelf --set-rpath '$ORIGIN' --force-rpath ${PREFIX}/${targetsDir}/$j
+                fi
+            done
+        fi
+    else
+        # Put all other files in targetsDir
+        mkdir -p ${PREFIX}/${targetsDir}/${PKG_NAME}
+        cp -rv $i ${PREFIX}/${targetsDir}/${PKG_NAME}
+    fi
+done
+
+check-glibc "$PREFIX"/lib*/*.so.* "$PREFIX"/bin/* "$PREFIX"/targets/*/lib*/*.so.* "$PREFIX"/targets/*/bin/*

--- a/tests/mock_nvtools_migrator_feedstock_ref/recipe/meta.yaml
+++ b/tests/mock_nvtools_migrator_feedstock_ref/recipe/meta.yaml
@@ -1,0 +1,155 @@
+{% set name = "libnvjpeg" %}
+{% set version = "12.3.3.54" %}
+{% set cuda_version = "12.6" %}
+{% set platform = "linux-x86_64" %}  # [linux64]
+{% set platform = "linux-ppc64le" %}  # [ppc64le]
+{% set platform = "linux-sbsa" %}  # [aarch64]
+{% set platform = "windows-x86_64" %}  # [win]
+{% set target_name = "x86_64-linux" %}  # [linux64]
+{% set target_name = "ppc64le-linux" %}  # [ppc64le]
+{% set target_name = "sbsa-linux" %}  # [aarch64]
+{% set target_name = "x64" %}  # [win]
+{% set extension = "tar.xz" %}  # [not win]
+{% set extension = "zip" %}  # [win]
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://developer.download.nvidia.com/compute/cuda/redist/{{ name }}/{{ platform }}/{{ name }}-{{ platform }}-{{ version }}-archive.{{ extension }}
+  sha256: f74f6aee35ef4fb1619bc2a67be943c3d1a84d6746b41788c44a7d3b0d9ae3b4  # [linux64]
+  sha256: 6970db1c9757f3ae30adba21d7c1306fd5afc4cb034b0739c711691a481d3ed4  # [aarch64]
+  sha256: 15c1b28e623598eb75f48d02bfd34efa83b35e3f8d1d5241c93a385d0bea9d18  # [win]
+
+build:
+  number: 2
+  binary_relocation: false
+  skip: true  # [osx or ppc64le]
+
+test:
+  requires:
+    - patchelf  # [linux]
+  files:
+    - test-rpath.sh
+  commands:
+    - test -L $PREFIX/lib/libnvjpeg.so.{{ version.split(".")[0] }}                            # [linux]
+    - test -L $PREFIX/lib/libnvjpeg.so.{{ version }}                                          # [linux]
+    - test -L $PREFIX/targets/{{ target_name }}/lib/libnvjpeg.so.{{ version.split(".")[0] }}  # [linux]
+    - test -f $PREFIX/targets/{{ target_name }}/lib/libnvjpeg.so.{{ version }}                # [linux]
+    - bash test-rpath.sh                                                                      # [linux]
+    - if not exist %LIBRARY_BIN%\nvjpeg64_{{ version.split(".")[0] }}.dll exit 1              # [win]
+
+outputs:
+  - name: libnvjpeg
+    files:
+      - lib/libnvjpeg.so.*            # [linux]
+      - targets/{{ target_name }}/lib/libnvjpeg.so.*  # [linux]
+      - Library\bin\nvjpeg*.dll       # [win]
+    requirements:
+      build:
+        - {{ compiler("c") }}
+        - {{ compiler("cxx") }}
+        - {{ stdlib("c") }}
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        - patchelf <0.18.0                      # [linux]
+      host:
+        - cuda-version {{ cuda_version }}
+      run:
+        - {{ pin_compatible("cuda-version", max_pin="x.x") }}
+      run_constrained:
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+    # Tests are defined at the top level, due to package/output name conflicts.
+    about:
+      home: https://developer.nvidia.com/nvjpeg
+      license_file: LICENSE
+      license: LicenseRef-NVIDIA-End-User-License-Agreement
+      license_url: https://docs.nvidia.com/cuda/eula/index.html
+      summary: nvJPEG native runtime libraries
+      description: |
+        nvJPEG native runtime libraries
+      doc_url: https://docs.nvidia.com/cuda/nvjpeg/index.html
+
+  - name: libnvjpeg-dev
+    build:
+      run_exports:
+        - {{ pin_subpackage("libnvjpeg", max_pin="x") }}
+    files:
+      - lib/libnvjpeg.so                                  # [linux]
+      - lib/pkgconfig/nvjpeg*.pc                          # [linux]
+      - targets/{{ target_name }}/lib/libnvjpeg.so        # [linux]
+      - targets/{{ target_name }}/lib/stubs/libnvjpeg.so  # [linux]
+      - targets/{{ target_name }}/include/nvjpeg*         # [linux]
+      - Library\include                                   # [win]
+      - Library\lib\nvjpeg.lib                            # [win]
+    requirements:
+      build:
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+      host:
+        - cuda-version {{ cuda_version }}
+      run:
+        - {{ pin_compatible("cuda-version", max_pin="x.x") }}
+        - {{ pin_subpackage("libnvjpeg", exact=True) }}
+        - cuda-cudart-dev
+      run_constrained:
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        - libnvjpeg-static >={{ version }}      # [linux]
+    test:
+      commands:
+        - test -L $PREFIX/lib/libnvjpeg.so                                    # [linux]
+        - test -f $PREFIX/lib/pkgconfig/nvjpeg*.pc                            # [linux]
+        - test -f $PREFIX/targets/{{ target_name }}/include/nvjpeg.h          # [linux]
+        - test -L $PREFIX/targets/{{ target_name }}/lib/libnvjpeg.so          # [linux]
+        - test -f $PREFIX/targets/{{ target_name }}/lib/stubs/libnvjpeg.so    # [linux]
+        - if not exist %LIBRARY_INC%\nvjpeg.h exit 1                          # [win]
+        - if not exist %LIBRARY_LIB%\nvjpeg.lib exit 1                        # [win]
+    about:
+      home: https://developer.nvidia.com/cuda-toolkit
+      license_file: LICENSE
+      license: LicenseRef-NVIDIA-End-User-License-Agreement
+      license_url: https://docs.nvidia.com/cuda/eula/index.html
+      summary: nvJPEG native runtime libraries
+      description: |
+        nvJPEG native runtime libraries
+      doc_url: https://docs.nvidia.com/cuda/nvjpeg/index.html
+
+  - name: libnvjpeg-static
+    build:
+      skip: True  # [not linux]
+    files:
+      - targets/{{ target_name }}/lib/libnvjpeg_static.a  # [linux]
+    requirements:
+      build:
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+      host:
+        - cuda-version {{ cuda_version }}
+      run:
+        - {{ pin_compatible("cuda-version", max_pin="x.x") }}
+      run_constrained:
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+    test:
+      commands:
+        - test -f $PREFIX/targets/{{ target_name }}/lib/libnvjpeg_static.a  # [linux]
+    about:
+      home: https://developer.nvidia.com/cuda-toolkit
+      license_file: LICENSE
+      license: LicenseRef-NVIDIA-End-User-License-Agreement
+      license_url: https://docs.nvidia.com/cuda/eula/index.html
+      summary: nvJPEG native runtime libraries
+      description: |
+        nvJPEG native runtime libraries
+      doc_url: https://docs.nvidia.com/cuda/nvjpeg/index.html
+
+about:
+  home: https://developer.nvidia.com/nvjpeg
+  license_file: LICENSE
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  license_url: https://docs.nvidia.com/cuda/eula/index.html
+  summary: nvJPEG native runtime libraries
+  description: |
+    nvJPEG native runtime libraries
+  doc_url: https://docs.nvidia.com/cuda/nvjpeg/index.html
+
+extra:
+  recipe-maintainers:
+    - conda-forge/cuda

--- a/tests/test_migrator_nvtools.py
+++ b/tests/test_migrator_nvtools.py
@@ -1,0 +1,19 @@
+import os.path
+
+from conda_forge_tick.migrators import AddNVIDIATools
+
+mock_recipe_dir = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "mock_nvtools_migrator_feedstock",
+    "recipe",
+)
+
+mock_node_attrs = {}
+
+
+def test_nvtools_migrate():
+    migrator = AddNVIDIATools()
+    migrator.migrate(
+        mock_recipe_dir,
+        mock_node_attrs,
+    )

--- a/tests/test_migrator_nvtools.py
+++ b/tests/test_migrator_nvtools.py
@@ -1,3 +1,4 @@
+import filecmp
 import os.path
 
 from conda_forge_tick.migrators import AddNVIDIATools
@@ -5,6 +6,12 @@ from conda_forge_tick.migrators import AddNVIDIATools
 mock_recipe_dir = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
     "mock_nvtools_migrator_feedstock",
+    "recipe",
+)
+
+mock_recipe_dir_ref = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "mock_nvtools_migrator_feedstock_ref",
     "recipe",
 )
 
@@ -16,4 +23,19 @@ def test_nvtools_migrate():
     migrator.migrate(
         mock_recipe_dir,
         mock_node_attrs,
+    )
+    assert filecmp.cmp(
+        os.path.join(mock_recipe_dir, "build.sh"),
+        os.path.join(mock_recipe_dir_ref, "build.sh"),
+        shallow=False,
+    )
+    assert filecmp.cmp(
+        os.path.join(mock_recipe_dir, "meta.yaml"),
+        os.path.join(mock_recipe_dir_ref, "meta.yaml"),
+        shallow=False,
+    )
+    assert filecmp.cmp(
+        os.path.join(mock_recipe_dir, "..", "conda-forge.yml"),
+        os.path.join(mock_recipe_dir_ref, "..", "conda-forge.yml"),
+        shallow=False,
     )

--- a/tests/test_migrator_nvtools.py
+++ b/tests/test_migrator_nvtools.py
@@ -18,24 +18,48 @@ mock_recipe_dir_ref = os.path.join(
 mock_node_attrs = {}
 
 
+def store_file_contents(filename):
+    with open(filename) as file:
+        return file.read()
+
+
+def write_file_contents(filename, buffer):
+    with open(filename, "w") as file:
+        file.write(buffer)
+
+
 def test_nvtools_migrate():
+    backups = [
+        store_file_contents(os.path.join(mock_recipe_dir, f))
+        for f in ["build.sh", "meta.yaml", "../conda-forge.yml"]
+    ]
+
     migrator = AddNVIDIATools()
     migrator.migrate(
         mock_recipe_dir,
         mock_node_attrs,
     )
-    assert filecmp.cmp(
-        os.path.join(mock_recipe_dir, "build.sh"),
-        os.path.join(mock_recipe_dir_ref, "build.sh"),
-        shallow=False,
+    success = (
+        filecmp.cmp(
+            os.path.join(mock_recipe_dir, "build.sh"),
+            os.path.join(mock_recipe_dir_ref, "build.sh"),
+            shallow=False,
+        )
+        and filecmp.cmp(
+            os.path.join(mock_recipe_dir, "meta.yaml"),
+            os.path.join(mock_recipe_dir_ref, "meta.yaml"),
+            shallow=False,
+        )
+        and filecmp.cmp(
+            os.path.join(mock_recipe_dir, "..", "conda-forge.yml"),
+            os.path.join(mock_recipe_dir_ref, "..", "conda-forge.yml"),
+            shallow=False,
+        )
     )
-    assert filecmp.cmp(
-        os.path.join(mock_recipe_dir, "meta.yaml"),
-        os.path.join(mock_recipe_dir_ref, "meta.yaml"),
-        shallow=False,
-    )
-    assert filecmp.cmp(
-        os.path.join(mock_recipe_dir, "..", "conda-forge.yml"),
-        os.path.join(mock_recipe_dir_ref, "..", "conda-forge.yml"),
-        shallow=False,
-    )
+    if success:
+        # Files only restored on success, so that you can see why the comparison failed
+        [
+            write_file_contents(os.path.join(mock_recipe_dir, f), b)
+            for f, b in zip(["build.sh", "meta.yaml", "../conda-forge.yml"], backups)
+        ]
+    assert success

--- a/tests/test_migrator_nvtools.py
+++ b/tests/test_migrator_nvtools.py
@@ -39,27 +39,26 @@ def test_nvtools_migrate():
         mock_recipe_dir,
         mock_node_attrs,
     )
-    success = (
+    try:
         filecmp.cmp(
             os.path.join(mock_recipe_dir, "build.sh"),
             os.path.join(mock_recipe_dir_ref, "build.sh"),
             shallow=False,
         )
-        and filecmp.cmp(
+        filecmp.cmp(
             os.path.join(mock_recipe_dir, "meta.yaml"),
             os.path.join(mock_recipe_dir_ref, "meta.yaml"),
             shallow=False,
         )
-        and filecmp.cmp(
+        filecmp.cmp(
             os.path.join(mock_recipe_dir, "..", "conda-forge.yml"),
             os.path.join(mock_recipe_dir_ref, "..", "conda-forge.yml"),
             shallow=False,
         )
-    )
-    if success:
-        # Files only restored on success, so that you can see why the comparison failed
+    except Exception as e:
+        raise e
+    finally:
         [
             write_file_contents(os.path.join(mock_recipe_dir, f), b)
             for f, b in zip(["build.sh", "meta.yaml", "../conda-forge.yml"], backups)
         ]
-    assert success


### PR DESCRIPTION
This PR is ready for us to fix some initialization issue in this migrator class. I will push changes to the test suite to catch this bug too.

Reverts regro/cf-scripts#3882