### PR TITLE
feat: introduce global settings object

### DIFF
--- a/autotick-bot/install_bot_code.sh
+++ b/autotick-bot/install_bot_code.sh
@@ -1,4 +1,16 @@
 #!/bin/bash
+
+# Environment Variables:
+# - CF_FEEDSTOCK_OPS_CONTAINER_NAME: The name of the container image to use for the bot (optional, not used but left intact)
+# - CF_FEEDSTOCK_OPS_CONTAINER_TAG: The tag of the container image to use for the bot (optional).
+# - CF_TICK_GRAPH_GITHUB_BACKEND_REPO: The GitHub repository to clone cf-graph from. Default: regro/cf-graph-countyfair
+
+# Sets the following environment variables via GITHUB_ENV:
+# - CF_FEEDSTOCK_OPS_CONTAINER_NAME (see above)
+# - CF_FEEDSTOCK_OPS_CONTAINER_TAG (see above)
+
+set -euo pipefail
+
 git config --global user.name regro-cf-autotick-bot
 git config --global user.email 36490558+regro-cf-autotick-bot@users.noreply.github.com
 git config --global pull.rebase false
@@ -29,11 +41,14 @@ for arg in "$@"; do
   fi
 done
 if [[ "${clone_graph}" == "true" ]]; then
-  git clone --depth=5 https://github.com/regro/cf-graph-countyfair.git cf-graph
+  cf_graph_repo=${CF_TICK_GRAPH_GITHUB_BACKEND_REPO:-"regro/cf-graph-countyfair"}
+  cf_graph_remote="https://github.com/${cf_graph_repo}.git"
+  git clone --depth=5 "${cf_graph_remote}" cf-graph
 else
   echo "Skipping cloning of cf-graph"
 fi
 
+docker_name=${CF_FEEDSTOCK_OPS_CONTAINER_NAME:-"ghcr.io/regro/conda-forge-tick"}
 bot_tag=$(python -c "import conda_forge_tick; print(conda_forge_tick.__version__)")
 docker_tag=${CF_FEEDSTOCK_OPS_CONTAINER_TAG:-${bot_tag}}
 
@@ -44,11 +59,12 @@ for arg in "$@"; do
   fi
 done
 if [[ "${pull_cont}" == "true" ]]; then
-  docker pull ghcr.io/regro/conda-forge-tick:${docker_tag}
+  docker pull "${docker_name}:${docker_tag}"
 fi
 
+# left intact if already set
 export CF_FEEDSTOCK_OPS_CONTAINER_TAG=${docker_tag}
-export CF_FEEDSTOCK_OPS_CONTAINER_NAME="ghcr.io/regro/conda-forge-tick"
+export CF_FEEDSTOCK_OPS_CONTAINER_NAME=${docker_name}
 
 echo "CF_FEEDSTOCK_OPS_CONTAINER_TAG=${CF_FEEDSTOCK_OPS_CONTAINER_TAG}" >> "$GITHUB_ENV"
 echo "CF_FEEDSTOCK_OPS_CONTAINER_NAME=${CF_FEEDSTOCK_OPS_CONTAINER_NAME}" >> "$GITHUB_ENV"

--- a/autotick-bot/install_bot_code.sh
+++ b/autotick-bot/install_bot_code.sh
@@ -63,8 +63,8 @@ if [[ "${pull_cont}" == "true" ]]; then
 fi
 
 # left intact if already set
-export CF_FEEDSTOCK_OPS_CONTAINER_TAG=${docker_tag}
-export CF_FEEDSTOCK_OPS_CONTAINER_NAME=${docker_name}
+export CF_FEEDSTOCK_OPS_CONTAINER_TAG="${docker_tag}"
+export CF_FEEDSTOCK_OPS_CONTAINER_NAME="${docker_name}"
 
 echo "CF_FEEDSTOCK_OPS_CONTAINER_TAG=${CF_FEEDSTOCK_OPS_CONTAINER_TAG}" >> "$GITHUB_ENV"
 echo "CF_FEEDSTOCK_OPS_CONTAINER_NAME=${CF_FEEDSTOCK_OPS_CONTAINER_NAME}" >> "$GITHUB_ENV"

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -3,9 +3,9 @@ metadata:
     - url: conda-forge
       used_env_vars: []
   content_hash:
-    linux-64: ea0be66fad42c0be775b6964370d3e0630c3edfb46574a41e2fc7c21377be6dc
-    osx-64: 72950d92f109f4e2d6564afa451fe7c844d672d1bc57572fa706d45f85958c5d
-    osx-arm64: 85ed712bf6cefe23ec9a3973cc2b4bca64aaa23adcf0a6b0e3df5edda95b6198
+    linux-64: 7ba8c322a536718d19bfcabde20be1b67078d035abfe5d023c354adb17aaf007
+    osx-64: ac75d6b342290a7f650d0d9915a2d0efaf1a20208b2537a0fa56a139c33791d6
+    osx-arm64: f7aa2f8db311ba197dada2877a3a744f92c5493a61dd0040eda7041799a8bb9a
   platforms:
     - osx-arm64
     - linux-64
@@ -10442,6 +10442,51 @@ package:
     version: 2.10.3
   - category: main
     dependencies:
+      pydantic: '>=2.7.0'
+      python: '>=3.9'
+      python-dotenv: '>=0.21.0'
+    hash:
+      md5: 88715188749bfac9fa92aec9c747d62c
+      sha256: 84b78dcdc75d7dacd8c85df9a7fef42ff5684897217b46beef6c516afb2550dc
+    manager: conda
+    name: pydantic-settings
+    optional: false
+    platform: linux-64
+    url:
+      https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.8.1-pyh3cfb1c2_0.conda
+    version: 2.8.1
+  - category: main
+    dependencies:
+      pydantic: '>=2.7.0'
+      python: '>=3.9'
+      python-dotenv: '>=0.21.0'
+    hash:
+      md5: 88715188749bfac9fa92aec9c747d62c
+      sha256: 84b78dcdc75d7dacd8c85df9a7fef42ff5684897217b46beef6c516afb2550dc
+    manager: conda
+    name: pydantic-settings
+    optional: false
+    platform: osx-64
+    url:
+      https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.8.1-pyh3cfb1c2_0.conda
+    version: 2.8.1
+  - category: main
+    dependencies:
+      pydantic: '>=2.7.0'
+      python: '>=3.9'
+      python-dotenv: '>=0.21.0'
+    hash:
+      md5: 88715188749bfac9fa92aec9c747d62c
+      sha256: 84b78dcdc75d7dacd8c85df9a7fef42ff5684897217b46beef6c516afb2550dc
+    manager: conda
+    name: pydantic-settings
+    optional: false
+    platform: osx-arm64
+    url:
+      https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.8.1-pyh3cfb1c2_0.conda
+    version: 2.8.1
+  - category: main
+    dependencies:
       __glibc: '>=2.17,<3.0.a0'
       cffi: ''
       libgcc: '>=13'
@@ -11141,6 +11186,7 @@ package:
       libzlib: '>=1.3.1,<2.0a0'
       ncurses: '>=6.5,<7.0a0'
       openssl: '>=3.4.1,<4.0a0'
+      pip: ''
       readline: '>=8.2,<9.0a0'
       tk: '>=8.6.13,<8.7.0a0'
       tzdata: ''
@@ -11165,6 +11211,7 @@ package:
       libzlib: '>=1.3.1,<2.0a0'
       ncurses: '>=6.5,<7.0a0'
       openssl: '>=3.4.1,<4.0a0'
+      pip: ''
       readline: '>=8.2,<9.0a0'
       tk: '>=8.6.13,<8.7.0a0'
       tzdata: ''
@@ -11189,6 +11236,7 @@ package:
       libzlib: '>=1.3.1,<2.0a0'
       ncurses: '>=6.5,<7.0a0'
       openssl: '>=3.4.1,<4.0a0'
+      pip: ''
       readline: '>=8.2,<9.0a0'
       tk: '>=8.6.13,<8.7.0a0'
       tzdata: ''
@@ -11298,6 +11346,45 @@ package:
     url:
       https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
     version: 2.9.0.post0
