### PR TITLE
feat: Increase timeout for checking url exists from 2 seconds to 5 seconds

### DIFF
--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -373,7 +373,7 @@ def get_sha256(url: str) -> Optional[str]:
         return None
 
 
-def url_exists(url: str, timeout=2) -> bool:
+def url_exists(url: str, timeout=5) -> bool:
     """
     We use curl/wget here, as opposed requests.head, because
      - github urls redirect with a 3XX code even if the file doesn't exist


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This increases the default timeout for `wget --spider` calls from 2 seconds to 5 seconds.

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

Resolves #3977.
