### PR TITLE
fix(dockerfile): chown code directory for conda user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ ENV LOGNAME=conda
 ENV MAIL=/var/spool/mail/conda
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/conda/bin
 RUN chown conda:conda $HOME && \
+    chown -R conda:conda /opt/autotick-bot && \
     cp -R /etc/skel $HOME && \
     chown -R conda:conda $HOME/skel && \
     (ls -A1 $HOME/skel | xargs -I {} mv -n $HOME/skel/{} $HOME) && \


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->
Currently, I cannot execute some (any?) commands in the Docker container on my local machine (MacOS). Reason is that the `conda` user does not have sufficient permissions for the `/opt/autotick-bot` directory which contains the code of the bot.

**Before:**

```text
$ docker run --rm --net host conda-forge-tick:test conda-forge-tick-container parse-feedstock 
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
Traceback (most recent call last):
  File "/opt/conda/envs/cf-scripts/bin/conda-forge-tick-container", line 5, in <module>
    from conda_forge_tick.container_cli import cli
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1138, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1078, in _find_spec
  File "/opt/conda/envs/cf-scripts/lib/python3.11/site-packages/__editable___conda_forge_tick_2025_3_102_finder.py", line 20, in find_spec
    return cls._find_spec(fullname, Path(pkg_path))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/cf-scripts/lib/python3.11/site-packages/__editable___conda_forge_tick_2025_3_102_finder.py", line 38, in _find_spec
    if candidate.exists():
       ^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/cf-scripts/lib/python3.11/pathlib.py", line 1235, in exists
    self.stat()
  File "/opt/conda/envs/cf-scripts/lib/python3.11/pathlib.py", line 1013, in stat
    return os.stat(self, follow_symlinks=follow_symlinks)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: '/opt/autotick-bot/conda_forge_tick/__init__.py'
```

**After (successful):**

```text
$ docker run --rm --net host conda-forge-tick:test conda-forge-tick-container parse-feedstock
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
Usage: conda-forge-tick-container parse-feedstock [OPTIONS]
Try 'conda-forge-tick-container parse-feedstock --help' for help.

Error: Missing option '--existing-feedstock-node-attrs'.
```

The error here is expected and does not print above.

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
Cc @pavelzw