### PR TITLE
Do not combine non-adjacent conditions in v1 recipes

### DIFF
--- a/conda_forge_tick/migrators/recipe_v1.py
+++ b/conda_forge_tick/migrators/recipe_v1.py
@@ -6,62 +6,51 @@ from typing import Any
 from conda_forge_tick.migrators.core import MiniMigrator
 from conda_forge_tick.recipe_parser._parser import _get_yaml_parser
 
+from typing import Any
+
 if typing.TYPE_CHECKING:
     from ..migrators_types import AttrsTypedDict
 
 logger = logging.getLogger(__name__)
 
 
-def combine_conditions(node):
+def is_same_condition(a: Any, b: Any) -> bool:
+    return (
+        isinstance(a, dict)
+        and isinstance(b, dict)
+        and "if" in a
+        and "if" in b
+        and a["if"] == b["if"]
+    )
+
+
+def fold_branch(source: Any, dest: Any, branch: str) -> None:
+    if branch not in source:
+        return
+    source_l = source[branch]
+    if isinstance(source_l, str):
+        source_l = [source_l]
+
+    if branch not in dest:
+        dest[branch] = []
+    elif isinstance(dest[branch], str):
+        dest[branch] = [dest[branch]]
+    dest[branch].extend(source_l)
+
+
+def combine_conditions(node: Any):
     """Breadth first recursive call to combine list conditions"""
 
     # recursion is breadth first because we go through each element here
     # before calling `combine_conditions` on any element in the node
     if isinstance(node, list):
-        # 1. loop through list elements, gather the if conditions
-
-        # condition ("if:") -> [(then, else), (then, else)...]
-        conditions = {}
-
-        for i in node:
-            if isinstance(i, dict) and "if" in i:
-                conditions.setdefault(i["if"], []).append((i["then"], i.get("else")))
-
-        # 2. if elements share a compatible if condition
-        # combine their if...then...else statements
-        to_drop = []
-        for i in range(len(node)):
-            if isinstance(node[i], dict) and "if" in node[i]:
-                condition = node[i]["if"]
-                if condition not in conditions:
-                    # already combined it, so drop the repeat instance
-                    to_drop.append(i)
-                    continue
-                if len(conditions[condition]) > 1:
-                    new_then = []
-                    new_else = []
-                    for sub_then, sub_else in conditions[node[i]["if"]]:
-                        if isinstance(sub_then, list):
-                            new_then.extend(sub_then)
-                        else:
-                            assert sub_then is not None
-                            new_then.append(sub_then)
-                        if isinstance(sub_else, list):
-                            new_else.extend(sub_else)
-                        elif sub_else is not None:
-                            new_else.append(sub_else)
-                    node[i]["then"] = new_then
-                    if new_else:
-                        # TODO: preserve inline "else" instead of converting it to a list?
-                        node[i]["else"] = new_else
-                    else:
-                        assert "else" not in node[i]
-                    # remove it from the dict, so we don't output it again
-                    del conditions[condition]
-
-        # drop the repeated conditions
-        for i in reversed(to_drop):
-            del node[i]
+        # iterate in reverse order, so we can remove elements on the fly
+        # start at index 1, since we can only fold to the previous node
+        for i in reversed(range(1, len(node))):
+            if is_same_condition(node[i], node[i - 1]):
+                fold_branch(node[i], node[i - 1], "then")
+                fold_branch(node[i], node[i - 1], "else")
+                del node[i]
 
     # then we descend down the tree
     if isinstance(node, dict):

--- a/conda_forge_tick/migrators/recipe_v1.py
+++ b/conda_forge_tick/migrators/recipe_v1.py
@@ -6,8 +6,6 @@ from typing import Any
 from conda_forge_tick.migrators.core import MiniMigrator
 from conda_forge_tick.recipe_parser._parser import _get_yaml_parser
 
-from typing import Any
-
 if typing.TYPE_CHECKING:
     from ..migrators_types import AttrsTypedDict
 

--- a/tests/test_v1_yaml/version_pytorch.yaml
+++ b/tests/test_v1_yaml/version_pytorch.yaml
@@ -318,6 +318,8 @@ outputs:
             - torch
             - torch._C
       - files:
+          recipe:
+            - cmake_test/
           source:
             - test
             - tools
@@ -369,6 +371,15 @@ outputs:
             then: test ! -f $SP_DIR/functorch/__pycache__/__init__.cpython-313.pyc
           - if: match(python, "!=3.13") and win
             then: if exist %SP_DIR%\functorch\__pycache__\__init__.cpython-313.pyc exit 1
+          - cd cmake_test
+          - if: unix
+            then: cmake -GNinja -DCMAKE_CXX_STANDARD=17 -DWITH_TORCH_PYTHON=ON $CMAKE_ARGS .
+          - if: win
+            then: cmake -GNinja -DCMAKE_CXX_STANDARD=17 -DWITH_TORCH_PYTHON=ON %CMAKE_ARGS% .
+          - if: unix
+            then: cmake --build .
+          - if: win
+            then: cmake --build . --config Release
 
 about:
   license: BSD-3-Clause

--- a/tests/test_v1_yaml/version_pytorch_correct.yaml
+++ b/tests/test_v1_yaml/version_pytorch_correct.yaml
@@ -55,7 +55,6 @@ outputs:
           then:
             - intel-openmp ${{ mkl }}
             - libuv
