### PR TITLE
fix: ensure we parse as v1 when searching for new versions via raw urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ pixi.lock
 pixi.toml
 .ruff_cache/
 .repodata_cache/
+venv
+oryx-build-commands.txt

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -427,14 +427,14 @@ class BaseRawURL(AbstractSource):
     name = "BaseRawURL"
     next_ver_func = None
 
-    def get_url(self, meta_yaml) -> Optional[str]:
-        if "feedstock_name" not in meta_yaml:
+    def get_url(self, attrs) -> Optional[str]:
+        if "feedstock_name" not in attrs:
             return None
-        if "version" not in meta_yaml:
+        if "version" not in attrs:
             return None
 
         # TODO: pull this from the graph itself
-        content = meta_yaml["raw_meta_yaml"]
+        content = attrs["raw_meta_yaml"]
 
         if any(ln.startswith("{% set version") for ln in content.splitlines()):
             has_version_jinja2 = True
@@ -443,9 +443,9 @@ class BaseRawURL(AbstractSource):
 
         # this while statement runs until a bad version is found
         # then it uses the previous one
-        orig_urls = urls_from_meta(meta_yaml["meta_yaml"])
+        orig_urls = urls_from_meta(attrs["meta_yaml"])
         logger.debug("orig urls: %s", orig_urls)
-        current_ver = meta_yaml["version"]
+        current_ver = attrs["version"]
         current_sha256 = None
         orig_ver = current_ver
         found = True
@@ -469,7 +469,7 @@ class BaseRawURL(AbstractSource):
                     new_content = "\n".join(_new_lines)
                 else:
                     new_content = content.replace(orig_ver, next_ver)
-                if meta_yaml["meta_yaml"].get("schema_version", 0) == 0:
+                if attrs["meta_yaml"].get("schema_version", 0) == 0:
                     new_meta = parse_meta_yaml(new_content)
                 else:
                     new_meta = parse_recipe_yaml(new_content)
@@ -484,7 +484,7 @@ class BaseRawURL(AbstractSource):
                     # this URL looks bad if these things happen
                     if (
                         str(new_meta["package"]["version"]) != next_ver
-                        or meta_yaml["url"] == url
+                        or attrs.get("url", "") == url
                         or url in orig_urls
                     ):
                         logger.debug(
@@ -494,7 +494,7 @@ class BaseRawURL(AbstractSource):
                             'str(new_meta["package"]["version"]) != next_ver',
                             str(new_meta["package"]["version"]) != next_ver,
                             'meta_yaml["url"] == url',
-                            meta_yaml["url"] == url,
+                            attrs.get("url", "") == url,
                             "url in orig_urls",
                             url in orig_urls,
                         )

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -20,7 +20,7 @@ from conda.models.version import VersionOrder
 # TODO: parse_version has bad type annotations
 from pkg_resources import parse_version
 
-from conda_forge_tick.utils import parse_meta_yaml
+from conda_forge_tick.utils import parse_meta_yaml, parse_recipe_yaml
 
 from .hashing import hash_url
 
@@ -472,7 +472,7 @@ class BaseRawURL(AbstractSource):
                 if meta_yaml["meta_yaml"].get("schema_version", 0) == 0:
                     new_meta = parse_meta_yaml(new_content)
                 else:
-                    raise RuntimeError("blah!")
+                    new_meta = parse_recipe_yaml(new_content)
                 new_urls = urls_from_meta(new_meta)
                 if len(new_urls) == 0:
                     logger.debug("No URL in meta.yaml")

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -469,7 +469,10 @@ class BaseRawURL(AbstractSource):
                     new_content = "\n".join(_new_lines)
                 else:
                     new_content = content.replace(orig_ver, next_ver)
-                new_meta = parse_meta_yaml(new_content)
+                if meta_yaml["meta_yaml"].get("schema_version", 0) == 0:
+                    new_meta = parse_meta_yaml(new_content)
+                else:
+                    raise RuntimeError("blah!")
                 new_urls = urls_from_meta(new_meta)
                 if len(new_urls) == 0:
                     logger.debug("No URL in meta.yaml")


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR ensures we parse recipes properly as v0/v1 when getting new versions via raw urls.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

