### PR TITLE
Support combining trivial negations in v1 recipes

### DIFF
--- a/conda_forge_tick/migrators/recipe_v1.py
+++ b/conda_forge_tick/migrators/recipe_v1.py
@@ -31,12 +31,20 @@ def is_negated_condition(a: str, b: str) -> bool:
     if not all(map(is_single_expression, (a, b))):
         return False
 
+    # X <-> not X
     a_not = a.startswith("not")
     b_not = b.startswith("not")
-    return (
+    if (
         a_not != b_not
         and a.removeprefix("not").lstrip() == b.removeprefix("not").lstrip()
-    )
+    ):
+        return True
+
+    # A == B <-> A != B
+    if a == b.replace("==", "!=") or a == b.replace("!=", "=="):
+        return True
+
+    return False
 
 
 def fold_branch(source: Any, dest: Any, branch: str, dest_branch: str) -> None:

--- a/conda_forge_tick/migrators/recipe_v1.py
+++ b/conda_forge_tick/migrators/recipe_v1.py
@@ -41,7 +41,9 @@ def is_negated_condition(a: str, b: str) -> bool:
         return True
 
     # A == B <-> A != B
-    if a == b.replace("==", "!=") or a == b.replace("!=", "=="):
+    if "==" in b and a == b.replace("==", "!=", 1):
+        return True
+    if "!=" in b and a == b.replace("!=", "==", 1):
         return True
 
     return False

--- a/tests/test_recipe_v1.py
+++ b/tests/test_recipe_v1.py
@@ -21,44 +21,56 @@ combine_conditions_migrator = Version(
 )
 
 
-@pytest.mark.parametrize("x", [
-    "win",
-    "not unix",
-    'cuda_compiler_version == "None"',
-    "build_platform != target_platform",
-])
+@pytest.mark.parametrize(
+    "x",
+    [
+        "win",
+        "not unix",
+        'cuda_compiler_version == "None"',
+        "build_platform != target_platform",
+    ],
+)
 def test_is_single_expression(x):
     assert is_single_expression(x)
 
 
-@pytest.mark.parametrize("x", [
-    'cuda_compiler_version != "None" and linux"',
-    'unix and blas_impl != "mkl"',
-    "linux or osx",
-    "foo if bar else baz",
-])
+@pytest.mark.parametrize(
+    "x",
+    [
+        'cuda_compiler_version != "None" and linux"',
+        'unix and blas_impl != "mkl"',
+        "linux or osx",
+        "foo if bar else baz",
+    ],
+)
 def test_not_is_single_expression(x):
     assert not is_single_expression(x)
 
 
-@pytest.mark.parametrize("a,b", [
-    ("unix", "not unix"),
-    ('cuda_compiler_version == "None"', 'not cuda_compiler_version == "None"'),
-    ('cuda_compiler_version == "None"', 'cuda_compiler_version != "None"'),
-    ('not cuda_compiler_version == "None"', 'not cuda_compiler_version != "None"'),
-])
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        ("unix", "not unix"),
+        ('cuda_compiler_version == "None"', 'not cuda_compiler_version == "None"'),
+        ('cuda_compiler_version == "None"', 'cuda_compiler_version != "None"'),
+        ('not cuda_compiler_version == "None"', 'not cuda_compiler_version != "None"'),
+    ],
+)
 def test_is_negated_condition(a, b):
     assert is_negated_condition(a, b)
     assert is_negated_condition(b, a)
 
 
-@pytest.mark.parametrize("a,b", [
-    ("not unix", "not unix"),
-    ('cuda_compiler_version == "None"', 'not cuda_compiler_version != "None"'),
-    ('cuda_compiler_version != "None"', 'not cuda_compiler_version == "None"'),
-    ("a or b", "not a or b"),
-    ("a and b", "not a and b"),
-])
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        ("not unix", "not unix"),
+        ('cuda_compiler_version == "None"', 'not cuda_compiler_version != "None"'),
+        ('cuda_compiler_version != "None"', 'not cuda_compiler_version == "None"'),
+        ("a or b", "not a or b"),
+        ("a and b", "not a and b"),
+    ],
+)
 def test_not_is_negated_condition(a, b):
     assert not is_negated_condition(a, b)
     assert not is_negated_condition(b, a)

--- a/tests/test_recipe_v1.py
+++ b/tests/test_recipe_v1.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
-from flaky import flaky
 import pytest