+  - category: main
+    dependencies:
+      python: '>=3.9'
+    hash:
+      md5: e5c6ed218664802d305e79cc2d4491de
+      sha256: 99713f6b534fef94995c6c16fd21d59f3548784e9111775d692bdc7c44678f02
+    manager: conda
+    name: python-dotenv
+    optional: false
+    platform: linux-64
+    url:
+      https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
+    version: 1.0.1
+  - category: main
+    dependencies:
+      python: '>=3.9'
+    hash:
+      md5: e5c6ed218664802d305e79cc2d4491de
+      sha256: 99713f6b534fef94995c6c16fd21d59f3548784e9111775d692bdc7c44678f02
+    manager: conda
+    name: python-dotenv
+    optional: false
+    platform: osx-64
+    url:
+      https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
+    version: 1.0.1
+  - category: main
+    dependencies:
+      python: '>=3.9'
+    hash:
+      md5: e5c6ed218664802d305e79cc2d4491de
+      sha256: 99713f6b534fef94995c6c16fd21d59f3548784e9111775d692bdc7c44678f02
+    manager: conda
+    name: python-dotenv
+    optional: false
+    platform: osx-arm64
+    url:
+      https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
+    version: 1.0.1
   - category: main
     dependencies:
       cpython: 3.11.11.*

--- a/conda_forge_tick/all_feedstocks.py
+++ b/conda_forge_tick/all_feedstocks.py
@@ -6,14 +6,14 @@ import tqdm
 from conda_forge_tick.git_utils import github_client
 
 from .lazy_json_backends import dump, load
+from .settings import CONDA_FORGE_ORG
 
 logger = logging.getLogger(__name__)
 
 
 def get_all_feedstocks_from_github():
     gh = github_client()
-
-    org = gh.get_organization("conda-forge")
+    org = gh.get_organization(CONDA_FORGE_ORG)
     archived = set()
     not_archived = set()
     default_branches = {}

--- a/conda_forge_tick/all_feedstocks.py
+++ b/conda_forge_tick/all_feedstocks.py
@@ -6,14 +6,14 @@ import tqdm
 from conda_forge_tick.git_utils import github_client
 
 from .lazy_json_backends import dump, load
-from .settings import CONDA_FORGE_ORG
+from .settings import settings
 
 logger = logging.getLogger(__name__)
 
 
 def get_all_feedstocks_from_github():
     gh = github_client()