-            - sccache
         - cmake
         - ninja
         # Keep libprotobuf here so that a compatibile version
@@ -64,6 +63,8 @@ outputs:
         - protobuf
         - if: linux
           then: make
+        - if: win
+          then: sccache
         - if: unix
           then:
             - grep
@@ -71,11 +72,18 @@ outputs:
       host:
         # GPU requirements
         - if: "cuda_compiler_version != \"None\""
+          then: cudnn
+        - if: "cuda_compiler_version != \"None\" and linux"
+          then: nccl
+        - if: "cuda_compiler_version != \"None\""
           then:
-            - cudnn
             - magma
             - cuda-version ${{ cuda_compiler_version }}
             - nvtx-c
+        - if: "linux and cuda_compiler_version != \"None\""
+          then: cuda-driver-dev
+        - if: "cuda_compiler_version != \"None\""
+          then:
             - cuda-cudart-dev
             - cuda-cupti-dev
             - cuda-nvrtc-dev
@@ -85,16 +93,14 @@ outputs:
             - cusparselt
             - libcublas-dev
             - libcudss-dev
+        - if: "linux and cuda_compiler_version != \"None\""
+          then: libcufile-dev
+        - if: "cuda_compiler_version != \"None\""
+          then:
             - libcufft-dev
             - libcurand-dev
             - libcusolver-dev
             - libcusparse-dev
-        - if: "cuda_compiler_version != \"None\" and linux"
-          then: nccl
-        - if: "linux and cuda_compiler_version != \"None\""
-          then:
-            - cuda-driver-dev
-            - libcufile-dev
         - if: megabuild
           else:
             - python
@@ -182,11 +188,18 @@ outputs:
         - ${{ pin_subpackage('libtorch', exact=True) }}
         # GPU requirements
         - if: "cuda_compiler_version != \"None\""
+          then: cudnn
+        - if: "cuda_compiler_version != \"None\" and linux"
+          then: nccl
+        - if: "cuda_compiler_version != \"None\""
           then:
-            - cudnn
             - cuda-version ${{ cuda_compiler_version }}
             - nvtx-c
             - magma
+        - if: "linux and cuda_compiler_version != \"None\""
+          then: cuda-driver-dev
+        - if: "cuda_compiler_version != \"None\""
+          then:
             - cuda-cudart-dev
             - cuda-cupti-dev
             - cuda-nvrtc-dev
@@ -196,16 +209,14 @@ outputs:
             - cusparselt
             - libcublas-dev
             - libcudss-dev
+        - if: "linux and cuda_compiler_version != \"None\""
+          then: libcufile-dev
+        - if: "cuda_compiler_version != \"None\""
+          then:
             - libcufft-dev
             - libcurand-dev
             - libcusolver-dev
             - libcusparse-dev
-        - if: "cuda_compiler_version != \"None\" and linux"
-          then: nccl
-        - if: "linux and cuda_compiler_version != \"None\""
-          then:
-            - cuda-driver-dev
-            - libcufile-dev
         - python
         - numpy
         - pip
@@ -252,12 +263,12 @@ outputs:
           then: nomkl
         # GPU requirements without run_exports
         - if: "cuda_compiler_version != \"None\""
-          then:
-            - ${{ pin_compatible('cudnn') }}
-            - __cuda
+          then: ${{ pin_compatible('cudnn') }}
         - if: "cuda_compiler_version != \"None\" and not win"
           then: triton =${{ triton }}
         # avoid that people without GPUs needlessly download ~0.5-1GB
+        - if: "cuda_compiler_version != \"None\""
+          then: __cuda
         - python
         # other requirements, see https://github.com/pytorch/pytorch/blame/main/requirements.txt
         - filelock
@@ -285,6 +296,8 @@ outputs:
             - torch
             - torch._C
       - files:
+          recipe:
+            - cmake_test/
           source:
             - test
             - tools
@@ -333,6 +346,15 @@ outputs:
             then: test ! -f $SP_DIR/functorch/__pycache__/__init__.cpython-313.pyc
           - if: match(python, "!=3.13") and win
             then: if exist %SP_DIR%\functorch\__pycache__\__init__.cpython-313.pyc exit 1
+          - cd cmake_test
+          - if: unix
+            then: cmake -GNinja -DCMAKE_CXX_STANDARD=17 -DWITH_TORCH_PYTHON=ON $CMAKE_ARGS .
+          - if: win
+            then: cmake -GNinja -DCMAKE_CXX_STANDARD=17 -DWITH_TORCH_PYTHON=ON %CMAKE_ARGS% .
+          - if: unix
+            then: cmake --build .
+          - if: win
+            then: cmake --build . --config Release
 
 about:
   license: BSD-3-Clause


### PR DESCRIPTION
#### Description:

Modify the v1 recipe condition combiner not to merge non-adjacent conditions.  While this is not really a problem for dependencies (though it could break original dependency grouping), it did lead to reordering test commands that could lead to breaking the recipe.

The algorithm aims to be as simple as possible.  It iterates over lists tail-to-head and folds an "if" into the preceding item if it has the same condition.

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

Fixes #3933