+from flaky import flaky
 from test_migrators import run_test_migration
 
 from conda_forge_tick.migrators import (
@@ -9,8 +9,8 @@ from conda_forge_tick.migrators import (
     Version,
 )
 from conda_forge_tick.migrators.recipe_v1 import (
-    is_single_expression,
     is_negated_condition,
+    is_single_expression,
 )
 
 YAML_PATH = Path(__file__).parent / "test_v1_yaml"

--- a/tests/test_v1_yaml/version_pytorch_correct.yaml
+++ b/tests/test_v1_yaml/version_pytorch_correct.yaml
@@ -149,8 +149,7 @@ outputs:
           else:
             - pytorch-gpu ==${{ version }}
             - pytorch-cpu ==99999999
-        - if: "cuda_compiler_version != \"None\""
-          then: pytorch =${{ version }} cuda${{ cuda_compiler_version | replace('.', '') }}_${{ blas_impl }}_*_${{ build }}
+            - pytorch =${{ version }} cuda${{ cuda_compiler_version | replace('.', '') }}_${{ blas_impl }}_*_${{ build }}
         - if: "unix and blas_impl != \"mkl\""
           then: openblas * openmp_*
 
@@ -225,9 +224,9 @@ outputs:
           then:
             - mkl-devel ${{ mkl }}
             - libcblas * *_mkl
-          else: libcblas
-        - if: "blas_impl != \"mkl\""
-          then: liblapack
+          else:
+            - libcblas
+            - liblapack
         - if: not win
           then: llvm-openmp
           else: intel-openmp ${{ mkl }}
@@ -252,9 +251,7 @@ outputs:
           else: intel-openmp ${{ mkl }}
         - if: "blas_impl == \"mkl\""
           then: libblas * *${{ blas_impl }}
-        - if: "blas_impl != \"mkl\""
-          then: nomkl
-        # GPU requirements without run_exports
+          else: nomkl
         - if: "cuda_compiler_version != \"None\""
           then: ${{ pin_compatible('cudnn') }}
         - if: "cuda_compiler_version != \"None\" and not win"

--- a/tests/test_v1_yaml/version_pytorch_correct.yaml
+++ b/tests/test_v1_yaml/version_pytorch_correct.yaml
@@ -39,8 +39,7 @@ outputs:
               then:
                 - python 3.12.*
                 - numpy  *
-            - if: not megabuild
-              then:
+              else:
                 - python
                 - numpy
             - cross-python_${{ target_platform }}
@@ -51,8 +50,7 @@ outputs:
           then: ${{ compiler('cuda') }}
         - if: not win
           then: llvm-openmp
-        - if: win
-          then:
+          else:
             - intel-openmp ${{ mkl }}
             - libuv
         - cmake
@@ -123,8 +121,7 @@ outputs:
             - liblapack
         - if: not win
           then: llvm-openmp
-        - if: win
-          then: intel-openmp ${{ mkl }}
+          else: intel-openmp ${{ mkl }}
         - libabseil
         - libprotobuf
         - sleef
@@ -228,14 +225,12 @@ outputs:
           then:
             - mkl-devel ${{ mkl }}
             - libcblas * *_mkl
-          else:
-            - libcblas
+          else: libcblas
         - if: "blas_impl != \"mkl\""
           then: liblapack
         - if: not win
           then: llvm-openmp
-        - if: win
-          then: intel-openmp ${{ mkl }}
+          else: intel-openmp ${{ mkl }}
         - libabseil
         - libprotobuf
         - pybind11
@@ -251,12 +246,10 @@ outputs:
           then: ${{ pin_subpackage('libtorch', exact=True) }}
         # for non-megabuild, allow libtorch from any python version;
         # pinning build number would be nice but breaks conda
-        - if: not megabuild
-          then: libtorch ${{ version }}.*
+          else: libtorch ${{ version }}.*
         - if: not win
           then: llvm-openmp
-        - if: win
-          then: intel-openmp ${{ mkl }}
+          else: intel-openmp ${{ mkl }}
         - if: "blas_impl == \"mkl\""
           then: libblas * *${{ blas_impl }}
         - if: "blas_impl != \"mkl\""


### PR DESCRIPTION
#### Description:

Extend the v1 recipe condition combiner to detect negations of trivial conditions (`x` vs. `not x`, provided that `x` does not use `and`, `or` or `if` operators).

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

