### PR TITLE
fix: log_level argument for parse_recipe_yaml is not correct in container cli

### DIFF
--- a/conda_forge_tick/container_cli.py
+++ b/conda_forge_tick/container_cli.py
@@ -83,7 +83,7 @@ def _get_existing_feedstock_node_attrs(existing_feedstock_node_attrs):
     return attrs
 
 
-def _run_bot_task(func, *, log_level, existing_feedstock_node_attrs, **kwargs):
+def _run_bot_task(func, *, log_level: str, existing_feedstock_node_attrs, **kwargs):
     with (
         tempfile.TemporaryDirectory() as tmpdir_cbld,
         _setenv("CONDA_BLD_PATH", os.path.join(tmpdir_cbld, "conda-bld")),
@@ -434,7 +434,7 @@ def cli():
 )
 @click.option("--log-debug", is_flag=True, help="Log debug information.")
 def parse_meta_yaml(
-    log_level,
+    log_level: str,
     for_pinning,
     platform,
     arch,
@@ -472,12 +472,14 @@ def parse_meta_yaml(
     "--cbc-path", type=str, default=None, help="The path to global pinning file."
 )
 def parse_recipe_yaml(
+    log_level: str,
     for_pinning,
     platform_arch,
     cbc_path,
 ):
     return _run_bot_task(
         _parse_recipe_yaml,
+        log_level=log_level,
         existing_feedstock_node_attrs=None,
         for_pinning=for_pinning,
         platform_arch=platform_arch,

--- a/tests/test_make_migrators.py
+++ b/tests/test_make_migrators.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import networkx as nx
 import pytest
+from _pytest.fixtures import FixtureRequest
 
 from conda_forge_tick.lazy_json_backends import get_sharded_path
 from conda_forge_tick.make_migrators import create_migration_yaml_creator
@@ -19,6 +20,7 @@ CONDA_FORGE_PINNINGS_ATTRS_FILE = TEST_FILES_DIR / "conda-forge-pinning_node_att
 NUMPY_NODE_ATTRS_FILE = TEST_FILES_DIR / "numpy_node_attrs.json"
 
 
+@pytest.mark.parametrize("enable_containers", [True, False])
 class TestCreateMigrationYamlCreator:
     @pytest.fixture
     def inject_conda_build_config(self):
@@ -63,8 +65,15 @@ class TestCreateMigrationYamlCreator:
         "prepared_graph", [["conda-forge-pinning", "numpy"]], indirect=True
     )
     def test_successful_recipe_v0(
-        self, prepared_graph: nx.DiGraph, inject_conda_build_config
+        self,
+        prepared_graph: nx.DiGraph,
+        inject_conda_build_config,
+        enable_containers: bool,
+        request: FixtureRequest,
     ):
+        if enable_containers:
+            request.getfixturevalue("use_containers")
+
         # feedstock under test: numpy
         migrators: list[MigrationYamlCreator] = []
         create_migration_yaml_creator(migrators, prepared_graph)
@@ -85,8 +94,15 @@ class TestCreateMigrationYamlCreator:
         "prepared_graph", [["conda-forge-pinning", "aws-c-io"]], indirect=True
     )
     def test_successful_recipe_v1(
-        self, prepared_graph: nx.DiGraph, inject_conda_build_config
+        self,
+        prepared_graph: nx.DiGraph,
+        inject_conda_build_config,
+        enable_containers: bool,
+        request: FixtureRequest,
     ):
+        if enable_containers:
+            request.getfixturevalue("use_containers")
+
         # feedstock under test: aws-c-io
         migrators: list[MigrationYamlCreator] = []
         create_migration_yaml_creator(migrators, prepared_graph)

--- a/tests/test_make_migrators.py
+++ b/tests/test_make_migrators.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import networkx as nx
 import pytest
-from _pytest.fixtures import FixtureRequest
+from pytest import FixtureRequest
 
 from conda_forge_tick.lazy_json_backends import get_sharded_path
 from conda_forge_tick.make_migrators import create_migration_yaml_creator


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->
The newly added v1 support for `create_migration_yaml_creator` added in #3970 is currently broken because there is an unrelated bug in the `parse_recipe_yaml` container CLI. This PR fixes the issue.

Logs: https://github.com/regro/cf-scripts/actions/runs/14226411844/job/39866904255#step:7:1546

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
FYI @xhochy