-    org = gh.get_organization(CONDA_FORGE_ORG)
+    org = gh.get_organization(settings().conda_forge_org)
     archived = set()
     not_archived = set()
     default_branches = {}

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -72,6 +72,7 @@ from conda_forge_tick.utils import (
 
 from .migrators_types import MigrationUidTypedDict
 from .models.pr_json import PullRequestData, PullRequestInfoSpecial, PullRequestState
+from .settings import CONDA_FORGE_ORG
 
 logger = logging.getLogger(__name__)
 
@@ -1047,6 +1048,7 @@ def _run_migrator(migrator, mctx, temp, time_per, git_backend: GitPlatformBacken
             fctx = FeedstockContext(
                 feedstock_name=attrs["feedstock_name"],
                 attrs=attrs,
+                git_repo_owner=CONDA_FORGE_ORG,
             )
 
             # map main to current default branch

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -72,7 +72,7 @@ from conda_forge_tick.utils import (
 
 from .migrators_types import MigrationUidTypedDict
 from .models.pr_json import PullRequestData, PullRequestInfoSpecial, PullRequestState
-from .settings import CONDA_FORGE_ORG
+from .settings import settings
 
 logger = logging.getLogger(__name__)
 
@@ -1048,7 +1048,7 @@ def _run_migrator(migrator, mctx, temp, time_per, git_backend: GitPlatformBacken
             fctx = FeedstockContext(
                 feedstock_name=attrs["feedstock_name"],
                 attrs=attrs,
-                git_repo_owner=CONDA_FORGE_ORG,
+                git_repo_owner=settings().conda_forge_org,
             )
 
             # map main to current default branch

--- a/conda_forge_tick/contexts.py
+++ b/conda_forge_tick/contexts.py
@@ -37,6 +37,10 @@ class FeedstockContext:
     """
     If not provided, this is set to a default branch read from all_feedstocks.json, or 'main'.
     """
+    git_repo_owner: str = "conda-forge"
+    """
+    The owner of the upstream git repository.
+    """
 
     def __post_init__(self):
         if not self.default_branch:
@@ -45,10 +49,6 @@ class FeedstockContext:
                 "default_branch",
                 DEFAULT_BRANCHES.get(self.feedstock_name, "main"),
             )
-
-    @property
-    def git_repo_owner(self) -> str:
-        return "conda-forge"
 
     @property
     def git_repo_name(self) -> str:

--- a/conda_forge_tick/deploy.py
+++ b/conda_forge_tick/deploy.py
@@ -10,7 +10,7 @@ from .lazy_json_backends import (
     get_lazy_json_backends,
 )
 from .os_utils import clean_disk_space
-from .settings import GRAPH_REPO, GRAPH_REPO_DEFAULT_BRANCH
+from .settings import settings
 from .utils import (
     fold_log_lines,
     get_bot_run_url,
@@ -151,8 +151,8 @@ def _deploy_batch(*, files_to_add, batch, n_added, max_per_batch=200):
                 [
                     "git",
                     "push",
-                    f"https://{get_bot_token()}@github.com/{GRAPH_REPO}.git",
-                    GRAPH_REPO_DEFAULT_BRANCH,
+                    f"https://{get_bot_token()}@github.com/{settings().graph_github_backend_repo}.git",
+                    settings().graph_repo_default_branch,
                 ],
                 token=get_bot_token(),
             )
@@ -276,7 +276,7 @@ def deploy(ctx: CliContext, dirs_to_deploy: list[str] = None):
 
                 msg = _get_pth_commit_message(pth)
 
-                push_file_via_gh_api(pth, GRAPH_REPO, msg)
+                push_file_via_gh_api(pth, settings().graph_github_backend_repo, msg)
             except Exception as e:
                 logger.warning(
                     "git push via API failed - trying via git CLI", exc_info=e
@@ -299,7 +299,7 @@ def deploy(ctx: CliContext, dirs_to_deploy: list[str] = None):
                 # make a nice message for stuff managed via LazyJson
                 msg = _get_pth_commit_message(pth)
 
-                delete_file_via_gh_api(pth, GRAPH_REPO, msg)
+                delete_file_via_gh_api(pth, settings().graph_github_backend_repo, msg)
             except Exception as e:
                 logger.warning(
                     "git delete via API failed - trying via git CLI", exc_info=e

--- a/conda_forge_tick/deploy.py
+++ b/conda_forge_tick/deploy.py
@@ -147,17 +147,17 @@ def _deploy_batch(*, files_to_add, batch, n_added, max_per_batch=200):
                     pass
 
                 print(">>>>>>>>>>>> git push try", flush=True)
-            status = run_command_hiding_token(
-                [
-                    "git",
-                    "push",
-                    f"https://{get_bot_token()}@github.com/{settings().graph_github_backend_repo}.git",
-                    settings().graph_repo_default_branch,
-                ],
-                token=get_bot_token(),
-            )
-            if status != 0:
-                print(">>>>>>>>>>>> git push failed", flush=True)
+                status = run_command_hiding_token(
+                    [
+                        "git",
+                        "push",
+                        f"https://{get_bot_token()}@github.com/{settings().graph_github_backend_repo}.git",
+                        settings().graph_repo_default_branch,
+                    ],
+                    token=get_bot_token(),
+                )
+                if status != 0:
+                    print(">>>>>>>>>>>> git push failed", flush=True)
             num_try += 1
 
         if status != 0 or not graph_ok:

--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -19,7 +19,7 @@ from conda_forge_feedstock_ops.container_utils import (
 )
 from requests.models import Response
 
-from conda_forge_tick.settings import CONDA_FORGE_ORG, ENV_OVERRIDE_CONDA_FORGE_ORG
+from conda_forge_tick.settings import ENV_CONDA_FORGE_ORG, settings
 
 if typing.TYPE_CHECKING:
     from mypy_extensions import TestTypedDict
@@ -194,7 +194,7 @@ def _fetch_static_repo(name, dest):
     for branch in ["main", "master"]:
         try:
             r = requests.get(
-                f"https://github.com/{CONDA_FORGE_ORG}/{name}-feedstock/archive/{branch}.zip",
+                f"https://github.com/{settings().conda_forge_org}/{name}-feedstock/archive/{branch}.zip",
             )
             r.raise_for_status()
             found_branch = branch
@@ -676,7 +676,7 @@ def load_feedstock_containerized(
         input=json_blob,
         extra_container_args=[
             "-e",
-            f"{ENV_OVERRIDE_CONDA_FORGE_ORG}={CONDA_FORGE_ORG}",
+            f"{ENV_CONDA_FORGE_ORG}={settings().conda_forge_org}",
         ],
     )
 

--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -19,6 +19,8 @@ from conda_forge_feedstock_ops.container_utils import (
 )
 from requests.models import Response
 
+from conda_forge_tick.settings import CONDA_FORGE_ORG, ENV_OVERRIDE_CONDA_FORGE_ORG
+
 if typing.TYPE_CHECKING:
     from mypy_extensions import TestTypedDict
 
@@ -192,7 +194,7 @@ def _fetch_static_repo(name, dest):
     for branch in ["main", "master"]:
         try:
             r = requests.get(
-                f"https://github.com/conda-forge/{name}-feedstock/archive/{branch}.zip",
+                f"https://github.com/{CONDA_FORGE_ORG}/{name}-feedstock/archive/{branch}.zip",
             )
             r.raise_for_status()
             found_branch = branch
@@ -672,6 +674,10 @@ def load_feedstock_containerized(
         args,
         json_loads=loads,
         input=json_blob,
+        extra_container_args=[
+            "-e",
+            f"{ENV_OVERRIDE_CONDA_FORGE_ORG}={CONDA_FORGE_ORG}",
+        ],
     )
 
     return data

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -193,7 +193,8 @@ class GitCli:
         """
         git_command = ["git"] + cmd
 
-        logger.debug(f"Running git command: {git_command}")
+        if not suppress_all_output:
+            logger.debug("Running git command: %s", git_command)
 
         # stdout and stderr are piped to devnull if suppress_all_output is True
         stdout_args = (

--- a/conda_forge_tick/import_to_pkg.py
+++ b/conda_forge_tick/import_to_pkg.py
@@ -18,7 +18,6 @@ from tqdm import tqdm
 from conda_forge_tick.cli_context import CliContext
 from conda_forge_tick.lazy_json_backends import (
     CF_TICK_GRAPH_DATA_BACKENDS,
-    CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL,
     CF_TICK_GRAPH_GITHUB_BACKEND_NUM_DIRS,
     LazyJson,
     dump,
@@ -26,6 +25,7 @@ from conda_forge_tick.lazy_json_backends import (
     lazy_json_override_backends,
     load,
 )
+from conda_forge_tick.settings import settings
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +80,7 @@ def _get_head_letters(name):
 def _ranked_hubs_authorities() -> list[str]:
     req = requests.get(
         os.path.join(
-            CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL,
+            settings().graph_github_backend_raw_base_url,
             "ranked_hubs_authorities.json",
         )
     )
@@ -99,7 +99,7 @@ def _import_to_pkg_maps_cache(import_first_letters: str) -> dict[str, set[str]]:
     else:
         req = requests.get(
             os.path.join(
-                CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL,
+                settings().graph_github_backend_raw_base_url,
                 pth,
             )
         )

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -31,7 +31,7 @@ import requests
 
 from .cli_context import CliContext
 from .executors import lock_git_operation
-from .settings import GRAPH_REPO, GRAPH_REPO_DEFAULT_BRANCH
+from .settings import settings
 
 logger = logging.getLogger(__name__)
 
@@ -57,9 +57,6 @@ CF_TICK_GRAPH_DATA_HASHMAPS = [
     "migrators",
 ]
 
-CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL = (
-    f"https://github.com/{GRAPH_REPO}/raw/{GRAPH_REPO_DEFAULT_BRANCH}"
-)
 CF_TICK_GRAPH_GITHUB_BACKEND_NUM_DIRS = 5
 
 
@@ -207,7 +204,7 @@ class GithubLazyJsonBackend(LazyJsonBackend):
     _n_requests = 0
 
     def __init__(self) -> None:
-        self.base_url = CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL
+        self.base_url = settings().graph_github_backend_raw_base_url
 
     @property
     def base_url(self) -> str:
@@ -327,7 +324,7 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
         from conda_forge_tick.git_utils import github_client
 
         self._gh = github_client()
-        self._repo = self._gh.get_repo(GRAPH_REPO)
+        self._repo = self._gh.get_repo(settings().graph_github_backend_repo)
 
     @contextlib.contextmanager
     def transaction_context(self) -> "Iterator[FileLazyJsonBackend]":
@@ -499,7 +496,7 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
         for tr in range(ntries):
             try:
                 cnts = requests.get(
-                    f"https://api.github.com/repos/{GRAPH_REPO}/contents/{pth}",
+                    f"https://api.github.com/repos/{settings().graph_github_backend_repo}/contents/{pth}",
                     headers=hrds,
                 )
                 cnts.raise_for_status()

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -31,6 +31,7 @@ import requests
 
 from .cli_context import CliContext
 from .executors import lock_git_operation
+from .settings import GRAPH_REPO, GRAPH_REPO_DEFAULT_BRANCH
 
 logger = logging.getLogger(__name__)
 
@@ -56,9 +57,8 @@ CF_TICK_GRAPH_DATA_HASHMAPS = [
     "migrators",
 ]
 
-CF_TICK_GRAPH_GITHUB_BACKEND_REPO = "regro/cf-graph-countyfair"
 CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL = (
-    f"https://github.com/{CF_TICK_GRAPH_GITHUB_BACKEND_REPO}/raw/master"
+    f"https://github.com/{GRAPH_REPO}/raw/{GRAPH_REPO_DEFAULT_BRANCH}"
 )
 CF_TICK_GRAPH_GITHUB_BACKEND_NUM_DIRS = 5
 
@@ -327,7 +327,7 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
         from conda_forge_tick.git_utils import github_client
 
         self._gh = github_client()
-        self._repo = self._gh.get_repo(CF_TICK_GRAPH_GITHUB_BACKEND_REPO)
+        self._repo = self._gh.get_repo(GRAPH_REPO)
 
     @contextlib.contextmanager
     def transaction_context(self) -> "Iterator[FileLazyJsonBackend]":
@@ -499,7 +499,7 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
         for tr in range(ntries):
             try:
                 cnts = requests.get(
-                    f"https://api.github.com/repos/{CF_TICK_GRAPH_GITHUB_BACKEND_REPO}/contents/{pth}",
+                    f"https://api.github.com/repos/{GRAPH_REPO}/contents/{pth}",
                     headers=hrds,
                 )
                 cnts.raise_for_status()

--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -24,7 +24,7 @@ from conda_forge_tick.lazy_json_backends import (
 from .all_feedstocks import get_all_feedstocks, get_archived_feedstocks
 from .cli_context import CliContext
 from .executors import executor
-from .settings import FRAC_MAKE_GRAPH
+from .settings import settings
 from .utils import as_iterable, dump_graph, load_graph, sanitize_string
 
 # from conda_forge_tick.profiler import profiling
@@ -199,7 +199,7 @@ def _build_graph_process_pool(
         futures = {
             pool.submit(get_attrs, name, mark_not_archived=mark_not_archived): name
             for name in names
-            if RNG.random() < FRAC_MAKE_GRAPH
+            if RNG.random() < settings().frac_make_graph
         }
         logger.info("submitted all nodes")
 
@@ -230,7 +230,7 @@ def _build_graph_sequential(
     mark_not_archived=False,
 ) -> None:
     for name in names:
-        if RNG.random() >= FRAC_MAKE_GRAPH:
+        if RNG.random() >= settings().frac_make_graph:
             logger.debug("skipping %s due to random fraction to update", name)
             continue
 

--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -24,6 +24,7 @@ from conda_forge_tick.lazy_json_backends import (
 from .all_feedstocks import get_all_feedstocks, get_archived_feedstocks
 from .cli_context import CliContext
 from .executors import executor
+from .settings import FRAC_MAKE_GRAPH
 from .utils import as_iterable, dump_graph, load_graph, sanitize_string
 
 # from conda_forge_tick.profiler import profiling
@@ -33,8 +34,6 @@ logger = logging.getLogger(__name__)
 
 pin_sep_pat = re.compile(r" |>|<|=|\[")
 RNG = secrets.SystemRandom()
-
-RANDOM_FRAC_TO_UPDATE = 0.1
 
 # AFAIK, go and rust do not have strong run exports and so do not need to
 # appear here
@@ -200,7 +199,7 @@ def _build_graph_process_pool(
         futures = {
             pool.submit(get_attrs, name, mark_not_archived=mark_not_archived): name
             for name in names
-            if RNG.random() < RANDOM_FRAC_TO_UPDATE
+            if RNG.random() < FRAC_MAKE_GRAPH
         }
         logger.info("submitted all nodes")
 
@@ -231,7 +230,8 @@ def _build_graph_sequential(
     mark_not_archived=False,
 ) -> None:
     for name in names:
-        if RNG.random() >= RANDOM_FRAC_TO_UPDATE:
+        if RNG.random() >= FRAC_MAKE_GRAPH:
+            logger.debug("skipping %s due to random fraction to update", name)
             continue
 
         try:

--- a/conda_forge_tick/migrators/pip_wheel_dep.py
+++ b/conda_forge_tick/migrators/pip_wheel_dep.py
@@ -8,9 +8,9 @@ from typing import Any, Dict
 import requests
 from ruamel.yaml import YAML
 
-from conda_forge_tick.lazy_json_backends import CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL
 from conda_forge_tick.migrators.core import MiniMigrator, skip_migrator_due_to_schema
 from conda_forge_tick.os_utils import pushd
+from conda_forge_tick.settings import settings
 from conda_forge_tick.utils import get_keys_default
 
 if typing.TYPE_CHECKING:
@@ -28,7 +28,7 @@ def pypi_conda_mapping() -> Dict[str, str]:
     yaml = YAML()
     content = requests.get(
         os.path.join(
-            CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL,
+            settings().graph_github_backend_raw_base_url,
             "mappings",
             "pypi",
             "grayskull_pypi_mapping.yaml",

--- a/conda_forge_tick/pypi_name_mapping.py
+++ b/conda_forge_tick/pypi_name_mapping.py
@@ -23,12 +23,12 @@ from packaging.utils import canonicalize_name as canonicalize_pypi_name
 from .import_to_pkg import IMPORT_TO_PKG_DIR_CLOBBERING
 from .lazy_json_backends import (
     CF_TICK_GRAPH_DATA_BACKENDS,
-    CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL,
     LazyJson,
     dump,
     get_all_keys_for_hashmap,
     loads,
 )
+from .settings import settings
 from .utils import as_iterable, load_existing_graph
 
 
@@ -320,7 +320,7 @@ def determine_best_matches_for_pypi_import(
             clobberers = loads(
                 requests.get(
                     os.path.join(
-                        CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL,
+                        settings().graph_github_backend_raw_base_url,
                         IMPORT_TO_PKG_DIR_CLOBBERING,
                     )
                 ).text,

--- a/conda_forge_tick/settings.py
+++ b/conda_forge_tick/settings.py
@@ -5,7 +5,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 ENVIRONMENT_PREFIX = "CF_TICK_"
 """
-All environment are expected to be prefixed with this.
+All environment variables are expected to be prefixed with this.
 """
 
 ENV_CONDA_FORGE_ORG = ENVIRONMENT_PREFIX + "CONDA_FORGE_ORG"

--- a/conda_forge_tick/settings.py
+++ b/conda_forge_tick/settings.py
@@ -11,6 +11,17 @@ import os
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+ENVIRONMENT_PREFIX = "CF_TICK_"
+"""
+All environment are expected to be prefixed with this.
+"""
+
+ENV_CONDA_FORGE_ORG = ENVIRONMENT_PREFIX + "CONDA_FORGE_ORG"
+"""
+The environment variable used to set the `conda_forge_org` setting.
+Note: This must match the field name in the `BotSettings` class.
+"""
+
 
 class BotSettings(BaseSettings):
     """
@@ -23,7 +34,13 @@ class BotSettings(BaseSettings):
     To access the current settings object, please use the `settings()` function.
     """
 
-    model_config = SettingsConfigDict(env_prefix="CF_TICK_")
+    model_config = SettingsConfigDict(env_prefix=ENVIRONMENT_PREFIX)
+
+    conda_forge_org: str = Field("conda-forge", pattern=r"^[\w\.-]+$")
+    """
+    The GitHub organization containing all feedstocks. Default: "conda-forge".
+    If you change the field name, you must also update the `ENV_CONDA_FORGE_ORG` constant.
+    """
 
     graph_github_backend_repo: str = Field(
         "regro/cf-graph-countyfair", pattern=r"^[\w\.-]+/[\w\.-]+$"
@@ -52,13 +69,6 @@ def settings() -> BotSettings:
     """
     return BotSettings()
 
-
-ENV_OVERRIDE_CONDA_FORGE_ORG = "CF_TICK_OVERRIDE_CONDA_FORGE_ORG"
-CONDA_FORGE_ORG: str = os.getenv(ENV_OVERRIDE_CONDA_FORGE_ORG, "conda-forge")
-"""
-The GitHub organization containing all feedstocks. Default: "conda-forge".
-Overwrite with the environment variable CF_TICK_OVERRIDE_CONDA_FORGE_ORG.
-"""
 
 ENV_GITHUB_RUNNER_DEBUG = "RUNNER_DEBUG"
 GITHUB_RUNNER_DEBUG: bool = os.getenv(ENV_GITHUB_RUNNER_DEBUG, "0") == "1"

--- a/conda_forge_tick/settings.py
+++ b/conda_forge_tick/settings.py
@@ -1,0 +1,52 @@
+"""
+This module contains global settings for the bot.
+For each setting available as `SETTING_NAME`, there is an environment variable available as `ENV_SETTING_NAME`
+that can be used to override the default value.
+Note that there is no further validation of environment variables as of now.
+To make settings easier to understand for humans, we use explicit type annotations.
+"""
+
+import os
+
+ENV_GRAPH_REPO = "CF_TICK_GRAPH_GITHUB_BACKEND_REPO"
+GRAPH_REPO: str = os.getenv(ENV_GRAPH_REPO, "regro/cf-graph-countyfair")
+"""
+The GitHub repository to deploy to. Default: "regro/cf-graph-countyfair".
+Overwrite with the environment variable CF_TICK_GRAPH_GITHUB_BACKEND_REPO.
+"""
+
+GRAPH_REPO_DEFAULT_BRANCH: str = "master"
+"""
+The default branch of the GRAPH_REPO repository.
+"""
+
+ENV_OVERRIDE_CONDA_FORGE_ORG = "CF_TICK_OVERRIDE_CONDA_FORGE_ORG"
+CONDA_FORGE_ORG: str = os.getenv(ENV_OVERRIDE_CONDA_FORGE_ORG, "conda-forge")
+"""
+The GitHub organization containing all feedstocks. Default: "conda-forge".
+Overwrite with the environment variable CF_TICK_OVERRIDE_CONDA_FORGE_ORG.
+"""
+
+ENV_GITHUB_RUNNER_DEBUG = "RUNNER_DEBUG"
+GITHUB_RUNNER_DEBUG: bool = os.getenv(ENV_GITHUB_RUNNER_DEBUG, "0") == "1"
+"""
+Whether we are executing within a GitHub Actions run with debug logging enabled. Default: False.
+https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
+"""
+
+ENV_FRAC_UPDATE_UPSTREAM_VERSIONS = "CF_TICK_FRAC_UPDATE_UPSTREAM_VERSIONS"
+FRAC_UPDATE_UPSTREAM_VERSIONS: float = float(
+    os.getenv(ENV_FRAC_UPDATE_UPSTREAM_VERSIONS, "0.1")
+)
+"""
+The fraction of feedstocks (randomly selected) to update in the update-upstream-versions job.
+This is currently only respected when running concurrently (via process pool), not in sequential mode.
+Therefore, you don't need to set this when debugging locally.
+"""
+
+ENV_RANDOM_FRAC_MAKE_GRAPH = "CF_TICK_FRAC_MAKE_GRAPH"
+FRAC_MAKE_GRAPH: float = float(os.getenv(ENV_RANDOM_FRAC_MAKE_GRAPH, "0.1"))
+"""
+The fraction of feedstocks (randomly selected) to update in the make-graph job.
+In tests or when debugging, you probably need to set this to 1.0 to update all feedstocks.
+"""

--- a/conda_forge_tick/settings.py
+++ b/conda_forge_tick/settings.py
@@ -34,6 +34,9 @@ class BotSettings(BaseSettings):
     `CF_TICK_GRAPH_GITHUB_BACKEND_REPO`.
 
     To access the current settings object, please use the `settings()` function.
+
+    Note: There still exists a significant amount of settings that are not yet exposed here.
+    All new settings should go here, and the other ones should eventually be migrated.
     """
 
     model_config = SettingsConfigDict(env_prefix=ENVIRONMENT_PREFIX)

--- a/conda_forge_tick/settings.py
+++ b/conda_forge_tick/settings.py
@@ -1,11 +1,3 @@
-"""
-This module contains global settings for the bot.
-For each setting available as `SETTING_NAME`, there is an environment variable available as `ENV_SETTING_NAME`
-that can be used to override the default value.
-Note that there is no further validation of environment variables as of now.
-To make settings easier to understand for humans, we use explicit type annotations.
-"""
-
 from typing import Annotated
 
 from pydantic import Field
@@ -88,8 +80,27 @@ class BotSettings(BaseSettings):
     """
 
 
+_USE_SETTINGS_OVERRIDE: BotSettings | None = None
+"""
+If not None, the application should use this settings object instead of generating a new one.
+"""
+
+
 def settings() -> BotSettings:
     """
     Get the current settings object.
     """
+    if _USE_SETTINGS_OVERRIDE:
+        return _USE_SETTINGS_OVERRIDE.model_copy()  # prevent side-effects
     return BotSettings()
+
+
+def use_settings(s: BotSettings | None) -> None:
+    """
+    Overrides the application settings with the given settings object.
+    The new settings object is persisted indefinitely until another call to `use_settings` is made.
+
+    :param s: The settings object to use. If None, the application will revert to using the default settings.
+    """
+    global _USE_SETTINGS_OVERRIDE
+    _USE_SETTINGS_OVERRIDE = s

--- a/conda_forge_tick/settings.py
+++ b/conda_forge_tick/settings.py
@@ -62,6 +62,13 @@ class BotSettings(BaseSettings):
         """
         return f"https://github.com/{self.graph_github_backend_repo}/raw/{self.graph_repo_default_branch}"
 
+    github_runner_debug: bool = Field(False, alias="RUNNER_DEBUG")
+    """
+    Whether we are executing within a GitHub Actions run with debug logging enabled. Default: False.
+    This is set automatically by GitHub Actions.
+    https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
+    """
+
 
 def settings() -> BotSettings:
     """
@@ -69,13 +76,6 @@ def settings() -> BotSettings:
     """
     return BotSettings()
 
-
-ENV_GITHUB_RUNNER_DEBUG = "RUNNER_DEBUG"
-GITHUB_RUNNER_DEBUG: bool = os.getenv(ENV_GITHUB_RUNNER_DEBUG, "0") == "1"
-"""
-Whether we are executing within a GitHub Actions run with debug logging enabled. Default: False.
-https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
-"""
 
 ENV_FRAC_UPDATE_UPSTREAM_VERSIONS = "CF_TICK_FRAC_UPDATE_UPSTREAM_VERSIONS"
 FRAC_UPDATE_UPSTREAM_VERSIONS: float = float(

--- a/conda_forge_tick/settings.py
+++ b/conda_forge_tick/settings.py
@@ -8,17 +8,50 @@ To make settings easier to understand for humans, we use explicit type annotatio
 
 import os
 
-ENV_GRAPH_REPO = "CF_TICK_GRAPH_GITHUB_BACKEND_REPO"
-GRAPH_REPO: str = os.getenv(ENV_GRAPH_REPO, "regro/cf-graph-countyfair")
-"""
-The GitHub repository to deploy to. Default: "regro/cf-graph-countyfair".
-Overwrite with the environment variable CF_TICK_GRAPH_GITHUB_BACKEND_REPO.
-"""
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
-GRAPH_REPO_DEFAULT_BRANCH: str = "master"
-"""
-The default branch of the GRAPH_REPO repository.
-"""
+
+class BotSettings(BaseSettings):
+    """
+    The global settings for the bot.
+
+    To configure a settings value, set the corresponding environment variable with the prefix `CF_TICK_`.
+    For example, to set the `graph_github_backend_repo` setting, set the environment variable
+    `CF_TICK_GRAPH_GITHUB_BACKEND_REPO`.
+
+    To access the current settings object, please use the `settings()` function.
+    """
+
+    model_config = SettingsConfigDict(env_prefix="CF_TICK_")
+
+    graph_github_backend_repo: str = Field(
+        "regro/cf-graph-countyfair", pattern=r"^[\w\.-]+/[\w\.-]+$"
+    )
+    """
+    The GitHub repository to deploy to. Default: "regro/cf-graph-countyfair".
+    """
+
+    graph_repo_default_branch: str = "master"
+    """
+    The default branch of the graph_github_backend_repo repository.
+    """
+
+    @property
+    def graph_github_backend_raw_base_url(self) -> str:
+        """
+        The base URL for the GitHub raw view of the graph_github_backend_repo repository.
+        Example: https://github.com/regro/cf-graph-countyfair/raw/master
+        """
+        return f"https://github.com/{self.graph_github_backend_repo}/raw/{self.graph_repo_default_branch}"
+
+
+def settings() -> BotSettings:
+    """
+    Get the current settings object.
+    """
+    return BotSettings()
+
 
 ENV_OVERRIDE_CONDA_FORGE_ORG = "CF_TICK_OVERRIDE_CONDA_FORGE_ORG"
 CONDA_FORGE_ORG: str = os.getenv(ENV_OVERRIDE_CONDA_FORGE_ORG, "conda-forge")

--- a/conda_forge_tick/settings.py
+++ b/conda_forge_tick/settings.py
@@ -6,7 +6,7 @@ Note that there is no further validation of environment variables as of now.
 To make settings easier to understand for humans, we use explicit type annotations.
 """
 
-import os
+from typing import Annotated
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -21,6 +21,8 @@ ENV_CONDA_FORGE_ORG = ENVIRONMENT_PREFIX + "CONDA_FORGE_ORG"
 The environment variable used to set the `conda_forge_org` setting.
 Note: This must match the field name in the `BotSettings` class.
 """
+
+Fraction = Annotated[float, Field(ge=0.0, le=1.0)]
 
 
 class BotSettings(BaseSettings):
@@ -69,27 +71,22 @@ class BotSettings(BaseSettings):
     https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
     """
 
+    frac_update_upstream_versions: Fraction = 0.1
+    """
+    The fraction of feedstocks (randomly selected) to update in the update-upstream-versions job.
+    This is currently only respected when running concurrently (via process pool), not in sequential mode.
+    Therefore, you don't need to set this when debugging locally.
+    """
+
+    frac_make_graph: Fraction = 0.1
+    """
+    The fraction of feedstocks (randomly selected) to update in the make-graph job.
+    In tests or when debugging, you probably need to set this to 1.0 to update all feedstocks.
+    """
+
 
 def settings() -> BotSettings:
     """
     Get the current settings object.
     """
     return BotSettings()
-
-
-ENV_FRAC_UPDATE_UPSTREAM_VERSIONS = "CF_TICK_FRAC_UPDATE_UPSTREAM_VERSIONS"
-FRAC_UPDATE_UPSTREAM_VERSIONS: float = float(
-    os.getenv(ENV_FRAC_UPDATE_UPSTREAM_VERSIONS, "0.1")
-)
-"""
-The fraction of feedstocks (randomly selected) to update in the update-upstream-versions job.
-This is currently only respected when running concurrently (via process pool), not in sequential mode.
-Therefore, you don't need to set this when debugging locally.
-"""
-
-ENV_RANDOM_FRAC_MAKE_GRAPH = "CF_TICK_FRAC_MAKE_GRAPH"
-FRAC_MAKE_GRAPH: float = float(os.getenv(ENV_RANDOM_FRAC_MAKE_GRAPH, "0.1"))
-"""
-The fraction of feedstocks (randomly selected) to update in the make-graph job.
-In tests or when debugging, you probably need to set this to 1.0 to update all feedstocks.
-"""

--- a/conda_forge_tick/settings.py
+++ b/conda_forge_tick/settings.py
@@ -103,4 +103,4 @@ def use_settings(s: BotSettings | None) -> None:
     :param s: The settings object to use. If None, the application will revert to using the default settings.
     """
     global _USE_SETTINGS_OVERRIDE
-    _USE_SETTINGS_OVERRIDE = s.model_copy()  # prevent side-effects
+    _USE_SETTINGS_OVERRIDE = s.model_copy() if s else s  # prevent side-effects

--- a/conda_forge_tick/settings.py
+++ b/conda_forge_tick/settings.py
@@ -103,4 +103,4 @@ def use_settings(s: BotSettings | None) -> None:
     :param s: The settings object to use. If None, the application will revert to using the default settings.
     """
     global _USE_SETTINGS_OVERRIDE
-    _USE_SETTINGS_OVERRIDE = s
+    _USE_SETTINGS_OVERRIDE = s.model_copy()  # prevent side-effects

--- a/conda_forge_tick/update_deps.py
+++ b/conda_forge_tick/update_deps.py
@@ -11,12 +11,12 @@ from stdlib_list import stdlib_list
 
 from conda_forge_tick.depfinder_api import simple_import_to_pkg_map
 from conda_forge_tick.feedstock_parser import load_feedstock
-from conda_forge_tick.lazy_json_backends import CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL
 from conda_forge_tick.make_graph import COMPILER_STUBS_WITH_STRONG_EXPORTS
 from conda_forge_tick.os_utils import pushd
 from conda_forge_tick.provide_source_code import provide_source_code
 from conda_forge_tick.pypi_name_mapping import _KNOWN_NAMESPACE_PACKAGES
 from conda_forge_tick.recipe_parser import CONDA_SELECTOR, CondaMetaYAML
+from conda_forge_tick.settings import settings
 
 try:
     from grayskull.main import create_python_recipe
@@ -67,7 +67,7 @@ RANKINGS = []
 for _ in range(10):
     r = requests.get(
         os.path.join(
-            CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL,
+            settings().graph_github_backend_raw_base_url,
             "ranked_hubs_authorities.json",
         )
     )

--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -31,7 +31,7 @@ from conda_forge_tick.cli_context import CliContext
 from conda_forge_tick.executors import executor
 from conda_forge_tick.lazy_json_backends import LazyJson, dumps
 from conda_forge_tick.settings import (
-    FRAC_UPDATE_UPSTREAM_VERSIONS,
+    settings,
 )
 from conda_forge_tick.update_sources import (
     CRAN,
@@ -366,7 +366,7 @@ def _update_upstream_versions_process_pool(
             ncols=80,
             desc="submitting version update jobs",
         ):
-            if RNG.random() >= FRAC_UPDATE_UPSTREAM_VERSIONS:
+            if RNG.random() >= settings().frac_update_upstream_versions:
                 continue
 
             futures.update(

--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -30,6 +30,9 @@ from conda_forge_feedstock_ops.container_utils import (
 from conda_forge_tick.cli_context import CliContext
 from conda_forge_tick.executors import executor
 from conda_forge_tick.lazy_json_backends import LazyJson, dumps
+from conda_forge_tick.settings import (
+    FRAC_UPDATE_UPSTREAM_VERSIONS,
+)
 from conda_forge_tick.update_sources import (
     CRAN,
     NPM,
@@ -51,8 +54,6 @@ T = TypeVar("T")
 logger = logging.getLogger(__name__)
 
 RNG = secrets.SystemRandom()
-
-RANDOM_FRAC_TO_UPDATE = 0.1
 
 
 def ignore_version(attrs: Mapping[str, Any], version: str) -> bool:
@@ -365,7 +366,7 @@ def _update_upstream_versions_process_pool(
             ncols=80,
             desc="submitting version update jobs",
         ):
-            if RNG.random() >= RANDOM_FRAC_TO_UPDATE:
+            if RNG.random() >= FRAC_UPDATE_UPSTREAM_VERSIONS:
                 continue
 
             futures.update(

--- a/environment.yml
+++ b/environment.yml
@@ -40,6 +40,7 @@ dependencies:
   - psutil
   - pydantic
   - pydantic-extra-types
+  - pydantic-settings
   - pygithub
   - pymongo
   - pynamodb

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,4 +114,5 @@ def pytest_configure(config):
 def temporary_environment():
     old_env = os.environ.copy()
     yield
-    os.environ = old_env
+    os.environ.clear()
+    os.environ.update(old_env)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,3 +108,10 @@ def pytest_configure(config):
         "markers",
         "mongodb: mark tests that run with mongodb",
     )
+
+
+@pytest.fixture
+def temporary_environment():
+    old_env = os.environ.copy()
+    yield
+    os.environ = old_env

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -50,6 +50,11 @@ def test_feedstock_context_git_repo_owner():
     context = FeedstockContext("TEST-FEEDSTOCK-NAME", demo_attrs)
     assert context.git_repo_owner == "conda-forge"
 
+    override_git_repo_owner_context = FeedstockContext(
+        "TEST-FEEDSTOCK-NAME", demo_attrs, git_repo_owner="GIT_REPO_OWNER"
+    )
+    assert override_git_repo_owner_context.git_repo_owner == "GIT_REPO_OWNER"
+
 
 def test_feedstock_context_git_repo_name():
     context = FeedstockContext("TEST-FEEDSTOCK-NAME", demo_attrs)

--- a/tests/test_lazy_json_backends.py
+++ b/tests/test_lazy_json_backends.py
@@ -16,7 +16,6 @@ import conda_forge_tick
 import conda_forge_tick.utils
 from conda_forge_tick.git_utils import github_client
 from conda_forge_tick.lazy_json_backends import (
-    CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL,
     LAZY_JSON_BACKENDS,
     GithubLazyJsonBackend,
     LazyJson,
@@ -37,6 +36,7 @@ from conda_forge_tick.lazy_json_backends import (
     touch_all_lazy_json_refs,
 )
 from conda_forge_tick.os_utils import pushd
+from conda_forge_tick.settings import settings
 
 HAVE_MONGODB = (
     "MONGODB_CONNECTION_STRING" in conda_forge_tick.global_sensitive_env.classified_info
@@ -624,7 +624,7 @@ def test_lazy_json_backends_hashmap(tmpdir):
 
 def test_github_base_url() -> None:
     github_backend = GithubLazyJsonBackend()
-    assert github_backend.base_url == CF_TICK_GRAPH_GITHUB_BACKEND_BASE_URL + "/"
+    assert github_backend.base_url == settings().graph_github_backend_raw_base_url + "/"
     github_backend.base_url = "https://github.com/lorem/ipsum"
     assert github_backend.base_url == "https://github.com/lorem/ipsum" + "/"
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -12,6 +12,8 @@ class TestBotSettings:
         os.environ["CF_TICK_GRAPH_GITHUB_BACKEND_REPO"] = "graph-owner/graph-repo"
         os.environ["CF_TICK_GRAPH_REPO_DEFAULT_BRANCH"] = "mybranch"
         os.environ["RUNNER_DEBUG"] = "1"
+        os.environ["CF_TICK_FRAC_UPDATE_UPSTREAM_VERSIONS"] = "0.5"
+        os.environ["CF_TICK_FRAC_MAKE_GRAPH"] = "0.7"
 
         settings = BotSettings()
 
@@ -23,6 +25,8 @@ class TestBotSettings:
             == "https://github.com/graph-owner/graph-repo/raw/mybranch"
         )
         assert settings.github_runner_debug is True
+        assert settings.frac_update_upstream_versions == 0.5
+        assert settings.frac_make_graph == 0.7
 
     def test_defaults(self, temporary_environment):
         os.environ.clear()
@@ -33,6 +37,8 @@ class TestBotSettings:
         assert settings.graph_github_backend_repo == "regro/cf-graph-countyfair"
         assert settings.graph_repo_default_branch == "master"
         assert settings.github_runner_debug is False
+        assert settings.frac_update_upstream_versions == 0.1
+        assert settings.frac_make_graph == 0.1
 
     def test_env_conda_forge_org(self, temporary_environment):
         os.environ.clear()
@@ -58,3 +64,32 @@ class TestBotSettings:
 
         with pytest.raises(ValidationError, match="should match pattern"):
             BotSettings()
+
+    @pytest.mark.parametrize("value", [-0.1, 1.1])
+    @pytest.mark.parametrize(
+        "attribute", ["FRAC_UPDATE_UPSTREAM_VERSIONS", "FRAC_MAKE_GRAPH"]
+    )
+    def test_reject_invalid_fraction(
+        self, attribute: str, value: float, temporary_environment
+    ):
+        os.environ.clear()
+
+        os.environ[f"CF_TICK_{attribute}"] = str(value)
+
+        with pytest.raises(ValidationError, match="Input should be (greater|less)"):
+            BotSettings()
+
+    @pytest.mark.parametrize("value", [0.0, 1.0])
+    @pytest.mark.parametrize(
+        "attribute", ["FRAC_UPDATE_UPSTREAM_VERSIONS", "FRAC_MAKE_GRAPH"]
+    )
+    def test_accept_valid_fraction(
+        self, attribute: str, value: float, temporary_environment
+    ):
+        os.environ.clear()
+
+        os.environ[f"CF_TICK_{attribute}"] = str(value)
+
+        settings = BotSettings()
+
+        assert getattr(settings, attribute.lower()) == value

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3,16 +3,18 @@ import os
 import pytest
 from pydantic import ValidationError
 
-from conda_forge_tick.settings import BotSettings
+from conda_forge_tick.settings import ENV_CONDA_FORGE_ORG, BotSettings
 
 
 class TestBotSettings:
     def test_parse(self, temporary_environment):
+        os.environ["CF_TICK_CONDA_FORGE_ORG"] = "myorg"
         os.environ["CF_TICK_GRAPH_GITHUB_BACKEND_REPO"] = "graph-owner/graph-repo"
         os.environ["CF_TICK_GRAPH_REPO_DEFAULT_BRANCH"] = "mybranch"
 
         settings = BotSettings()
 
+        assert settings.conda_forge_org == "myorg"
         assert settings.graph_github_backend_repo == "graph-owner/graph-repo"
         assert settings.graph_repo_default_branch == "mybranch"
         assert (
@@ -25,8 +27,26 @@ class TestBotSettings:
 
         settings = BotSettings()
 
+        assert settings.conda_forge_org == "conda-forge"
         assert settings.graph_github_backend_repo == "regro/cf-graph-countyfair"
         assert settings.graph_repo_default_branch == "master"
+
+    def test_env_conda_forge_org(self, temporary_environment):
+        os.environ.clear()
+
+        os.environ[ENV_CONDA_FORGE_ORG] = "myorg"
+
+        settings = BotSettings()
+
+        assert settings.conda_forge_org == "myorg"
+
+    def test_reject_invalid_conda_forge_org(self, temporary_environment):
+        os.environ.clear()
+
+        os.environ["CF_TICK_CONDA_FORGE_ORG"] = "invalid org"
+
+        with pytest.raises(ValidationError, match="should match pattern"):
+            BotSettings()
 
     def test_reject_invalid_repo_pattern(self, temporary_environment):
         os.environ.clear()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -11,6 +11,7 @@ class TestBotSettings:
         os.environ["CF_TICK_CONDA_FORGE_ORG"] = "myorg"
         os.environ["CF_TICK_GRAPH_GITHUB_BACKEND_REPO"] = "graph-owner/graph-repo"
         os.environ["CF_TICK_GRAPH_REPO_DEFAULT_BRANCH"] = "mybranch"
+        os.environ["RUNNER_DEBUG"] = "1"
 
         settings = BotSettings()
 
@@ -21,6 +22,7 @@ class TestBotSettings:
             settings.graph_github_backend_raw_base_url
             == "https://github.com/graph-owner/graph-repo/raw/mybranch"
         )
+        assert settings.github_runner_debug is True
 
     def test_defaults(self, temporary_environment):
         os.environ.clear()
@@ -30,6 +32,7 @@ class TestBotSettings:
         assert settings.conda_forge_org == "conda-forge"
         assert settings.graph_github_backend_repo == "regro/cf-graph-countyfair"
         assert settings.graph_repo_default_branch == "master"
+        assert settings.github_runner_debug is False
 
     def test_env_conda_forge_org(self, temporary_environment):
         os.environ.clear()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -104,14 +104,17 @@ def test_use_settings(temporary_environment):
     os.environ.clear()
     bot_settings = settings()
     bot_settings.github_runner_debug = True
-    use_settings(bot_settings)
 
-    ret_settings = settings()
-    assert ret_settings.github_runner_debug is True
+    with use_settings(bot_settings):
+        ret_settings = settings()
+        assert ret_settings.github_runner_debug is True
 
-    # there should be no side effects
-    bot_settings.github_runner_debug = False
-    ret_settings.github_runner_debug = False
+        # there should be no side effects
+        bot_settings.github_runner_debug = False
+        ret_settings.github_runner_debug = False
 
-    side_effect_check_settings = settings()
-    assert side_effect_check_settings.github_runner_debug is True
+        side_effect_check_settings = settings()
+        assert side_effect_check_settings.github_runner_debug is True
+
+    # the settings should be restored
+    assert settings().github_runner_debug is False

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,37 @@
+import os
+
+import pytest
+from pydantic import ValidationError
+
+from conda_forge_tick.settings import BotSettings
+
+
+class TestBotSettings:
+    def test_parse(self, temporary_environment):
+        os.environ["CF_TICK_GRAPH_GITHUB_BACKEND_REPO"] = "graph-owner/graph-repo"
+        os.environ["CF_TICK_GRAPH_REPO_DEFAULT_BRANCH"] = "mybranch"
+
+        settings = BotSettings()
+
+        assert settings.graph_github_backend_repo == "graph-owner/graph-repo"
+        assert settings.graph_repo_default_branch == "mybranch"
+        assert (
+            settings.graph_github_backend_raw_base_url
+            == "https://github.com/graph-owner/graph-repo/raw/mybranch"
+        )
+
+    def test_defaults(self, temporary_environment):
+        os.environ.clear()
+
+        settings = BotSettings()
+
+        assert settings.graph_github_backend_repo == "regro/cf-graph-countyfair"
+        assert settings.graph_repo_default_branch == "master"
+
+    def test_reject_invalid_repo_pattern(self, temporary_environment):
+        os.environ.clear()
+
+        os.environ["CF_TICK_GRAPH_GITHUB_BACKEND_REPO"] = "no-owner-repo"
+
+        with pytest.raises(ValidationError, match="should match pattern"):
+            BotSettings()

--- a/tests/test_upstream_versions.py
+++ b/tests/test_upstream_versions.py
@@ -15,6 +15,7 @@ from flaky import flaky
 
 from conda_forge_tick.cli_context import CliContext
 from conda_forge_tick.lazy_json_backends import LazyJson
+from conda_forge_tick.settings import settings, use_settings
 from conda_forge_tick.update_sources import (
     NPM,
     NVIDIA,
@@ -1356,13 +1357,26 @@ def test_update_upstream_versions_run_parallel_custom_sources(
     ) == ("source a", "source b")
 
 
-@mock.patch(
-    "conda_forge_tick.update_upstream_versions.FRAC_UPDATE_UPSTREAM_VERSIONS", new=1.1
-)
+@pytest.fixture
+def version_update_frac_always():
+    new_settings = settings()
+
+    new_settings.frac_update_upstream_versions = True
+    use_settings(new_settings)
+
+    yield
+
+    # revert to default settings
+    use_settings(None)
+
+
 @mock.patch("conda_forge_tick.update_upstream_versions.get_latest_version")
 @mock.patch("conda_forge_tick.update_upstream_versions.LazyJson")
 def test_update_upstream_versions_sequential_error(
-    lazy_json_mock: MagicMock, get_latest_version_mock: MagicMock, caplog
+    lazy_json_mock: MagicMock,
+    get_latest_version_mock: MagicMock,
+    version_update_frac_always,
+    caplog,
 ):
     caplog.set_level(logging.DEBUG)
     source_a = Mock(AbstractSource)
@@ -1396,13 +1410,13 @@ class BrokenException(Exception):
         raise Exception("broken exception")
 
 
-@mock.patch(
-    "conda_forge_tick.update_upstream_versions.FRAC_UPDATE_UPSTREAM_VERSIONS", new=1.1
-)
 @mock.patch("conda_forge_tick.update_upstream_versions.get_latest_version")
 @mock.patch("conda_forge_tick.update_upstream_versions.LazyJson")
 def test_update_upstream_versions_sequential_exception_repr_exception(
-    lazy_json_mock: MagicMock, get_latest_version_mock: MagicMock, caplog
+    lazy_json_mock: MagicMock,
+    get_latest_version_mock: MagicMock,
+    version_update_frac_always,
+    caplog,
 ):
     caplog.set_level(logging.DEBUG)
     source_a = Mock(AbstractSource)
@@ -1433,13 +1447,13 @@ def test_update_upstream_versions_sequential_exception_repr_exception(
     )
 
 
-@mock.patch(
-    "conda_forge_tick.update_upstream_versions.FRAC_UPDATE_UPSTREAM_VERSIONS", new=1.1
-)
 @mock.patch("conda_forge_tick.update_upstream_versions.get_latest_version")
 @mock.patch("conda_forge_tick.update_upstream_versions.LazyJson")
 def test_update_upstream_versions_sequential(
-    lazy_json_mock: MagicMock, get_latest_version_mock: MagicMock, caplog
+    lazy_json_mock: MagicMock,
+    get_latest_version_mock: MagicMock,
+    version_update_frac_always,
+    caplog,
 ):
     caplog.set_level(logging.DEBUG)
     source_a = Mock(AbstractSource)
@@ -1486,13 +1500,13 @@ def test_update_upstream_versions_sequential(
     assert "# 1     - testpackage2 - 1.2.4 -> 1.2.5" in caplog.text
 
 
-@mock.patch(
-    "conda_forge_tick.update_upstream_versions.FRAC_UPDATE_UPSTREAM_VERSIONS", new=1.1
-)
 @mock.patch("conda_forge_tick.update_upstream_versions.executor")
 @mock.patch("conda_forge_tick.update_upstream_versions.LazyJson")
 def test_update_upstream_versions_process_pool(
-    lazy_json_mock: MagicMock, executor_mock: MagicMock, caplog
+    lazy_json_mock: MagicMock,
+    executor_mock: MagicMock,
+    version_update_frac_always,
+    caplog,
 ):
     caplog.set_level(logging.DEBUG)
     source_a = Mock(AbstractSource)
@@ -1549,13 +1563,13 @@ def test_update_upstream_versions_process_pool(
     assert "testpackage - 2.2.3 -> 2.2.4" in caplog.text
 
 
-@mock.patch(
-    "conda_forge_tick.update_upstream_versions.FRAC_UPDATE_UPSTREAM_VERSIONS", new=1.1
-)
 @mock.patch("conda_forge_tick.update_upstream_versions.executor")
 @mock.patch("conda_forge_tick.update_upstream_versions.LazyJson")
 def test_update_upstream_versions_process_pool_exception(
-    lazy_json_mock: MagicMock, executor_mock: MagicMock, caplog
+    lazy_json_mock: MagicMock,
+    executor_mock: MagicMock,
+    version_update_frac_always,
+    caplog,
 ):
     caplog.set_level(logging.DEBUG)
     source_a = Mock(AbstractSource)
@@ -1595,13 +1609,13 @@ def test_update_upstream_versions_process_pool_exception(
     assert "source a error" in caplog.text
 
 
-@mock.patch(
-    "conda_forge_tick.update_upstream_versions.FRAC_UPDATE_UPSTREAM_VERSIONS", new=1.1
-)
 @mock.patch("conda_forge_tick.update_upstream_versions.executor")
 @mock.patch("conda_forge_tick.update_upstream_versions.LazyJson")
 def test_update_upstream_versions_process_pool_exception_repr_exception(
-    lazy_json_mock: MagicMock, executor_mock: MagicMock, caplog
+    lazy_json_mock: MagicMock,
+    executor_mock: MagicMock,
+    version_update_frac_always,
+    caplog,
 ):
     caplog.set_level(logging.DEBUG)
     source_a = Mock(AbstractSource)

--- a/tests/test_upstream_versions.py
+++ b/tests/test_upstream_versions.py
@@ -1356,7 +1356,9 @@ def test_update_upstream_versions_run_parallel_custom_sources(
     ) == ("source a", "source b")
 
 
-@mock.patch("conda_forge_tick.update_upstream_versions.RANDOM_FRAC_TO_UPDATE", new=1.1)
+@mock.patch(
+    "conda_forge_tick.update_upstream_versions.FRAC_UPDATE_UPSTREAM_VERSIONS", new=1.1
+)
 @mock.patch("conda_forge_tick.update_upstream_versions.get_latest_version")
 @mock.patch("conda_forge_tick.update_upstream_versions.LazyJson")
 def test_update_upstream_versions_sequential_error(
@@ -1394,7 +1396,9 @@ class BrokenException(Exception):
         raise Exception("broken exception")
 
 
-@mock.patch("conda_forge_tick.update_upstream_versions.RANDOM_FRAC_TO_UPDATE", new=1.1)
+@mock.patch(
+    "conda_forge_tick.update_upstream_versions.FRAC_UPDATE_UPSTREAM_VERSIONS", new=1.1
+)
 @mock.patch("conda_forge_tick.update_upstream_versions.get_latest_version")
 @mock.patch("conda_forge_tick.update_upstream_versions.LazyJson")
 def test_update_upstream_versions_sequential_exception_repr_exception(
@@ -1429,7 +1433,9 @@ def test_update_upstream_versions_sequential_exception_repr_exception(
     )
 
 
-@mock.patch("conda_forge_tick.update_upstream_versions.RANDOM_FRAC_TO_UPDATE", new=1.1)
+@mock.patch(
+    "conda_forge_tick.update_upstream_versions.FRAC_UPDATE_UPSTREAM_VERSIONS", new=1.1
+)
 @mock.patch("conda_forge_tick.update_upstream_versions.get_latest_version")
 @mock.patch("conda_forge_tick.update_upstream_versions.LazyJson")
 def test_update_upstream_versions_sequential(
@@ -1480,7 +1486,9 @@ def test_update_upstream_versions_sequential(
     assert "# 1     - testpackage2 - 1.2.4 -> 1.2.5" in caplog.text
 
 
-@mock.patch("conda_forge_tick.update_upstream_versions.RANDOM_FRAC_TO_UPDATE", new=1.1)
+@mock.patch(
+    "conda_forge_tick.update_upstream_versions.FRAC_UPDATE_UPSTREAM_VERSIONS", new=1.1
+)
 @mock.patch("conda_forge_tick.update_upstream_versions.executor")
 @mock.patch("conda_forge_tick.update_upstream_versions.LazyJson")
 def test_update_upstream_versions_process_pool(
@@ -1541,7 +1549,9 @@ def test_update_upstream_versions_process_pool(
     assert "testpackage - 2.2.3 -> 2.2.4" in caplog.text
 
 
-@mock.patch("conda_forge_tick.update_upstream_versions.RANDOM_FRAC_TO_UPDATE", new=1.1)
+@mock.patch(
+    "conda_forge_tick.update_upstream_versions.FRAC_UPDATE_UPSTREAM_VERSIONS", new=1.1
+)
 @mock.patch("conda_forge_tick.update_upstream_versions.executor")
 @mock.patch("conda_forge_tick.update_upstream_versions.LazyJson")
 def test_update_upstream_versions_process_pool_exception(
@@ -1585,7 +1595,9 @@ def test_update_upstream_versions_process_pool_exception(
     assert "source a error" in caplog.text
 
 
-@mock.patch("conda_forge_tick.update_upstream_versions.RANDOM_FRAC_TO_UPDATE", new=1.1)
+@mock.patch(
+    "conda_forge_tick.update_upstream_versions.FRAC_UPDATE_UPSTREAM_VERSIONS", new=1.1
+)
 @mock.patch("conda_forge_tick.update_upstream_versions.executor")
 @mock.patch("conda_forge_tick.update_upstream_versions.LazyJson")
 def test_update_upstream_versions_process_pool_exception_repr_exception(

--- a/tests/test_upstream_versions.py
+++ b/tests/test_upstream_versions.py
@@ -1362,12 +1362,8 @@ def version_update_frac_always():
     new_settings = settings()
 
     new_settings.frac_update_upstream_versions = True
-    use_settings(new_settings)
-
-    yield
-
-    # revert to default settings
-    use_settings(None)
+    with use_settings(new_settings):
+        yield
 
 
 @mock.patch("conda_forge_tick.update_upstream_versions.get_latest_version")


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->
In #3417, I proposed to introduce a settings module to centralize the configuration of the bot. However, it had 2 flaws:
- It was not proposed in a separate PR.
- It loaded environment variables at import time, which complicates modifying them between CLI invocations.

This separate PR improves upon the old approach by using `pydantic-settings` to manage a global settings object. The values of the settings object are read from environment variables. As an advantage,

- environment variables can be modified, taking effect immediately on their next usage (because they aren't cached)
- the entire settings object can be overridden with another one, which allows type-safe settings modifications (e.g. for testing)

To keep the scope of this PR under control, not all configuration values are moved to the settings object; only the ones that are needed for the integration tests. I'd be happy though if this could become the new standard for adding new configuration values to stay flexible and have an overview of everything!

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
Cc @pavelzw