### PR TITLE
fix: remove side effects from feedstock loading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ ENV LOGNAME=conda
 ENV MAIL=/var/spool/mail/conda
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/conda/bin
 RUN chown conda:conda $HOME && \
+    chown -R conda:conda /opt/autotick-bot && \
     cp -R /etc/skel $HOME && \
     chown -R conda:conda $HOME/skel && \
     (ls -A1 $HOME/skel | xargs -I {} mv -n $HOME/skel/{} $HOME) && \

--- a/conda_forge_tick/container_cli.py
+++ b/conda_forge_tick/container_cli.py
@@ -320,7 +320,7 @@ def _parse_feedstock(
 
     name = attrs["feedstock_name"]
 
-    load_feedstock_local(
+    node_attrs = load_feedstock_local(
         name,
         attrs,
         meta_yaml=meta_yaml,
@@ -329,7 +329,7 @@ def _parse_feedstock(
         mark_not_archived=mark_not_archived,
     )
 
-    return attrs
+    return node_attrs
 
 
 def _parse_meta_yaml(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,6 +98,10 @@ class FakeLazyJson(dict):
     ) -> None:
         pass
 
+    @property
+    def data(self):
+        return self
+
 
 def pytest_configure(config):
     config.addinivalue_line(

--- a/tests/test_make_graph.py
+++ b/tests/test_make_graph.py
@@ -1,8 +1,8 @@
 import pytest
+from conftest import FakeLazyJson
 
 from conda_forge_tick.lazy_json_backends import LazyJson
 from conda_forge_tick.make_graph import try_load_feedstock
-from tests.conftest import FakeLazyJson
 
 
 @pytest.mark.parametrize("container_enabled", [True, False])

--- a/tests/test_make_graph.py
+++ b/tests/test_make_graph.py
@@ -18,6 +18,7 @@ def test_try_load_feedstock(
     fake_lazy_json = FakeLazyJson()  # empty dict
 
     with fake_lazy_json as loaded_lazy_json:
+        # FakeLazyJson is not an instance of LazyJson
         # noinspection PyTypeChecker
         data = try_load_feedstock(feedstock, loaded_lazy_json, mark_not_archived).data  # type: ignore
 

--- a/tests/test_make_graph.py
+++ b/tests/test_make_graph.py
@@ -10,10 +10,6 @@ from conda_forge_tick.make_graph import try_load_feedstock
 def test_try_load_feedstock(
     request: pytest.FixtureRequest, mark_not_archived: bool, container_enabled: bool
 ):
-    """
-    If executed without containers (which is the default), try_load_feedstock should return the
-    correct LazyJSON data.
-    """
     if container_enabled:
         request.getfixturevalue("use_containers")
 

--- a/tests/test_make_graph.py
+++ b/tests/test_make_graph.py
@@ -1,0 +1,50 @@
+import pytest
+
+from conda_forge_tick.lazy_json_backends import LazyJson
+from conda_forge_tick.make_graph import try_load_feedstock
+from tests.conftest import FakeLazyJson
+
+
+@pytest.mark.parametrize("container_enabled", [True, False])
+@pytest.mark.parametrize("mark_not_archived", [True, False])
+def test_try_load_feedstock(
+    request: pytest.FixtureRequest, mark_not_archived: bool, container_enabled: bool
+):
+    """
+    If executed without containers (which is the default), try_load_feedstock should return the
+    correct LazyJSON data.
+    """
+    if container_enabled:
+        request.getfixturevalue("use_containers")
+
+    feedstock = "typst-test"  # archived
+
+    fake_lazy_json = FakeLazyJson()  # empty dict
+
+    with fake_lazy_json as loaded_lazy_json:
+        # noinspection PyTypeChecker
+        data = try_load_feedstock(feedstock, loaded_lazy_json, mark_not_archived).data  # type: ignore
+
+    if mark_not_archived:
+        assert data["archived"] is False
+    else:
+        # apparently, this is how the function behaves
+        assert "archived" not in data
+
+    assert data["feedstock_name"] == feedstock
+    assert data["parsing_error"] is False
+    assert data["raw_meta_yaml"].startswith("{% set name")
+    assert isinstance(data["conda-forge.yml"], dict)
+    assert "linux_64" in data["platforms"]
+    assert data["meta_yaml"]["about"]["license"] == "MIT"
+    assert isinstance(data["linux_64_meta_yaml"], dict)
+    assert isinstance(data["linux_64_requirements"], dict)
+    assert isinstance(data["total_requirements"], dict)
+    assert data["strong_exports"] is False
+    assert data["outputs_names"] == {feedstock}
+    assert isinstance(data["req"], set)
+    assert data["name"] == feedstock
+    assert data["version"].startswith("0.")
+    assert data["url"].startswith("https://github.com/tingerrr/typst-test")
+    assert data["hash_type"] == "sha256"
+    assert isinstance(data["version_pr_info"], LazyJson)

--- a/tests/test_migrators.py
+++ b/tests/test_migrators.py
@@ -549,7 +549,7 @@ def run_test_migration(
             name = "blah"
 
         pmy = populate_feedstock_attributes(
-            name, sub_graph={}, meta_yaml=inp, conda_forge_yaml=cf_yml
+            name, existing_node_attrs={}, meta_yaml=inp, conda_forge_yaml=cf_yml
         )
 
         # these are here for legacy migrators
@@ -571,7 +571,7 @@ def run_test_migration(
 
         pmy = populate_feedstock_attributes(
             name,
-            sub_graph={},
+            existing_node_attrs={},
             recipe_yaml=inp,
             conda_forge_yaml=cf_yml,
             feedstock_dir=tmp_path,

--- a/tests/test_recipe_yaml_parsing.py
+++ b/tests/test_recipe_yaml_parsing.py
@@ -238,16 +238,16 @@ class TestRecipeYamlParsing:
     def test_populate_feedstock_attributes(self, recipe_env, recipe_name):
         """Test parsing different recipe files."""
         recipe_yaml = recipe_env.recipe_path.parent / f"{recipe_name}.yaml"
-        subgraph = {}
-        populate_feedstock_attributes(
+        existing_attrs = {}
+        node_attrs = populate_feedstock_attributes(
             recipe_name,
-            subgraph,
+            existing_attrs,
             recipe_yaml=recipe_yaml.read_text(),
             feedstock_dir=recipe_env.root,
         )
 
-        assert subgraph["feedstock_name"] == recipe_name
-        for key, value in subgraph["total_requirements"].items():
+        assert node_attrs["feedstock_name"] == recipe_name
+        for key, value in node_attrs["total_requirements"].items():
             assert isinstance(value, set)
             for el in value:
                 assert isinstance(el, str)

--- a/tests/test_staticlib.py
+++ b/tests/test_staticlib.py
@@ -270,7 +270,7 @@ def test_staticlib_migrator_llvmlite(tmp_path, yaml_path):
         }
     pmy = populate_feedstock_attributes(
         name,
-        sub_graph={},
+        existing_node_attrs={},
         conda_forge_yaml="bot: {update_static_libs: true}\n",
         **pkwargs,
         feedstock_dir=tmp_path,


### PR DESCRIPTION
```
A function’s touch should leave no trace,
No hidden change, no state misplaced.
Let inputs stay as first they came,
Pure and true—untouched, the same.
```

<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR removes side effects from the `load_feedstock_local` and `populate_feedstock_attributes` functions.
Instead of modifying the `sub_graph` parameter, we create a new dictionary in the function body and return that one.

Rationale: As of now, `try_load_feedstock` **is flawed if run without containers**.

https://github.com/regro/cf-scripts/blob/160c08d1e846272182b5d27a4e640d1b2fce6137/conda_forge_tick/make_graph.py#L100-L115

This is because in no-container mode, the return value `data` of `load_feedstock` is identical to `attrs` which is cleared a few lines after. Hence, we always return a LazyJSON object which is empty besides the two values added by `_add_required_lazy_json_refs`.

In container mode, `load_feedstock` is already pure (free of side effects), hence the bug does not occur.

As far as I am aware, nothing depends on the side-effects (note that these for `load_feedstock` do not exist in container mode anyway!)

I also verified that this does not break any external code.

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
Cc @pavelzw

Blocks #3417