### PR TITLE
refactor: centralize migrator filtering to migrators again

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -738,20 +738,14 @@ def _run_migrator_on_feedstock_branch(
     sync_version_pr_info = False
     is_version = isinstance(migrator, Version)
     try:
-        try:
-            fctx.attrs["new_version"] = attrs.get("version_pr_info", {}).get(
-                "new_version", None
-            )
-            migrator_uid, pr_json = run_with_tmpdir(
-                context=fctx,
-                migrator=migrator,
-                git_backend=git_backend,
-                rerender=migrator.rerender,
-                base_branch=base_branch,
-                hash_type=attrs.get("hash_type", "sha256"),
-            )
-        finally:
-            fctx.attrs.pop("new_version", None)
+        migrator_uid, pr_json = run_with_tmpdir(
+            context=fctx,
+            migrator=migrator,
+            git_backend=git_backend,
+            rerender=migrator.rerender,
+            base_branch=base_branch,
+            hash_type=attrs.get("hash_type", "sha256"),
+        )
 
         # if migration successful
         if migrator_uid:

--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -47,7 +47,6 @@ from conda_forge_tick.migrators import (
     DuplicateLinesCleanup,
     ExtraJinja2KeysCleanup,
     FlangMigrator,
-    GraphMigrator,
     GuardTestingMigrator,
     Jinja2VarsCleanup,
     LibboostMigrator,
@@ -824,16 +823,6 @@ def initialize_migrators(
     migration_factory(pinning_migrators, gx)
     create_migration_yaml_creator(migrators=pinning_migrators, gx=gx)
 
-    with fold_log_lines("migration graph sizes"):
-        print("rebuild migration graph sizes:", flush=True)
-        for m in migrators + pinning_migrators:
-            if isinstance(m, GraphMigrator):
-                print(
-                    f"    {getattr(m, 'name', m)} graph size: "
-                    f"{len(getattr(m, 'graph', []))}",
-                    flush=True,
-                )
-
     with fold_log_lines("making version migrator"):
         print("building package import maps and version migrator", flush=True)
         python_nodes = {
@@ -862,6 +851,15 @@ def initialize_migrators(
 
         RNG.shuffle(pinning_migrators)
         migrators = [version_migrator] + migrators + pinning_migrators
+
+    with fold_log_lines("migration graph sizes"):
+        print("rebuild migration graph sizes:", flush=True)
+        for m in migrators:
+            print(
+                f"    {getattr(m, 'name', m)} graph size: "
+                f"{len(getattr(m, 'graph', []))}",
+                flush=True,
+            )
 
     return migrators
 

--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -1,5 +1,4 @@
 import contextlib
-import copy
 import glob
 import logging
 import os
@@ -85,7 +84,6 @@ from conda_forge_tick.utils import (
     parse_meta_yaml,
     parse_munged_run_export,
     parse_recipe_yaml,
-    pluck,
     yaml_safe_load,
 )
 
@@ -577,11 +575,6 @@ def _outside_pin_range(pin_spec, current_pin, new_version):
 def create_migration_yaml_creator(
     migrators: MutableSequence[Migrator], gx: nx.DiGraph, pin_to_debug=None
 ):
-    cfp_gx = copy.deepcopy(gx)
-    for node in list(cfp_gx.nodes):
-        if node != "conda-forge-pinning":
-            pluck(cfp_gx, node)
-
     with pushd(os.environ["CONDA_PREFIX"]):
         pinnings = parse_config_file(
             "conda_build_config.yaml",
@@ -714,7 +707,7 @@ def create_migration_yaml_creator(
                             current_pin=current_pin,
                             pin_spec=pin_spec,
                             feedstock_name=feedstock_name,
-                            total_graph=cfp_gx,
+                            total_graph=gx,
                             pinnings=pinnings_together,
                             pr_limit=1,
                         ),

--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -716,7 +716,6 @@ def create_migration_yaml_creator(
                             feedstock_name=feedstock_name,
                             total_graph=cfp_gx,
                             pinnings=pinnings_together,
-                            full_graph=gx,
                             pr_limit=1,
                         ),
                     )

--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -9,13 +9,11 @@ import networkx as nx
 from conda_forge_tick.contexts import ClonedFeedstockContext, FeedstockContext
 from conda_forge_tick.make_graph import (
     get_deps_from_outputs_lut,
-    make_outputs_lut_from_graph,
 )
-from conda_forge_tick.migrators.core import GraphMigrator, _sanitized_muids
+from conda_forge_tick.migrators.core import GraphMigrator, MiniMigrator, get_outputs_lut
 from conda_forge_tick.os_utils import pushd
 from conda_forge_tick.utils import (
     as_iterable,
-    frozen_to_json_friendly,
     pluck,
     yaml_safe_dump,
     yaml_safe_load,
@@ -25,8 +23,6 @@ from .migration_yaml import all_noarch
 
 if typing.TYPE_CHECKING:
     from conda_forge_tick.migrators_types import AttrsTypedDict, MigrationUidTypedDict
-
-from .core import MiniMigrator
 
 
 def _filter_excluded_deps(graph, excluded_dependencies):
@@ -106,15 +102,15 @@ class ArchRebuild(GraphMigrator):
 
     def __init__(
         self,
-        graph: nx.DiGraph = None,
-        name: Optional[str] = None,
+        graph: nx.DiGraph | None = None,
+        name: str = "aarch64 and ppc64le addition",
         pr_limit: int = 0,
         piggy_back_migrations: Optional[Sequence[MiniMigrator]] = None,
         target_packages: Optional[Sequence[str]] = None,
-        effective_graph: nx.DiGraph = None,
-        _do_init: bool = True,
+        effective_graph: nx.DiGraph | None = None,
+        total_graph: nx.DiGraph | None = None,
     ):
-        if _do_init:
+        if total_graph is not None:
             if target_packages is None:
                 # We are constraining the scope of this migrator
                 with open(
@@ -128,12 +124,11 @@ class ArchRebuild(GraphMigrator):
                 ) as f:
                     target_packages = set(f.read().split())
 
-            if "outputs_lut" not in graph.graph:
-                graph.graph["outputs_lut"] = make_outputs_lut_from_graph(graph)
+            outputs_lut = get_outputs_lut(total_graph, graph, effective_graph)
 
             # rebuild the graph to only use edges from the arm and power requirements
-            graph2 = nx.create_empty_copy(graph)
-            for node, attrs in graph.nodes(data="payload"):
+            graph2 = nx.create_empty_copy(total_graph)
+            for node, attrs in total_graph.nodes(data="payload"):
                 for plat_arch in self.arches:
                     deps = set().union(
                         *attrs.get(
@@ -141,20 +136,18 @@ class ArchRebuild(GraphMigrator):
                             attrs.get("requirements", {}),
                         ).values()
                     )
-                    for dep in get_deps_from_outputs_lut(
-                        deps, graph.graph["outputs_lut"]
-                    ):
+                    for dep in get_deps_from_outputs_lut(deps, outputs_lut):
                         graph2.add_edge(dep, node)
                 pass
 
-            graph = graph2
+            total_graph = graph2
             target_packages = set(target_packages)
             if target_packages:
                 target_packages.add("python")  # hack that is ~harmless?
-                _cut_to_target_packages(graph, target_packages)
+                _cut_to_target_packages(total_graph, target_packages)
 
             # filter out stub packages and ignored packages
-            _filter_stubby_and_ignored_nodes(graph, self.ignored_packages)
+            _filter_stubby_and_ignored_nodes(total_graph, self.ignored_packages)
 
         if not hasattr(self, "_init_args"):
             self._init_args = []
@@ -167,8 +160,10 @@ class ArchRebuild(GraphMigrator):
                 "piggy_back_migrations": piggy_back_migrations,
                 "target_packages": target_packages,
                 "effective_graph": effective_graph,
-                "_do_init": False,
+                "total_graph": total_graph,
             }
+
+        self.target_packages = target_packages
 
         super().__init__(
             graph=graph,
@@ -176,29 +171,10 @@ class ArchRebuild(GraphMigrator):
             check_solvable=False,
             piggy_back_migrations=piggy_back_migrations,
             effective_graph=effective_graph,
+            total_graph=total_graph,
+            name=name,
         )
-
         assert not self.check_solvable, "We don't want to check solvability for aarch!"
-        self.target_packages = target_packages
-        self.name = name
-
-        if _do_init:
-            self._reset_effective_graph()
-
-    def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
-        if super().filter(attrs):
-            return True
-        muid = frozen_to_json_friendly(self.migrator_uid(attrs))
-        for arch in self.arches:
-            configured_arch = (
-                attrs.get("conda-forge.yml", {}).get("provider", {}).get(arch)
-            )
-            if configured_arch:
-                return muid in _sanitized_muids(
-                    attrs.get("pr_info", {}).get("PRed", []),
-                )
-        else:
-            return False
 
     def migrate(
         self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any
@@ -269,15 +245,15 @@ class OSXArm(GraphMigrator):
 
     def __init__(
         self,
-        graph: nx.DiGraph = None,
-        name: Optional[str] = None,
+        graph: nx.DiGraph | None = None,
+        name: str = "arm osx addition",
         pr_limit: int = 0,
         piggy_back_migrations: Optional[Sequence[MiniMigrator]] = None,
         target_packages: Optional[Sequence[str]] = None,
-        effective_graph: nx.DiGraph = None,
-        _do_init: bool = True,
+        effective_graph: nx.DiGraph | None = None,
+        total_graph: nx.DiGraph | None = None,
     ):
-        if _do_init:
+        if total_graph is not None:
             if target_packages is None:
                 # We are constraining the scope of this migrator
                 with open(
@@ -291,12 +267,11 @@ class OSXArm(GraphMigrator):
                 ) as f:
                     target_packages = set(f.read().split())
 
-            if "outputs_lut" not in graph.graph:
-                graph.graph["outputs_lut"] = make_outputs_lut_from_graph(graph)
+            outputs_lut = get_outputs_lut(total_graph, graph, effective_graph)
 
             # rebuild the graph to only use edges from the arm osx requirements
-            graph2 = nx.create_empty_copy(graph)
-            for node, attrs in graph.nodes(data="payload"):
+            graph2 = nx.create_empty_copy(total_graph)
+            for node, attrs in total_graph.nodes(data="payload"):
                 for plat_arch in self.arches:
                     reqs = attrs.get(
                         f"{plat_arch}_requirements",
@@ -314,26 +289,27 @@ class OSXArm(GraphMigrator):
                         if build_dep.endswith("_stub"):
                             deps.add(build_dep)
                     for dep in get_deps_from_outputs_lut(
-                        deps, graph.graph["outputs_lut"]
+                        deps,
+                        outputs_lut,
                     ):
                         graph2.add_edge(dep, node)
 
-            graph = graph2
+            total_graph = graph2
 
             # Excluded dependencies need to be removed before non target_packages are
             # filtered out so that if a target_package is excluded, its dependencies
             # are not added to the graph
-            _filter_excluded_deps(graph, self.excluded_dependencies)
+            _filter_excluded_deps(total_graph, self.excluded_dependencies)
 
             target_packages = set(target_packages)
 
             # filter the graph down to the target packages
             if target_packages:
                 target_packages.add("python")  # hack that is ~harmless?
-                _cut_to_target_packages(graph, target_packages)
+                _cut_to_target_packages(total_graph, target_packages)
 
             # filter out stub packages and ignored packages
-            _filter_stubby_and_ignored_nodes(graph, self.ignored_packages)
+            _filter_stubby_and_ignored_nodes(total_graph, self.ignored_packages)
 
         if not hasattr(self, "_init_args"):
             self._init_args = []
@@ -346,8 +322,10 @@ class OSXArm(GraphMigrator):
                 "piggy_back_migrations": piggy_back_migrations,
                 "target_packages": target_packages,
                 "effective_graph": effective_graph,
-                "_do_init": False,
+                "total_graph": total_graph,
             }
+
+        self.target_packages = target_packages
 
         super().__init__(
             graph=graph,
@@ -355,31 +333,12 @@ class OSXArm(GraphMigrator):
             check_solvable=False,
             piggy_back_migrations=piggy_back_migrations,
             effective_graph=effective_graph,
+            total_graph=total_graph,
+            name=name,
         )
-
         assert not self.check_solvable, (
             "We don't want to check solvability for arm osx!"
         )
-        self.target_packages = target_packages
-        self.name = name
-
-        if _do_init:
-            self._reset_effective_graph()
-
-    def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
-        if super().filter(attrs):
-            return True
-        muid = frozen_to_json_friendly(self.migrator_uid(attrs))
-        for arch in self.arches:
-            configured_arch = (
-                attrs.get("conda-forge.yml", {}).get("provider", {}).get(arch)
-            )
-            if configured_arch:
-                return muid in _sanitized_muids(
-                    attrs.get("pr_info", {}).get("PRed", []),
-                )
-        else:
-            return False
 
     def migrate(
         self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any

--- a/conda_forge_tick/migrators/broken_rebuild.py
+++ b/conda_forge_tick/migrators/broken_rebuild.py
@@ -4,7 +4,7 @@ import secrets
 import networkx as nx
 
 from conda_forge_tick.contexts import ClonedFeedstockContext
-from conda_forge_tick.migrators.core import Migrator
+from conda_forge_tick.migrators.core import Migrator, get_outputs_lut
 
 RNG = secrets.SystemRandom()
 
@@ -326,34 +326,38 @@ class RebuildBroken(Migrator):
     def __init__(
         self,
         *,
-        outputs_lut,
         pr_limit: int = 0,
-        graph: nx.DiGraph = None,
-        effective_graph: nx.DiGraph = None,
+        total_graph: nx.DiGraph | None = None,
+        graph: nx.DiGraph | None = None,
+        effective_graph: nx.DiGraph | None = None,
     ):
         if not hasattr(self, "_init_args"):
             self._init_args = []
 
         if not hasattr(self, "_init_kwargs"):
             self._init_kwargs = {
-                "outputs_lut": outputs_lut,
                 "pr_limit": pr_limit,
                 "graph": graph,
                 "effective_graph": effective_graph,
+                "total_graph": total_graph,
             }
 
-        super().__init__(
-            1, check_solvable=False, graph=graph, effective_graph=effective_graph
-        )
         self.name = "rebuild-broken"
 
         outputs_to_migrate = {split_pkg(pkg)[1] for pkg in BROKEN_PACKAGES}
         self.feedstocks_to_migrate = set()
+        outputs_lut = get_outputs_lut(total_graph, graph, effective_graph)
         for output in outputs_to_migrate:
             for fs in outputs_lut.get(output, {output}):
                 self.feedstocks_to_migrate |= {fs}
 
-        self._reset_effective_graph()
+        super().__init__(
+            pr_limit=pr_limit,
+            check_solvable=False,
+            graph=graph,
+            effective_graph=effective_graph,
+            total_graph=total_graph,
+        )
 
     def order(
         self,
@@ -362,11 +366,12 @@ class RebuildBroken(Migrator):
     ):
         return sorted(list(graph.nodes), key=lambda x: RNG.random())
 
-    def filter(self, attrs) -> bool:
-        return (
-            super().filter(attrs)
-            or attrs["feedstock_name"] not in self.feedstocks_to_migrate
-        )
+    def filter_not_in_migration(self, attrs, not_bad_str_start=""):
+        if super().filter_not_in_migration(attrs, not_bad_str_start):
+            return True
+
+        not_broken = attrs["feedstock_name"] not in self.feedstocks_to_migrate
+        return not_broken
 
     def migrate(self, recipe_dir, attrs, **kwargs):
         self.set_build_number(os.path.join(recipe_dir, "meta.yaml"))

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -91,22 +91,22 @@ def _make_migrator_graph(graph, migrator, effective=False):
         with _lazy_json_or_dict(graph.nodes[node]["payload"]) as attrs:
             had_orig_branch = "branch" in attrs
             orig_branch = attrs.get("branch")
-            # try:
-            base_branches = migrator.get_possible_feedstock_branches(attrs)
-            filters = []
-            for base_branch in base_branches:
-                attrs["branch"] = base_branch
-                if effective:
-                    filters.append(migrator.filter_node_migrated(attrs))
+            try:
+                base_branches = migrator.get_possible_feedstock_branches(attrs)
+                filters = []
+                for base_branch in base_branches:
+                    attrs["branch"] = base_branch
+                    if effective:
+                        filters.append(migrator.filter_node_migrated(attrs))
+                    else:
+                        filters.append(migrator.filter_not_in_migration(attrs))
+                if filters and all(filters):
+                    nodes_to_pluck.add(node)
+            finally:
+                if had_orig_branch:
+                    attrs["branch"] = orig_branch
                 else:
-                    filters.append(migrator.filter_not_in_migration(attrs))
-            if filters and all(filters):
-                nodes_to_pluck.add(node)
-            # finally:
-            if had_orig_branch:
-                attrs["branch"] = orig_branch
-            else:
-                del attrs["branch"]
+                    del attrs["branch"]
 
     # the plucking
     for node in nodes_to_pluck:

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -12,13 +12,13 @@ import networkx as nx
 
 from conda_forge_tick.contexts import ClonedFeedstockContext, FeedstockContext
 from conda_forge_tick.lazy_json_backends import LazyJson
-from conda_forge_tick.make_graph import make_outputs_lut_from_graph
 from conda_forge_tick.update_recipe import update_build_number, v1_recipe
 from conda_forge_tick.utils import (
     frozen_to_json_friendly,
     get_bot_run_url,
     get_keys_default,
     get_recipe_schema_version,
+    pluck,
 )
 
 if typing.TYPE_CHECKING:
@@ -49,12 +49,34 @@ def skip_migrator_due_to_schema(
         return False
 
 
-def _make_effective_graph(graph, migrator):
+def get_outputs_lut(
+    total_graph: nx.DiGraph | None,
+    graph: nx.DiGraph | None,
+    effective_graph: nx.DiGraph | None,
+) -> dict[str, str]:
+    outputs_lut = None
+    for gx in [total_graph, graph, effective_graph]:
+        if gx is not None and "outputs_lut" in gx.graph:
+            return gx.graph["outputs_lut"]
+    if outputs_lut is None:
+        raise ValueError(
+            "Either `total_graph` or both `graph` and `effective_graph` "
+            "must be provided and must contain `outputs_lut` in their "
+            "`.graph` attribute."
+        )
+
+
+def _make_migrator_graph(graph, migrator, effective=False):
     """Prune graph only to nodes that need rebuilds."""
     gx2 = copy.deepcopy(graph)
 
     # Prune graph to only things that need builds right now
     for node in list(gx2.nodes):
+        if "payload" not in gx2.nodes[node]:
+            logger.critical("node %s: no payload, removing", node)
+            pluck(gx2, node)
+            continue
+
         if isinstance(graph.nodes[node]["payload"], LazyJson):
             with graph.nodes[node]["payload"] as _attrs:
                 attrs = copy.deepcopy(_attrs.data)
@@ -64,11 +86,15 @@ def _make_effective_graph(graph, migrator):
         filters = []
         for base_branch in base_branches:
             attrs["branch"] = base_branch
-            filters.append(migrator.filter(attrs))
-
+            if effective:
+                filters.append(migrator.filter(attrs))
+            else:
+                filters.append(migrator.filter_not_in_migration(attrs))
         if filters and all(filters):
-            gx2.remove_node(node)
+            pluck(gx2, node)
 
+    # post plucking cleanup
+    gx2.remove_edges_from(nx.selfloop_edges(gx2))
     return gx2
 
 
@@ -107,7 +133,7 @@ def _gen_active_feedstocks_payloads(nodes, gx):
             yield node, payload
 
 
-def _migratror_hash(klass, args, kwargs):
+def _migrator_hash(klass, args, kwargs):
     import hashlib
 
     from conda_forge_tick.lazy_json_backends import dumps
@@ -130,7 +156,7 @@ def _make_migrator_lazy_json_name(mgr, data):
             ""
             if len(mgr._init_args) == 0 and len(mgr._init_kwargs) == 0
             else "_h"
-            + _migratror_hash(
+            + _migrator_hash(
                 data["class"],
                 data["args"],
                 data["kwargs"],
@@ -217,27 +243,12 @@ class MiniMigrator:
 class Migrator:
     """Base class for Migrators
 
-    Inheritors
-    ----------
-    Subclasses of Migrator should have at least the following in their __init__ function:
-
-    ```python
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._reset_effective_graph()
-    ```
-
     Initialization of Instances
     ---------------------------
     When a migrator is initialized, you need to supply at least the following items
 
     - pr_limit: The number of PRs the migrator can open in a given run of the bot.
-    - graph: The graph of feedstocks to be migrated.
-
-    The graph you feed the migrator should be the entire graph of feedstocks the
-    migrator could ever run on. If a migrator skips a feedstock because that migrator
-    does not apply to that feedstock, then it should not be in the graph passed to the
-    migrator. If you do not do this, the status page statistics will be incorrect.
+    - total_graph: The entire graph of conda-forge feedstocks.
     """
 
     name: str
@@ -267,13 +278,15 @@ class Migrator:
 
     def __init__(
         self,
+        total_graph: nx.DiGraph | None = None,
+        graph: nx.DiGraph | None = None,
+        effective_graph: nx.DiGraph | None = None,
+        *,
         pr_limit: int = 0,
         # TODO: Validate this?
         obj_version: int | None = None,
         piggy_back_migrations: Sequence[MiniMigrator] | None = None,
         check_solvable: bool = True,
-        graph: nx.DiGraph | None = None,
-        effective_graph: nx.DiGraph | None = None,
     ):
         if not hasattr(self, "_init_args"):
             self._init_args = []
@@ -284,21 +297,42 @@ class Migrator:
                 "obj_version": obj_version,
                 "piggy_back_migrations": piggy_back_migrations,
                 "check_solvable": check_solvable,
-                "graph": graph,
-                "effective_graph": effective_graph,
             }
 
         self.piggy_back_migrations = piggy_back_migrations or []
         self._pr_limit = pr_limit
         self.obj_version = obj_version
         self.check_solvable = check_solvable
-
-        if graph is None:
-            self.graph = nx.DiGraph()
-        else:
-            self.graph = graph
-
+        self.graph = graph
         self.effective_graph = effective_graph
+        self.total_graph = total_graph
+
+        if total_graph is not None:
+            if graph is not None or effective_graph is not None:
+                raise ValueError(
+                    "Cannot pass both `total_graph` and `graph` or "
+                    "`effective_graph` to the Migrator."
+                )
+
+            graph = _make_migrator_graph(total_graph, self, effective=False)
+            self.graph = graph
+            self._init_kwargs["graph"] = graph
+
+            effective_graph = _make_migrator_graph(self.graph, self, effective=True)
+            self.effective_graph = effective_graph
+            self._init_kwargs["effective_graph"] = effective_graph
+
+            # do not need this any more
+            self._init_kwargs["total_graph"] = None
+        else:
+            if graph is None or effective_graph is None:
+                raise ValueError(
+                    "Must pass graph and effective_graph "
+                    "to the Migrator if total_graph is not passed."
+                )
+            self._init_kwargs["graph"] = graph
+            self._init_kwargs["effective_graph"] = effective_graph
+            self._init_kwargs["total_graph"] = total_graph
 
     def to_lazy_json_data(self):
         """Serialize the migrator to LazyJson-compatible data."""
@@ -322,13 +356,6 @@ class Migrator:
         }
         data["name"] = _make_migrator_lazy_json_name(self, data)
         return data
-
-    def _reset_effective_graph(self, force=False):
-        """This method is meant to be called by an non-abstract child class at the end
-        of its __init__ method."""
-        if self.effective_graph is None or force:
-            self.effective_graph = _make_effective_graph(self.graph, self)
-            self._init_kwargs["effective_graph"] = self.effective_graph
 
     @property
     def pr_limit(self):
@@ -354,7 +381,7 @@ class Migrator:
         ][:limit]
 
     def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
-        """If true don't act upon node
+        """ "If True don't act upon a node.
 
         Parameters
         ----------
@@ -370,44 +397,18 @@ class Migrator:
         bool :
             True if node is to be skipped
         """
+        return self.filter_not_in_migration(
+            attrs, not_bad_str_start
+        ) or self.filter_node_migrated(attrs, not_bad_str_start)
+
+    def filter_not_in_migration(
+        self, attrs: "AttrsTypedDict", not_bad_str_start: str = ""
+    ) -> bool:
+        """If true don't act upon node because it is not in the migration."""
         # never run on archived feedstocks
-        # don't run on things we've already done
         # don't run on bad nodes
 
         __name = attrs.get("name", "")
-
-        def parse_already_pred() -> bool:
-            pr_data = frozen_to_json_friendly(self.migrator_uid(attrs))
-            migrator_uid: "MigrationUidTypedDict" = typing.cast(
-                "MigrationUidTypedDict",
-                pr_data["data"],
-            )
-            already_migrated_uids: typing.Iterable["MigrationUidTypedDict"] = list(
-                z["data"] for z in attrs.get("pr_info", {}).get("PRed", [])
-            )
-            already_pred = migrator_uid in already_migrated_uids
-            if already_pred:
-                ind = already_migrated_uids.index(migrator_uid)
-                logger.debug(f"{__name}: already PRed: uid: {migrator_uid}")
-                if "PR" in attrs.get("pr_info", {}).get("PRed", [])[ind]:
-                    if isinstance(
-                        attrs.get("pr_info", {}).get("PRed", [])[ind]["PR"],
-                        LazyJson,
-                    ):
-                        with attrs.get("pr_info", {}).get("PRed", [])[ind][
-                            "PR"
-                        ] as mg_attrs:
-                            logger.debug(
-                                "{}: already PRed: PR file: {}".format(
-                                    __name, mg_attrs.file_name
-                                ),
-                            )
-
-                            html_url = mg_attrs.get("html_url", "no url")
-
-                            logger.debug(f"{__name}: already PRed: url: {html_url}")
-
-            return already_pred
 
         if attrs.get("archived", False):
             logger.debug("%s: archived" % __name)
@@ -418,10 +419,49 @@ class Migrator:
 
         return (
             attrs.get("archived", False)
-            or parse_already_pred()
             or bad_attr
             or skip_migrator_due_to_schema(attrs, self.allowed_schema_versions)
         )
+
+    def filter_node_migrated(
+        self, attrs: "AttrsTypedDict", not_bad_str_start: str = ""
+    ) -> bool:
+        """If true don't act upon node because it is already migrated."""
+        # don't run on things we've already done
+
+        __name = attrs.get("name", "")
+
+        pr_data = frozen_to_json_friendly(self.migrator_uid(attrs))
+        migrator_uid: "MigrationUidTypedDict" = typing.cast(
+            "MigrationUidTypedDict",
+            pr_data["data"],
+        )
+        already_migrated_uids: typing.Iterable["MigrationUidTypedDict"] = list(
+            z["data"] for z in attrs.get("pr_info", {}).get("PRed", [])
+        )
+        already_pred = migrator_uid in already_migrated_uids
+        if already_pred:
+            ind = already_migrated_uids.index(migrator_uid)
+            logger.debug(f"{__name}: already PRed: uid: {migrator_uid}")
+            if "PR" in attrs.get("pr_info", {}).get("PRed", [])[ind]:
+                if isinstance(
+                    attrs.get("pr_info", {}).get("PRed", [])[ind]["PR"],
+                    LazyJson,
+                ):
+                    with attrs.get("pr_info", {}).get("PRed", [])[ind][
+                        "PR"
+                    ] as mg_attrs:
+                        logger.debug(
+                            "{}: already PRed: PR file: {}".format(
+                                __name, mg_attrs.file_name
+                            ),
+                        )
+
+                        html_url = mg_attrs.get("html_url", "no url")
+
+                        logger.debug(f"{__name}: already PRed: url: {html_url}")
+
+        return already_pred
 
     def get_possible_feedstock_branches(self, attrs: "AttrsTypedDict") -> List[str]:
         """Return the valid possible branches to which to apply this migration to
@@ -691,6 +731,7 @@ class GraphMigrator(Migrator):
     def __init__(
         self,
         *,
+        total_graph: nx.DiGraph | None = None,
         name: str | None = None,
         graph: nx.DiGraph | None = None,
         pr_limit: int = 0,
@@ -717,27 +758,23 @@ class GraphMigrator(Migrator):
                 "check_solvable": check_solvable,
                 "ignored_deps_per_node": ignored_deps_per_node,
                 "effective_graph": effective_graph,
+                "total_graph": total_graph,
             }
-
-        super().__init__(
-            pr_limit,
-            obj_version,
-            piggy_back_migrations,
-            check_solvable=check_solvable,
-            graph=graph,
-            effective_graph=effective_graph,
-        )
-
-        # IDK if this will be there so I am going to make it if needed
-        if "outputs_lut" in self.graph.graph:
-            self.outputs_lut = self.graph.graph["outputs_lut"]
-        else:
-            self.outputs_lut = make_outputs_lut_from_graph(self.graph)
 
         self.name = name
         self.top_level = top_level or set()
         self.cycles = set(cycles or [])
         self.ignored_deps_per_node = ignored_deps_per_node or {}
+
+        super().__init__(
+            pr_limit=pr_limit,
+            obj_version=obj_version,
+            piggy_back_migrations=piggy_back_migrations,
+            check_solvable=check_solvable,
+            graph=graph,
+            effective_graph=effective_graph,
+            total_graph=total_graph,
+        )
 
     def all_predecessors_issued(self, attrs: "AttrsTypedDict") -> bool:
         # Check if all upstreams have been issue and are stale
@@ -802,39 +839,45 @@ class GraphMigrator(Migrator):
 
         return False
 
-    def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
+    def filter_not_in_migration(self, attrs, not_bad_str_start=""):
+        if super().filter_not_in_migration(attrs, not_bad_str_start):
+            return True
+
+        name = attrs.get("name", "")
+        _gx = self.total_graph or self.graph
+        not_in_migration = attrs.get("feedstock_name", None) not in _gx
+
+        if not_in_migration:
+            logger.debug("filter %s: node not in graph", name)
+
+        return not_in_migration
+
+    def filter_node_migrated(self, attrs, not_bad_str_start=""):
         name = attrs.get("name", "")
 
-        if super().filter(attrs, "Upstream:"):
-            logger.debug(
-                "filter %s: archived or done or bad attr or schema_version not allowed",
-                name,
-            )
-            return True
-
-        if attrs.get("feedstock_name", None) not in self.graph:
-            logger.debug("filter %s: node not in graph", name)
-            return True
-
         # If in top level or in a cycle don't check for upstreams just build
-        if (attrs["feedstock_name"] in self.top_level) or (
+        is_top_level = (attrs["feedstock_name"] in self.top_level) or (
             attrs["feedstock_name"] in self.cycles
-        ):
-            return False
+        )
+        if is_top_level:
+            logger.debug("not filtered %s: top level", name)
+            node_is_ready = True
+        else:
+            if name == "conda-forge-pinning":
+                if self.all_predecessors_issued(attrs=attrs):
+                    node_is_ready = True
+                else:
+                    logger.debug("filtered %s: pinning parents not issued", name)
+                    node_is_ready = False
+            else:
+                # Check if all upstreams have been built
+                if self.predecessors_not_yet_built(attrs=attrs):
+                    logger.debug("filter %s: parents not built", name)
+                    node_is_ready = False
+                else:
+                    node_is_ready = True
 
-        # once all PRs are issued (not merged), propose the change in pin
-        if name == "conda-forge-pinning" and self.all_predecessors_issued(
-            attrs=attrs,
-        ):
-            logger.debug("not filtered %s: pinning parents issued", name)
-            return False
-
-        # Check if all upstreams have been built
-        if self.predecessors_not_yet_built(attrs=attrs):
-            logger.debug("filter %s: parents not built", name)
-            return True
-
-        return False
+        return (not node_is_ready) or super().filter_node_migrated(attrs, "Upstream:")
 
     def migrator_uid(self, attrs: "AttrsTypedDict") -> "MigrationUidTypedDict":
         n = super().migrator_uid(attrs)

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -270,12 +270,14 @@ class MigrationYaml(GraphMigrator):
         if total_graph is not None:
             # needed so that we can filter nodes not in migration
             self.graph = None
-            self.total_graph = total_graph
             total_graph = copy.deepcopy(total_graph)
+            self.total_graph = total_graph
             _trim_edges_for_abi_rebuild(total_graph, self, outputs_lut)
             total_graph.add_edges_from(
                 [(n, "conda-forge-pinning") for n in total_graph.nodes]
             )
+            delattr(self, "total_graph")
+            delattr(self, "graph")
 
         super().__init__(
             graph=graph,

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -675,11 +675,13 @@ class MigrationYamlCreator(Migrator):
         )
 
     def filter_not_in_migration(self, attrs, not_bad_str_start=""):
-        if super().filter_not_in_migration(attrs, not_bad_str_start):
+        if (
+            attrs.get("name", "") == "conda-forge-pinning"
+            or attrs.get("feedstock_name", "") == "conda-forge-pinning"
+        ):
+            return super().filter_not_in_migration(attrs, not_bad_str_start)
+        else:
             return True
-
-        is_pinning = attrs.get("name", "") == "conda-forge-pinning"
-        return not is_pinning
 
     def migrate(
         self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -6,20 +6,24 @@ import secrets
 import time
 import typing
 from collections import defaultdict
-from typing import Any, List, MutableSet, Optional, Sequence, Set
+from typing import Any, List, Optional, Sequence, Set
 
 import networkx as nx
 
 from conda_forge_tick.contexts import ClonedFeedstockContext, FeedstockContext
 from conda_forge_tick.feedstock_parser import PIN_SEP_PAT
 from conda_forge_tick.make_graph import get_deps_from_outputs_lut
-from conda_forge_tick.migrators.core import GraphMigrator, Migrator, MiniMigrator
+from conda_forge_tick.migrators.core import (
+    GraphMigrator,
+    Migrator,
+    MiniMigrator,
+    get_outputs_lut,
+)
 from conda_forge_tick.os_utils import pushd
 from conda_forge_tick.utils import (
     get_bot_run_url,
     get_keys_default,
     get_migrator_name,
-    pluck,
     yaml_safe_dump,
     yaml_safe_load,
 )
@@ -116,6 +120,46 @@ def merge_migrator_cbc(migrator_yaml: str, conda_build_config_yaml: str):
     return "\n".join(outbound_cbc)
 
 
+def _trim_edges_for_abi_rebuild(
+    total_graph: nx.DiGraph, migrator: Migrator, outputs_lut: dict[str, str]
+) -> nx.DiGraph:
+    migrator_payload = migrator.loaded_yaml.get("__migrator", {})
+    include_build = migrator_payload.get("include_build", False)
+
+    for node, node_attrs in total_graph.nodes.items():
+        # do not trim any edges for pinnings repo
+        if node == "conda-forge-pinning":
+            continue
+
+        with node_attrs["payload"] as attrs:
+            in_migration = not migrator.filter_not_in_migration(attrs)
+
+            requirements = attrs.get("requirements", {})
+            host = requirements.get("host", set())
+            build = requirements.get("build", set())
+            if include_build:
+                bh = host | build
+            else:
+                bh = host or build
+
+            # get host/build, run and test and launder them through outputs
+            # this should fix outputs related issues (eg gdal)
+            all_reqs = requirements.get("run", set())
+            if in_migration:
+                all_reqs = all_reqs | requirements.get("test", set())
+                all_reqs = all_reqs | bh
+            rq = get_deps_from_outputs_lut(
+                all_reqs,
+                outputs_lut,
+            )
+
+            for e in list(total_graph.in_edges(node)):
+                if e[0] not in rq:
+                    total_graph.remove_edge(*e)
+
+    return total_graph
+
+
 class MigrationYaml(GraphMigrator):
     """Migrator for bumping the build number."""
 
@@ -129,7 +173,9 @@ class MigrationYaml(GraphMigrator):
         self,
         yaml_contents: str,
         name: str,
-        graph: nx.DiGraph = None,
+        package_names: set[str] | None = None,
+        total_graph: nx.DiGraph | None = None,
+        graph: nx.DiGraph | None = None,
         pr_limit: int = 0,
         top_level: Set["PackageName"] = None,
         cycles: Optional[Sequence["PackageName"]] = None,
@@ -141,7 +187,7 @@ class MigrationYaml(GraphMigrator):
         conda_forge_yml_patches=None,
         ignored_deps_per_node=None,
         max_solver_attempts=3,
-        effective_graph: nx.DiGraph = None,
+        effective_graph: nx.DiGraph | None = None,
         force_pr_after_solver_attempts=10,
         longterm=False,
         paused=False,
@@ -152,6 +198,7 @@ class MigrationYaml(GraphMigrator):
 
         if not hasattr(self, "_init_kwargs"):
             self._init_kwargs = {
+                "total_graph": total_graph,
                 "graph": graph,
                 "pr_limit": pr_limit,
                 "top_level": top_level,
@@ -168,21 +215,12 @@ class MigrationYaml(GraphMigrator):
                 "longterm": longterm,
                 "force_pr_after_solver_attempts": force_pr_after_solver_attempts,
                 "paused": paused,
+                "package_names": package_names,
             }
             self._init_kwargs.update(copy.deepcopy(kwargs))
 
-        super().__init__(
-            graph=graph,
-            pr_limit=pr_limit,
-            obj_version=migration_number,
-            piggy_back_migrations=piggy_back_migrations,
-            check_solvable=check_solvable,
-            ignored_deps_per_node=ignored_deps_per_node,
-            effective_graph=effective_graph,
-        )
         self.yaml_contents = yaml_contents
         assert isinstance(name, str)
-        self.name = name
         self.top_level = top_level or set()
         self.cycles = set(cycles or [])
         self.automerge = automerge
@@ -193,20 +231,136 @@ class MigrationYaml(GraphMigrator):
         self.longterm = longterm
         self.force_pr_after_solver_attempts = force_pr_after_solver_attempts
         self.paused = paused
+        self.package_names = package_names or set()
 
-        self._reset_effective_graph()
+        # special init steps to be done on total_graph
+        # - compute package names to find in host to indicate needs migration
+        # - trim edges to only those for host|run|test deps - must be done before plucking
+        # - add pinning as child of all nodes in graph
+        if total_graph is not None:
+            # compute package names for migrating
+            migrator_payload = self.loaded_yaml.get("__migrator", {})
+            all_package_names = set(
+                sum(
+                    (
+                        list(node.get("payload", {}).get("outputs_names", set()))
+                        for node in total_graph.nodes.values()
+                    ),
+                    [],
+                ),
+            )
+            if "override_cbc_keys" in migrator_payload:
+                package_names = set(migrator_payload.get("override_cbc_keys"))
+            else:
+                package_names = (
+                    set(self.loaded_yaml)
+                    | {ly.replace("_", "-") for ly in self.loaded_yaml}
+                ) & all_package_names
+            self.package_names = package_names
+            self._init_kwargs["package_names"] = package_names
 
-    def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
-        """
-        Determine whether migrator needs to be filtered out.
+        # compute excluded pinned feedstocks no matter what
+        outputs_lut = get_outputs_lut(total_graph, graph, effective_graph)
 
-        Return value of True means to skip migrator, False means to go ahead.
-        Calls up the MRO until Migrator.filter, see docstring there (./core.py).
-        """
+        self.excluded_pinned_feedstocks = set()
+        for _node in self.package_names:
+            self.excluded_pinned_feedstocks.update(outputs_lut.get(_node, {_node}))
+
+        # finish special init steps
+        if total_graph is not None:
+            # needed so that we can filter nodes not in migration
+            self.graph = None
+            self.total_graph = total_graph
+            total_graph = copy.deepcopy(total_graph)
+            _trim_edges_for_abi_rebuild(total_graph, self, outputs_lut)
+            total_graph.add_edges_from(
+                [(n, "conda-forge-pinning") for n in total_graph.nodes]
+            )
+
+        super().__init__(
+            graph=graph,
+            pr_limit=pr_limit,
+            obj_version=migration_number,
+            piggy_back_migrations=piggy_back_migrations,
+            check_solvable=check_solvable,
+            ignored_deps_per_node=ignored_deps_per_node,
+            effective_graph=effective_graph,
+            total_graph=total_graph,
+            name=name,
+        )
+
+        if total_graph is not None:
+            # recompute top-level nodes and cycles after cutting to graph of all rebuilds
+            # these computations have to go after the call to super which turns the
+            # total graph into the graph of all possible rebuilds (stored in self.graph)
+            migrator_payload = self.loaded_yaml.get("__migrator", {})
+            excluded_feedstocks = set(migrator_payload.get("exclude", []))
+            feedstock_names = {
+                p for p in self.excluded_pinned_feedstocks if p in total_graph.nodes
+            } - excluded_feedstocks
+
+            top_level = {
+                node
+                for node in {
+                    total_graph.successors(feedstock_name)
+                    for feedstock_name in feedstock_names
+                }
+                if (node in self.graph)
+                and len(list(self.graph.predecessors(node))) == 0
+            }
+
+            cycles = set()
+            for cyc in nx.simple_cycles(self.graph):
+                cycles |= set(cyc)
+
+            self.top_level = self.top_level | top_level
+            self._init_kwargs["top_level"] = top_level
+            self.cycles = self.cycles | cycles
+            self._init_kwargs["cycles"] = cycles
+
+    def filter_not_in_migration(self, attrs, not_bad_str_start=""):
+        if super().filter_not_in_migration(attrs, not_bad_str_start):
+            return True
+
+        node = attrs["feedstock_name"]
+
+        if node == "conda-forge-pinning":
+            # conda-forge-pinning is always included in migration
+            return False
+
         migrator_payload = self.loaded_yaml.get("__migrator", {})
-        platform_allowlist = migrator_payload.get("platform_allowlist", [])
-        wait_for_migrators = migrator_payload.get("wait_for_migrators", [])
+        include_noarch = migrator_payload.get("include_noarch", False)
+        include_build = migrator_payload.get("include_build", False)
+        excluded_feedstocks = set(migrator_payload.get("exclude", []))
+        exclude_pinned_pkgs = migrator_payload.get("exclude_pinned_pkgs", True)
 
+        # Generally, the packages themselves should be excluded from the migration;
+        # an example for exceptions are migrations for new python versions
+        # where numpy needs to be rebuilt despite being pinned.
+        if exclude_pinned_pkgs:
+            excluded_feedstocks.update(self.excluded_pinned_feedstocks)
+
+        requirements = attrs.get("requirements", {})
+        host = requirements.get("host", set())
+        build = requirements.get("build", set())
+        if include_build:
+            bh = host | build
+        else:
+            bh = host or build
+        only_python = "python" in self.package_names
+        inclusion_criteria = bh & set(self.package_names) and (
+            include_noarch or not all_noarch(attrs, only_python=only_python)
+        )
+
+        if not inclusion_criteria:
+            logger.debug(
+                "filter %s: pin %s not in host/build %s",
+                node,
+                self.package_names,
+                bh,
+            )
+
+        platform_allowlist = migrator_payload.get("platform_allowlist", [])
         platform_filtered = False
         if platform_allowlist:
             # migrator.platform_allowlist allows both styles: "osx-64" & "osx_64";
@@ -217,6 +371,30 @@ class MigrationYaml(GraphMigrator):
             # attrs.platforms and platform_allowlist is empty
             intersection = set(attrs.get("platforms", {})) & set(platform_allowlist)
             platform_filtered = not bool(intersection)
+
+            if platform_filtered:
+                logger.debug(
+                    "filter %s: platform(s) %s not in %s",
+                    node,
+                    attrs.get("platforms", {}),
+                    platform_allowlist,
+                )
+
+        if node in excluded_feedstocks:
+            logger.debug(
+                "filter %s: excluded feedstock",
+                node,
+            )
+
+        return (
+            platform_filtered
+            or (not inclusion_criteria)
+            or (node in excluded_feedstocks)
+        )
+
+    def filter_node_migrated(self, attrs, not_bad_str_start=""):
+        migrator_payload = self.loaded_yaml.get("__migrator", {})
+        wait_for_migrators = migrator_payload.get("wait_for_migrators", [])
 
         need_to_wait = False
         if wait_for_migrators:
@@ -231,20 +409,14 @@ class MigrationYaml(GraphMigrator):
                     need_to_wait = True
             if set(wait_for_migrators) - found_migrators:
                 need_to_wait = True
+
         logger.debug(
             "filter %s: need to wait for %s",
             attrs.get("name", ""),
             wait_for_migrators,
         )
 
-        return (
-            platform_filtered
-            or need_to_wait
-            or super().filter(
-                attrs=attrs,
-                not_bad_str_start=not_bad_str_start,
-            )
-        )
+        return need_to_wait or super().filter_node_migrated(attrs, not_bad_str_start)
 
     def migrate(
         self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any
@@ -392,6 +564,38 @@ class MigrationYaml(GraphMigrator):
         return n
 
 
+def _compute_pin_impact(
+    total_graph: nx.DiGraph, package_names: tuple[str], outputs_lut: dict[str, str]
+) -> int:
+    # Generally, the packages themselves should be excluded from the migration;
+    # an example for exceptions are migrations for new python versions
+    # where numpy needs to be rebuilt despite being pinned.
+    excluded_feedstocks = set()
+    for node in package_names:
+        excluded_feedstocks.update(outputs_lut.get(node, {node}))
+
+    included_nodes = 0
+
+    for node, node_attrs in total_graph.nodes.items():
+        # always keep pinning
+        if node == "conda-forge-pinning":
+            included_nodes += 1
+        else:
+            with node_attrs["payload"] as attrs:
+                requirements = attrs.get("requirements", {})
+                host = requirements.get("host", set())
+                build = requirements.get("build", set())
+                bh = host or build
+                only_python = "python" in package_names
+                inclusion_criteria = bh & set(package_names) and (
+                    not all_noarch(attrs, only_python=only_python)
+                )
+                if inclusion_criteria and node not in excluded_feedstocks:
+                    included_nodes += 1
+
+    return included_nodes
+
+
 class MigrationYamlCreator(Migrator):
     """Migrator creating migration yaml files."""
 
@@ -402,14 +606,15 @@ class MigrationYamlCreator(Migrator):
     # TODO: make yaml_contents an arg?
     def __init__(
         self,
+        *,
         package_name: str,
         new_pin_version: str,
         current_pin: str,
         pin_spec: str,
         feedstock_name: str,
-        graph: nx.DiGraph,
+        total_graph: nx.DiGraph | None = None,
+        graph: nx.DiGraph | None = None,
         pin_impact: Optional[int] = None,
-        full_graph: Optional[nx.DiGraph] = None,
         pr_limit: int = 0,
         bump_number: int = 1,
         effective_graph: nx.DiGraph = None,
@@ -420,36 +625,34 @@ class MigrationYamlCreator(Migrator):
             pinnings = [package_name]
 
         if pin_impact is None:
-            if full_graph is not None:
-                pin_impact = len(create_rebuild_graph(full_graph, tuple(pinnings)))
-                full_graph = None
+            if total_graph is not None:
+                outputs_lut = get_outputs_lut(total_graph, graph, effective_graph)
+                pin_impact = _compute_pin_impact(
+                    total_graph, tuple(pinnings), outputs_lut
+                )
             else:
                 pin_impact = -1
 
         if not hasattr(self, "_init_args"):
-            self._init_args = [
-                package_name,
-                new_pin_version,
-                current_pin,
-                pin_spec,
-                feedstock_name,
-                graph,
-            ]
+            self._init_args = []
 
         if not hasattr(self, "_init_kwargs"):
             self._init_kwargs = {
+                "package_name": package_name,
+                "new_pin_version": new_pin_version,
+                "current_pin": current_pin,
+                "pin_spec": pin_spec,
+                "feedstock_name": feedstock_name,
+                "graph": graph,
                 "pr_limit": pr_limit,
                 "bump_number": bump_number,
                 "pin_impact": pin_impact,
-                "full_graph": full_graph,
                 "effective_graph": effective_graph,
                 "pinnings": pinnings,
+                "total_graph": total_graph,
             }
             self._init_kwargs.update(copy.deepcopy(kwargs))
 
-        super().__init__(
-            pr_limit=pr_limit, graph=graph, effective_graph=effective_graph
-        )
         self.feedstock_name = feedstock_name
         self.pin_spec = pin_spec
         self.current_pin = current_pin
@@ -459,18 +662,22 @@ class MigrationYamlCreator(Migrator):
         self.package_name = package_name
         self.bump_number = bump_number
         self.name = package_name + " pinning"
-        self.pin_impact = pin_impact
+        self.pin_impact = pin_impact or -1
         self.pinnings = pinnings
 
-        self._reset_effective_graph()
+        super().__init__(
+            pr_limit=pr_limit,
+            graph=graph,
+            effective_graph=effective_graph,
+            total_graph=total_graph,
+        )
 
-    def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
-        if (
-            not super().filter(attrs, not_bad_str_start)
-            and attrs.get("name", "") == "conda-forge-pinning"
-        ):
-            return False
-        return True
+    def filter_not_in_migration(self, attrs, not_bad_str_start=""):
+        if super().filter_not_in_migration(attrs, not_bad_str_start):
+            return True
+
+        is_pinning = attrs.get("name", "") == "conda-forge-pinning"
+        return not is_pinning
 
     def migrate(
         self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any
@@ -613,71 +820,3 @@ def all_noarch(attrs, only_python=False):
             all_noarch = all_noarch and _all_noarch
 
     return all_noarch
-
-
-def create_rebuild_graph(
-    gx: nx.DiGraph,
-    package_names: Sequence[str],
-    excluded_feedstocks: MutableSet[str] = None,
-    exclude_pinned_pkgs: bool = True,
-    include_noarch: bool = False,
-    include_build: bool = False,
-) -> nx.DiGraph:
-    total_graph = copy.deepcopy(gx)
-    excluded_feedstocks = set() if excluded_feedstocks is None else excluded_feedstocks
-    # Generally, the packages themselves should be excluded from the migration;
-    # an example for exceptions are migrations for new python versions
-    # where numpy needs to be rebuilt despite being pinned.
-    if exclude_pinned_pkgs:
-        for node in package_names:
-            excluded_feedstocks.update(gx.graph["outputs_lut"].get(node, {node}))
-
-    included_nodes = set()
-
-    for node, node_attrs in gx.nodes.items():
-        # always keep pinning
-        if node == "conda-forge-pinning":
-            continue
-        attrs: "AttrsTypedDict" = node_attrs["payload"]
-        requirements = attrs.get("requirements", {})
-        host = requirements.get("host", set())
-        build = requirements.get("build", set())
-        if include_build:
-            bh = host | build
-        else:
-            bh = host or build
-        only_python = "python" in package_names
-        inclusion_criteria = bh & set(package_names) and (
-            include_noarch or not all_noarch(attrs, only_python=only_python)
-        )
-        # get host/build, run and test and launder them through outputs
-        # this should fix outputs related issues (eg gdal)
-        all_reqs = requirements.get("run", set())
-        if inclusion_criteria:
-            all_reqs = all_reqs | requirements.get("test", set())
-            all_reqs = all_reqs | bh
-        rq = get_deps_from_outputs_lut(
-            all_reqs,
-            gx.graph["outputs_lut"],
-        )
-
-        for e in list(total_graph.in_edges(node)):
-            if e[0] not in rq:
-                total_graph.remove_edge(*e)
-        if inclusion_criteria:
-            included_nodes.add(node)
-
-    # all nodes have the conda-forge-pinning as child package
-    total_graph.add_edges_from([(n, "conda-forge-pinning") for n in total_graph.nodes])
-    included_nodes.add("conda-forge-pinning")  # it does not get added above
-
-    # finally remove all nodes that should not be built from the graph
-    for node in list(total_graph.nodes):
-        # if there isn't a strict dependency or if the feedstock is excluded,
-        # remove it while retaining the edges to its parents and children
-        if (node not in included_nodes) or (node in excluded_feedstocks):
-            pluck(total_graph, node)
-
-    # post plucking we can have several strange cases, lets remove all selfloops
-    total_graph.remove_edges_from(nx.selfloop_edges(total_graph))
-    return total_graph

--- a/conda_forge_tick/migrators/noarch_python_min.py
+++ b/conda_forge_tick/migrators/noarch_python_min.py
@@ -1,3 +1,4 @@
+import copy
 import functools
 import logging
 import os
@@ -14,7 +15,6 @@ from conda_forge_tick.contexts import ClonedFeedstockContext
 from conda_forge_tick.migrators.core import (
     Migrator,
     MiniMigrator,
-    skip_migrator_due_to_schema,
 )
 from conda_forge_tick.migrators.libboost import _slice_into_output_sections
 from conda_forge_tick.os_utils import pushd
@@ -421,8 +421,9 @@ class NoarchPythonMinMigrator(Migrator):
         self,
         *,
         pr_limit: int = 0,
-        graph: nx.DiGraph = None,
-        effective_graph: nx.DiGraph = None,
+        graph: nx.DiGraph | None = None,
+        effective_graph: nx.DiGraph | None = None,
+        total_graph: nx.DiGraph | None = None,
         piggy_back_migrations: Sequence[MiniMigrator] | None = None,
     ):
         if not hasattr(self, "_init_args"):
@@ -434,30 +435,34 @@ class NoarchPythonMinMigrator(Migrator):
                 "graph": graph,
                 "effective_graph": effective_graph,
                 "piggy_back_migrations": piggy_back_migrations,
+                "total_graph": total_graph,
             }
 
+        self.name = "noarch_python_min"
+
+        if total_graph is not None:
+            total_graph = copy.deepcopy(total_graph)
+            total_graph.clear_edges()
+
         super().__init__(
-            pr_limit,
+            pr_limit=pr_limit,
             graph=graph,
             effective_graph=effective_graph,
             piggy_back_migrations=piggy_back_migrations,
+            total_graph=total_graph,
         )
-        self.name = "noarch_python_min"
 
-        self._reset_effective_graph()
+    def filter_not_in_migration(self, attrs, not_bad_str_start=""):
+        if super().filter_not_in_migration(attrs, not_bad_str_start):
+            return True
 
-    def filter(self, attrs) -> bool:
         has_noarch_python = False
         for line in attrs.get("raw_meta_yaml", "").splitlines():
             if line.lstrip().startswith("noarch: python"):
                 has_noarch_python = True
                 break
 
-        return (
-            super().filter(attrs)
-            or (not has_noarch_python)
-            or skip_migrator_due_to_schema(attrs, self.allowed_schema_versions)
-        )
+        return not has_noarch_python
 
     def migrate(self, recipe_dir, attrs, **kwargs):
         # if the feedstock has already been updated, return a migration ID

--- a/conda_forge_tick/migrators/nvtools.py
+++ b/conda_forge_tick/migrators/nvtools.py
@@ -81,27 +81,10 @@ class AddNVIDIATools(Migrator):
 
     allowed_schema_versions = [0]
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._reset_effective_graph()
+    def filter_not_in_migration(self, attrs, not_bad_str_start=""):
+        if super().filter_not_in_migration(attrs, not_bad_str_start):
+            return True
 
-    def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
-        """If true don't act upon node
-
-        Parameters
-        ----------
-        attrs : dict
-            The node attributes
-        not_bad_str_start : str, optional
-            If the 'bad' notice starts with the string then it is not
-            to be excluded. For example, rebuild migrations don't need
-            to worry about if the upstream can be fetched. Defaults to ``''``
-
-        Returns
-        -------
-        bool :
-            True if node is to be skipped
-        """
         has_nvidia = False
         if "meta_yaml" in attrs and "source" in attrs["meta_yaml"]:
             if isinstance(attrs["meta_yaml"]["source"], list):
@@ -114,7 +97,7 @@ class AddNVIDIATools(Migrator):
                     "https://developer.download.nvidia.com" in src_url
                 )
 
-        return super().filter(attrs) or attrs["archived"] or (not has_nvidia)
+        return not has_nvidia
 
     def migrate(
         self, recipe_dir: str, attrs: AttrsTypedDict, **kwargs: Any

--- a/conda_forge_tick/migrators/replacement.py
+++ b/conda_forge_tick/migrators/replacement.py
@@ -47,10 +47,11 @@ class Replacement(Migrator):
         old_pkg: "PackageName",
         new_pkg: "PackageName",
         rationale: str,
-        graph: nx.DiGraph = None,
+        graph: nx.DiGraph | None = None,
         pr_limit: int = 0,
         check_solvable=True,
-        effective_graph: nx.DiGraph = None,
+        effective_graph: nx.DiGraph | None = None,
+        total_graph: nx.DiGraph | None = None,
     ):
         if not hasattr(self, "_init_args"):
             self._init_args = []
@@ -64,14 +65,9 @@ class Replacement(Migrator):
                 "pr_limit": pr_limit,
                 "check_solvable": check_solvable,
                 "effective_graph": effective_graph,
+                "total_graph": total_graph,
             }
 
-        super().__init__(
-            pr_limit,
-            check_solvable=check_solvable,
-            graph=graph,
-            effective_graph=effective_graph,
-        )
         self.old_pkg = old_pkg
         self.new_pkg = new_pkg
         self.pattern = re.compile(r"\s*-\s*(%s)(\s+|$)" % old_pkg)
@@ -79,9 +75,18 @@ class Replacement(Migrator):
         self.rationale = rationale
         self.name = f"{old_pkg}-to-{new_pkg}"
 
-        self._reset_effective_graph()
+        super().__init__(
+            pr_limit=pr_limit,
+            check_solvable=check_solvable,
+            graph=graph,
+            effective_graph=effective_graph,
+            total_graph=total_graph,
+        )
 
-    def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
+    def filter_not_in_migration(self, attrs, not_bad_str_start=""):
+        if super().filter_not_in_migration(attrs, not_bad_str_start):
+            return True
+
         requirements = attrs.get("requirements", {})
         rq = (
             requirements.get("build", set())
@@ -89,7 +94,8 @@ class Replacement(Migrator):
             | requirements.get("run", set())
             | requirements.get("test", set())
         )
-        return super().filter(attrs) or len(rq & self.packages) == 0
+
+        return len(rq & self.packages) == 0
 
     def migrate(
         self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any

--- a/conda_forge_tick/migrators/staticlib.py
+++ b/conda_forge_tick/migrators/staticlib.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import os
 import re
@@ -403,16 +404,17 @@ class StaticLibMigrator(GraphMigrator):
 
     def __init__(
         self,
-        graph: nx.DiGraph = None,
+        graph: nx.DiGraph | None = None,
         pr_limit: int = 0,
         bump_number: int = 1,
         piggy_back_migrations: Optional[Sequence[MiniMigrator]] = None,
         check_solvable=True,
         max_solver_attempts=3,
-        effective_graph: nx.DiGraph = None,
+        effective_graph: nx.DiGraph | None = None,
         force_pr_after_solver_attempts=10,
         longterm=False,
         paused=False,
+        total_graph: nx.DiGraph | None = None,
     ):
         if not hasattr(self, "_init_args"):
             self._init_args = []
@@ -429,7 +431,20 @@ class StaticLibMigrator(GraphMigrator):
                 "longterm": longterm,
                 "force_pr_after_solver_attempts": force_pr_after_solver_attempts,
                 "paused": paused,
+                "total_graph": total_graph,
             }
+
+        self.top_level = set()
+        self.cycles = set()
+        self.bump_number = bump_number
+        self.max_solver_attempts = max_solver_attempts
+        self.longterm = longterm
+        self.force_pr_after_solver_attempts = force_pr_after_solver_attempts
+        self.paused = paused
+
+        if total_graph is not None:
+            total_graph = copy.deepcopy(total_graph)
+            total_graph.clear_edges()
 
         super().__init__(
             graph=graph,
@@ -439,16 +454,8 @@ class StaticLibMigrator(GraphMigrator):
             check_solvable=check_solvable,
             effective_graph=effective_graph,
             name="static_lib_migrator",
+            total_graph=total_graph,
         )
-        self.top_level = set()
-        self.cycles = set()
-        self.bump_number = bump_number
-        self.max_solver_attempts = max_solver_attempts
-        self.longterm = longterm
-        self.force_pr_after_solver_attempts = force_pr_after_solver_attempts
-        self.paused = paused
-
-        self._reset_effective_graph()
 
     def predecessors_not_yet_built(self, attrs: "AttrsTypedDict") -> bool:
         # Check if all upstreams have been built
@@ -476,12 +483,10 @@ class StaticLibMigrator(GraphMigrator):
 
         return False
 
-    def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
-        """Determine whether feedstock needs to be filtered out.
+    def filter_not_in_migration(self, attrs, not_bad_str_start=""):
+        if super().filter_not_in_migration(attrs, not_bad_str_start):
+            return True
 
-        Return True to skip ("filter") the feedstock from the migration.
-        Return False to include the feedstock in the migration.
-        """
         update_static_libs = get_keys_default(
             attrs,
             ["conda-forge.yml", "bot", "update_static_libs"],
@@ -494,31 +499,24 @@ class StaticLibMigrator(GraphMigrator):
                 "filter %s: static lib updates not enabled",
                 attrs.get("name") or "",
             )
-            return True
 
-        platform_arches = tuple(attrs.get("platforms") or [])
-        static_libs_out_of_date, slrep = any_static_libs_out_of_date(
-            platform_arches=platform_arches,
-            raw_meta_yaml=attrs.get("raw_meta_yaml") or "",
-        )
-        if not static_libs_out_of_date:
-            logger.debug(
-                "filter %s: no static libs out of date\nmapping: %s",
-                attrs.get("name") or "",
-                static_libs_out_of_date,
-                slrep,
+        if update_static_libs:
+            platform_arches = tuple(attrs.get("platforms") or [])
+            static_libs_out_of_date, slrep = any_static_libs_out_of_date(
+                platform_arches=platform_arches,
+                raw_meta_yaml=attrs.get("raw_meta_yaml") or "",
             )
+            if not static_libs_out_of_date:
+                logger.debug(
+                    "filter %s: no static libs out of date\nmapping: %s",
+                    attrs.get("name") or "",
+                    slrep,
+                )
+            _read_repodata.cache_clear()
+        else:
+            static_libs_out_of_date = False
 
-        retval = (
-            (not update_static_libs)
-            or (not static_libs_out_of_date)
-            or super().filter(
-                attrs=attrs,
-                not_bad_str_start=not_bad_str_start,
-            )
-        )
-        _read_repodata.cache_clear()
-        return retval
+        return (not update_static_libs) or (not static_libs_out_of_date)
 
     def migrate(
         self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any

--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -100,11 +100,26 @@ def write_version_migrator_status(migrator, mctx):
                 else:
                     new_version = vpri.get("new_version", False)
 
+                try:
+                    if "new_version" in vpri:
+                        old_vpri_version = vpri["new_version"]
+                        had_vpri_version = True
+                    else:
+                        had_vpri_version = False
+
+                    vpri["new_version"] = new_version
+
+                    new_version_is_ok = _ok_version(
+                        new_version
+                    ) and not migrator.filter(attrs)
+                finally:
+                    if had_vpri_version:
+                        vpri["new_version"] = old_vpri_version
+                    else:
+                        del vpri["new_version"]
+
                 # run filter with new_version
-                if _ok_version(new_version) and not migrator.filter(
-                    attrs,
-                    new_version=new_version,
-                ):
+                if new_version_is_ok:
                     attempts = vpri.get("new_version_attempts", {}).get(new_version, 0)
                     if attempts == 0:
                         out["queued"][node] = new_version

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -1403,7 +1403,15 @@ def extract_section_from_yaml_text(
         A list of strings for the extracted sections.
     """
     # normalize the indents etc.
-    yaml_text = CondaMetaYAML(yaml_text).dumps()
+    try:
+        yaml_text = CondaMetaYAML(yaml_text).dumps()
+    except Exception as e:
+        logger.debug(
+            "Failed to normalize the YAML text due to error %s. We will try to parse anyways!",
+            repr(e),
+        )
+        pass
+
     lines = yaml_text.splitlines()
 
     in_requirements = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,13 @@
 import os
+import tempfile
 from types import TracebackType
 from typing import Self
 
+import networkx as nx
 import pytest
 
 from conda_forge_tick import global_sensitive_env
+from conda_forge_tick.lazy_json_backends import LazyJson
 
 
 @pytest.fixture
@@ -103,6 +106,19 @@ class FakeLazyJson(dict):
         return self
 
 
+@pytest.fixture
+def test_graph():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        gx = nx.DiGraph()
+        lzj = LazyJson(os.path.join(tmpdir, "conda.json"))
+        with lzj as attrs:
+            attrs.update({"reqs": ["python"]})
+        gx.add_node("conda", payload=lzj)
+        gx.graph["outputs_lut"] = {}
+
+        yield gx
+
+
 def pytest_configure(config):
     config.addinivalue_line(
         "markers",
@@ -112,7 +128,9 @@ def pytest_configure(config):
 
 @pytest.fixture
 def temporary_environment():
-    old_env = os.environ.copy()
-    yield
-    os.environ.clear()
-    os.environ.update(old_env)
+    try:
+        old_env = os.environ.copy()
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(old_env)

--- a/tests/test_cfyaml_cleanup_migrator.py
+++ b/tests/test_cfyaml_cleanup_migrator.py
@@ -1,14 +1,18 @@
 import os
 
+import networkx as nx
 import pytest
 from ruamel.yaml import YAML
 from test_migrators import run_test_migration
 
 from conda_forge_tick.migrators import CondaForgeYAMLCleanup, Version
 
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
 VERSION_CF = Version(
     set(),
     piggy_back_migrations=[CondaForgeYAMLCleanup()],
+    total_graph=TOTAL_GRAPH,
 )
 
 YAML_PATHS = [

--- a/tests/test_container_tasks.py
+++ b/tests/test_container_tasks.py
@@ -9,6 +9,7 @@ import subprocess
 import tempfile
 
 import conda_smithy
+import networkx as nx
 import pytest
 from conda.models.version import VersionOrder
 from conda_forge_feedstock_ops.container_utils import (
@@ -48,7 +49,9 @@ from conda_forge_tick.utils import (
     parse_meta_yaml_containerized,
 )
 
-VERSION = Version(set())
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
+VERSION = Version(set(), total_graph=TOTAL_GRAPH)
 
 YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")
 
@@ -608,7 +611,7 @@ def test_container_tasks_is_recipe_solvable_containerized(use_containers):
         assert res_cont == res_local
 
 
-yaml_rebuild = MigrationYaml(yaml_contents="{}", name="hi")
+yaml_rebuild = MigrationYaml(yaml_contents="{}", name="hi", total_graph=TOTAL_GRAPH)
 yaml_rebuild.cycles = []
 
 
@@ -732,7 +735,7 @@ def test_migration_runner_run_migration_containerized_version(
         pmy["req"] |= set(_set)
     pmy["raw_meta_yaml"] = inp
     pmy.update(kwargs)
-    pmy["new_version"] = new_ver
+    pmy["version_pr_info"] = {"new_version": new_ver}
 
     data = run_migration_containerized(
         migrator=m,

--- a/tests/test_cos7_config_migrator.py
+++ b/tests/test_cos7_config_migrator.py
@@ -1,14 +1,18 @@
 import os
 
+import networkx as nx
 import pytest
 from test_migrators import run_test_migration
 
 from conda_forge_tick.migrators import Cos7Config, Version
 from conda_forge_tick.migrators.cos7 import REQUIRED_RE_LINES, _has_line_set
 
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
 VERSION_COS7 = Version(
     set(),
     piggy_back_migrations=[Cos7Config()],
+    total_graph=TOTAL_GRAPH,
 )
 
 YAML_PATHS = [

--- a/tests/test_cross_compile.py
+++ b/tests/test_cross_compile.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import networkx as nx
 import pytest
 from flaky import flaky
 from test_migrators import run_test_migration
@@ -22,6 +23,9 @@ YAML_PATHS = [
 ]
 YAML_PATH = YAML_PATHS[0]
 
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
+
 config_migrator = UpdateConfigSubGuessMigrator()
 guard_testing_migrator = GuardTestingMigrator()
 cmake_migrator = UpdateCMakeArgsMigrator()
@@ -34,6 +38,7 @@ arm_and_power_migrator = CrossCompilationForARMAndPower()
 version_migrator_autoconf = Version(
     set(),
     piggy_back_migrations=[config_migrator, cmake_migrator, guard_testing_migrator],
+    total_graph=TOTAL_GRAPH,
 )
 version_migrator_cmake = Version(
     set(),
@@ -43,26 +48,32 @@ version_migrator_cmake = Version(
         cross_rbase_migrator,
         cross_python_migrator,
     ],
+    total_graph=TOTAL_GRAPH,
 )
 version_migrator_python = Version(
     set(),
     piggy_back_migrations=[cross_python_migrator],
+    total_graph=TOTAL_GRAPH,
 )
 version_migrator_rbase = Version(
     set(),
     piggy_back_migrations=[cross_rbase_migrator],
+    total_graph=TOTAL_GRAPH,
 )
 version_migrator_b2h = Version(
     set(),
     piggy_back_migrations=[b2h_migrator],
+    total_graph=TOTAL_GRAPH,
 )
 version_migrator_nci = Version(
     set(),
     piggy_back_migrations=[nci_migrator],
+    total_graph=TOTAL_GRAPH,
 )
 version_migrator_arm_and_power = Version(
     set(),
     piggy_back_migrations=[arm_and_power_migrator],
+    total_graph=TOTAL_GRAPH,
 )
 
 

--- a/tests/test_duplicate_lines_cleanup_migrator.py
+++ b/tests/test_duplicate_lines_cleanup_migrator.py
@@ -1,13 +1,17 @@
 import os
 
+import networkx as nx
 import pytest
 from test_migrators import run_test_migration
 
 from conda_forge_tick.migrators import DuplicateLinesCleanup, Version
 
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
 VERSION_DLC = Version(
     set(),
     piggy_back_migrations=[DuplicateLinesCleanup()],
+    total_graph=TOTAL_GRAPH,
 )
 
 YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")

--- a/tests/test_extra_jinja2_keys_migrator.py
+++ b/tests/test_extra_jinja2_keys_migrator.py
@@ -1,13 +1,17 @@
 import os
 
+import networkx as nx
 from flaky import flaky
 from test_migrators import run_test_migration
 
 from conda_forge_tick.migrators import ExtraJinja2KeysCleanup, Version
 
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
 VERSION_CF = Version(
     set(),
     piggy_back_migrations=[ExtraJinja2KeysCleanup()],
+    total_graph=TOTAL_GRAPH,
 )
 
 YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")

--- a/tests/test_flang.py
+++ b/tests/test_flang.py
@@ -1,5 +1,6 @@
 import os
 
+import networkx as nx
 import pytest
 from test_migrators import run_test_migration
 
@@ -8,10 +9,13 @@ from conda_forge_tick.migrators import FlangMigrator, Version
 TEST_YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")
 
 
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
 FLANG = FlangMigrator()
 VERSION_WITH_FLANG = Version(
     set(),
     piggy_back_migrations=[FLANG],
+    total_graph=TOTAL_GRAPH,
 )
 
 

--- a/tests/test_libboost.py
+++ b/tests/test_libboost.py
@@ -1,5 +1,6 @@
 import os
 
+import networkx as nx
 import pytest
 from test_migrators import run_test_migration
 
@@ -9,10 +10,13 @@ from conda_forge_tick.migrators.libboost import _slice_into_output_sections
 TEST_YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")
 
 
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
 LIBBOOST = LibboostMigrator()
 VERSION_WITH_LIBBOOST = Version(
     set(),
     piggy_back_migrations=[LIBBOOST],
+    total_graph=TOTAL_GRAPH,
 )
 
 

--- a/tests/test_license_migrator.py
+++ b/tests/test_license_migrator.py
@@ -1,11 +1,14 @@
+import networkx as nx
 from flaky import flaky
 from test_migrators import run_test_migration
 
 from conda_forge_tick.migrators import LicenseMigrator, Version
 from conda_forge_tick.migrators.license import _munge_licenses
 
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
 LM = LicenseMigrator()
-VER_LM = Version(set(), piggy_back_migrations=[LM])
+VER_LM = Version(set(), piggy_back_migrations=[LM], total_graph=TOTAL_GRAPH)
 
 version_license = """\
 {% set version = "0.8" %}

--- a/tests/test_make_migrators.py
+++ b/tests/test_make_migrators.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import subprocess
 import tempfile
 from pathlib import Path
 
@@ -7,10 +8,19 @@ import networkx as nx
 import pytest
 from pytest import FixtureRequest
 
-from conda_forge_tick.lazy_json_backends import get_sharded_path
-from conda_forge_tick.make_migrators import create_migration_yaml_creator
-from conda_forge_tick.migrators import MigrationYamlCreator
-from conda_forge_tick.utils import load_existing_graph
+from conda_forge_tick.lazy_json_backends import (
+    get_sharded_path,
+    lazy_json_override_backends,
+)
+from conda_forge_tick.make_migrators import (
+    create_migration_yaml_creator,
+    dump_migrators,
+    initialize_migrators,
+    load_migrators,
+)
+from conda_forge_tick.migrators import MigrationYaml, MigrationYamlCreator
+from conda_forge_tick.os_utils import pushd
+from conda_forge_tick.utils import load_existing_graph, load_graph, pluck
 
 TEST_FILES_DIR = Path(__file__).parent / "test_files_make_migrators"
 TEST_GRAPH_FILE = TEST_FILES_DIR / "test_graph.json"
@@ -118,3 +128,71 @@ class TestCreateMigrationYamlCreator:
 
         assert len(migrator.effective_graph) == 1
         assert "conda-forge-pinning" in migrator.effective_graph
+
+
+def test_make_migrators_initialize_migrators():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subprocess.run(
+            [
+                "git",
+                "clone",
+                "--depth=1",
+                "https://github.com/regro/cf-graph-countyfair.git",
+            ],
+            cwd=tmpdir,
+            check=True,
+        )
+        with (
+            pushd(os.path.join(tmpdir, "cf-graph-countyfair")),
+            lazy_json_override_backends(["file"], use_file_cache=True),
+        ):
+            gx = load_graph()
+
+            assert "payload" in gx.nodes["conda-forge-pinning"], (
+                "Payload not found for conda-forge-pinning!"
+            )
+
+            nodes_to_keep = set()
+            # random selection of packages to cut the graph down
+            nodes_to_test = [
+                "ngmix",
+                "ultraplot",
+                "r-semaphore",
+                "r-tidyverse",
+                "conda-forge-pinning",
+            ]
+            while nodes_to_test:
+                pkg = nodes_to_test.pop(0)
+                if pkg in gx.nodes:
+                    nodes_to_keep.add(pkg)
+                    for n in gx.predecessors(pkg):
+                        if n not in nodes_to_keep:
+                            nodes_to_test.append(n)
+
+            for pkg in set(gx.nodes) - nodes_to_keep:
+                pluck(gx, pkg)
+
+            # post plucking cleanup
+            gx.remove_edges_from(nx.selfloop_edges(gx))
+
+            print(
+                "Number of nodes in the graph after plucking:",
+                len(gx.nodes),
+                flush=True,
+            )
+
+            migrators = initialize_migrators(gx)
+
+            assert len(migrators) > 0, "No migrators found!"
+            for migrator in migrators:
+                assert migrator is not None, "Migrator is None!"
+                assert hasattr(migrator, "effective_graph"), (
+                    "Migrator has no effective graph!"
+                )
+                assert hasattr(migrator, "graph"), "Migrator has no graph attribute!"
+                if isinstance(migrator, MigrationYaml):
+                    assert "conda-forge-pinning" in migrator.graph.nodes
+
+            # dump and load the migrators
+            dump_migrators(migrators)
+            load_migrators(skip_paused=False)

--- a/tests/test_matplotlib_base.py
+++ b/tests/test_matplotlib_base.py
@@ -1,10 +1,13 @@
 import os
 
+import networkx as nx
 import pytest
 from test_migrators import run_test_migration
 
 from conda_forge_tick.migrators import MatplotlibBase
 
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
 MPLB = MatplotlibBase(
     old_pkg="matplotlib",
     new_pkg="matplotlib-base",
@@ -12,6 +15,7 @@ MPLB = MatplotlibBase(
         "Unless you need `pyqt`, recipes should depend only on `matplotlib-base`."
     ),
     pr_limit=5,
+    total_graph=TOTAL_GRAPH,
 )
 
 

--- a/tests/test_migration_runner.py
+++ b/tests/test_migration_runner.py
@@ -2,6 +2,7 @@ import os
 import pprint
 import subprocess
 
+import networkx as nx
 from test_migrators import sample_yaml_rebuild, updated_yaml_rebuild
 
 from conda_forge_tick.migration_runner import run_migration_local
@@ -19,7 +20,9 @@ class _MigrationYaml(NoFilter, MigrationYaml):
     pass
 
 
-yaml_rebuild = _MigrationYaml(yaml_contents="{}", name="hi")
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
+yaml_rebuild = _MigrationYaml(yaml_contents="{}", name="hi", total_graph=TOTAL_GRAPH)
 yaml_rebuild.cycles = []
 
 

--- a/tests/test_migration_yaml_migration.py
+++ b/tests/test_migration_yaml_migration.py
@@ -3,7 +3,6 @@ import os
 import re
 from unittest import mock
 
-import networkx as nx
 import pytest
 
 from conda_forge_tick.feedstock_parser import populate_feedstock_attributes
@@ -11,9 +10,6 @@ from conda_forge_tick.migrators import MigrationYamlCreator, merge_migrator_cbc
 from conda_forge_tick.os_utils import eval_cmd, pushd
 from conda_forge_tick.utils import frozen_to_json_friendly, parse_meta_yaml
 
-G = nx.DiGraph()
-G.add_node("conda", reqs=["python"], payload={})
-G.graph["outputs_lut"] = {}
 os.environ["RUN_URL"] = "hi world"
 
 YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")
@@ -124,7 +120,7 @@ migrator_ts: 12345.2
     [(IN_YAML, OUT_YAML), (IN_YAML_TODAY, OUT_YAML_TODAY)],
 )
 @mock.patch("time.time")
-def test_migration_yaml_migration(tmock, in_out_yaml, caplog, tmp_path):
+def test_migration_yaml_migration(tmock, in_out_yaml, caplog, tmp_path, test_graph):
     caplog.set_level(
         logging.DEBUG,
         logger="conda_forge_tick.migrators.migration_yaml",
@@ -136,14 +132,13 @@ def test_migration_yaml_migration(tmock, in_out_yaml, caplog, tmp_path):
     pin_spec = "x.x"
 
     MYM = MigrationYamlCreator(
-        pname,
-        pin_ver,
-        curr_pin,
-        pin_spec,
-        "hi",
-        G,
-        G,
+        package_name=pname,
+        new_pin_version=pin_ver,
+        current_pin=curr_pin,
+        pin_spec=pin_spec,
+        feedstock_name="hi",
         pinnings=["libboost_devel", "libboost_python_devel"],
+        total_graph=test_graph,
     )
 
     with pushd(tmp_path):

--- a/tests/test_migrator_nvtools.py
+++ b/tests/test_migrator_nvtools.py
@@ -28,13 +28,13 @@ def write_file_contents(filename, buffer):
         file.write(buffer)
 
 
-def test_nvtools_migrate():
+def test_nvtools_migrate(test_graph):
     backups = [
         store_file_contents(os.path.join(mock_recipe_dir, f))
         for f in ["build.sh", "meta.yaml", "../conda-forge.yml"]
     ]
 
-    migrator = AddNVIDIATools()
+    migrator = AddNVIDIATools(total_graph=test_graph)
     migrator.migrate(
         mock_recipe_dir,
         mock_node_attrs,

--- a/tests/test_migrator_to_json.py
+++ b/tests/test_migrator_to_json.py
@@ -3,10 +3,14 @@ import inspect
 import pprint
 
 import networkx as nx
+import pytest
 
 import conda_forge_tick.migrators
 from conda_forge_tick.lazy_json_backends import dumps, loads
 from conda_forge_tick.migrators import make_from_lazy_json_data
+
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
 
 
 def test_migrator_to_json_dep_update_minimigrator():
@@ -82,6 +86,7 @@ def test_migrator_to_json_version():
             conda_forge_tick.migrators.DuplicateLinesCleanup(),
             conda_forge_tick.migrators.MiniReplacement(old_pkg="foo", new_pkg="bar"),
         ],
+        total_graph=TOTAL_GRAPH,
     )
     data = migrator.to_lazy_json_data()
     pprint.pprint(data)
@@ -100,24 +105,19 @@ def test_migrator_to_json_version():
     assert dumps(migrator2.to_lazy_json_data()) == lzj_data
 
 
-def test_migrator_to_json_migration_yaml_creator():
-    gx = nx.DiGraph()
-    gx.add_node("conda", reqs=["python"], payload={}, blah="foo")
-    gx.graph["outputs_lut"] = {}
-
+def test_migrator_to_json_migration_yaml_creator(test_graph):
     pname = "boost"
     pin_ver = "1.99.0"
     curr_pin = "1.70.0"
     pin_spec = "x.x"
 
     migrator = conda_forge_tick.migrators.MigrationYamlCreator(
-        pname,
-        pin_ver,
-        curr_pin,
-        pin_spec,
-        "hi",
-        gx,
-        gx,
+        package_name=pname,
+        new_pin_version=pin_ver,
+        current_pin=curr_pin,
+        pin_spec=pin_spec,
+        feedstock_name="hi",
+        total_graph=test_graph,
         blah="foo",
     )
     data = migrator.to_lazy_json_data()
@@ -147,6 +147,7 @@ def test_migrator_to_json_matplotlib_base():
             "Unless you need `pyqt`, recipes should depend only on `matplotlib-base`."
         ),
         pr_limit=5,
+        total_graph=TOTAL_GRAPH,
     )
     data = migrator.to_lazy_json_data()
     pprint.pprint(data)
@@ -166,9 +167,10 @@ def test_migrator_to_json_matplotlib_base():
 
 def test_migrator_to_json_migration_yaml():
     migrator = conda_forge_tick.migrators.MigrationYaml(
-        yaml_contents="hello world",
+        yaml_contents="{}",
         name="hi",
         blah="foo",
+        total_graph=TOTAL_GRAPH,
     )
 
     data = migrator.to_lazy_json_data()
@@ -189,7 +191,7 @@ def test_migrator_to_json_migration_yaml():
     assert dumps(migrator2.to_lazy_json_data()) == lzj_data
 
 
-def test_migrator_to_json_rebuild():
+def test_migrator_to_json_replacement():
     migrator = conda_forge_tick.migrators.Replacement(
         old_pkg="matplotlib",
         new_pkg="matplotlib-base",
@@ -197,6 +199,7 @@ def test_migrator_to_json_rebuild():
             "Unless you need `pyqt`, recipes should depend only on `matplotlib-base`."
         ),
         pr_limit=5,
+        total_graph=TOTAL_GRAPH,
     )
 
     data = migrator.to_lazy_json_data()
@@ -218,12 +221,12 @@ def test_migrator_to_json_rebuild():
 def test_migrator_to_json_arch():
     gx = nx.DiGraph()
     gx.add_node("conda", reqs=["python"], payload={}, blah="foo")
+    gx.graph["outputs_lut"] = {}
 
     migrator = conda_forge_tick.migrators.ArchRebuild(
         target_packages=["python"],
-        graph=gx,
         pr_limit=5,
-        name="aarch64 and ppc64le addition",
+        total_graph=gx,
     )
 
     data = migrator.to_lazy_json_data()
@@ -245,12 +248,12 @@ def test_migrator_to_json_arch():
 def test_migrator_to_json_osx_arm():
     gx = nx.DiGraph()
     gx.add_node("conda", reqs=["python"], payload={}, blah="foo")
+    gx.graph["outputs_lut"] = {}
 
     migrator = conda_forge_tick.migrators.OSXArm(
         target_packages=["python"],
-        graph=gx,
+        total_graph=gx,
         pr_limit=5,
-        name="arm osx addition",
     )
 
     data = migrator.to_lazy_json_data()
@@ -266,4 +269,30 @@ def test_migrator_to_json_osx_arm():
         pgm.__class__.__name__ for pgm in migrator.piggy_back_migrations
     ]
     assert isinstance(migrator2, conda_forge_tick.migrators.OSXArm)
+    assert dumps(migrator2.to_lazy_json_data()) == lzj_data
+
+
+@pytest.mark.parametrize(
+    "klass",
+    [
+        conda_forge_tick.migrators.AddNVIDIATools,
+        conda_forge_tick.migrators.RebuildBroken,
+    ],
+)
+def test_migrator_to_json_others(klass):
+    migrator = klass(total_graph=TOTAL_GRAPH)
+
+    data = migrator.to_lazy_json_data()
+    pprint.pprint(data)
+    lzj_data = dumps(data)
+    print("lazy json data:\n", lzj_data)
+    assert data["__migrator__"] is True
+    assert data["class"] == klass.__name__
+    assert data["name"] == migrator.name.replace(" ", "_")
+
+    migrator2 = make_from_lazy_json_data(loads(lzj_data))
+    assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [
+        pgm.__class__.__name__ for pgm in migrator.piggy_back_migrations
+    ]
+    assert isinstance(migrator2, klass)
     assert dumps(migrator2.to_lazy_json_data()) == lzj_data

--- a/tests/test_migrators_v1.py
+++ b/tests/test_migrators_v1.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 
+import networkx as nx
 from test_migrators import run_test_migration, run_test_yaml_migration
 from test_recipe_yaml_parsing import TEST_RECIPE_YAML_PATH
 
@@ -21,12 +22,15 @@ class _MigrationYaml(NoFilter, MigrationYaml):
     pass
 
 
-yaml_rebuild = _MigrationYaml(yaml_contents="hello world", name="hi")
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
+yaml_rebuild = _MigrationYaml(yaml_contents="{}", name="hi", total_graph=TOTAL_GRAPH)
 yaml_rebuild.cycles = []
 yaml_rebuild_no_build_number = _MigrationYaml(
-    yaml_contents="hello world",
+    yaml_contents="{}",
     name="hi",
     bump_number=0,
+    total_graph=TOTAL_GRAPH,
 )
 yaml_rebuild_no_build_number.cycles = []
 
@@ -83,7 +87,7 @@ def test_yaml_migration_rebuild_no_buildno(tmp_path):
 # Run Matplotlib mini-migrator                               ###
 ##################################################################
 
-version = Version(set())
+version = Version(set(), total_graph=TOTAL_GRAPH)
 
 matplotlib = Replacement(
     old_pkg="matplotlib",
@@ -92,6 +96,7 @@ matplotlib = Replacement(
         "Unless you need `pyqt`, recipes should depend only on `matplotlib-base`."
     ),
     pr_limit=5,
+    total_graph=TOTAL_GRAPH,
 )
 
 

--- a/tests/test_minireplacement.py
+++ b/tests/test_minireplacement.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import networkx as nx
 import pytest
 from test_migrators import run_test_migration
 
@@ -9,17 +10,23 @@ XZLIBLZMADEVEL = MiniReplacement(old_pkg="xz", new_pkg="liblzma-devel")
 JPEGJPEGTURBO = MiniReplacement(old_pkg="jpeg", new_pkg="libjpeg-turbo")
 QTQTMAIN = MiniReplacement(old_pkg="qt", new_pkg="qt-main")
 
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
+
 VERSION_WITH_XZLIBLZMADEVEL = Version(
     set(),
     piggy_back_migrations=[XZLIBLZMADEVEL],
+    total_graph=TOTAL_GRAPH,
 )
 VERSION_WITH_JPEGTURBO = Version(
     set(),
     piggy_back_migrations=[JPEGJPEGTURBO],
+    total_graph=TOTAL_GRAPH,
 )
 VERSION_WITH_QTQTMAIN = Version(
     set(),
     piggy_back_migrations=[QTQTMAIN],
+    total_graph=TOTAL_GRAPH,
 )
 
 YAML_PATHS = [

--- a/tests/test_mpi_pin_run_as_build_cleanup_migrator.py
+++ b/tests/test_mpi_pin_run_as_build_cleanup_migrator.py
@@ -1,5 +1,6 @@
 import os
 
+import networkx as nx
 import pytest
 from ruamel.yaml import YAML
 from test_migrators import run_test_migration
@@ -7,9 +8,12 @@ from test_migrators import run_test_migration
 from conda_forge_tick.migrators import MPIPinRunAsBuildCleanup, Version
 from conda_forge_tick.migrators.mpi_pin_run_as_build import MPIS
 
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
 VERSION_CF = Version(
     set(),
     piggy_back_migrations=[MPIPinRunAsBuildCleanup()],
+    total_graph=TOTAL_GRAPH,
 )
 
 YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")

--- a/tests/test_noarch_python_min_migrator.py
+++ b/tests/test_noarch_python_min_migrator.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import textwrap
 
+import networkx as nx
 import pytest
 from test_migrators import run_test_migration
 
@@ -20,6 +21,9 @@ NEXT_GLOBAL_PYTHON_MIN = (
     + "."
     + str(int(GLOBAL_PYTHON_MIN.split(".")[1]) + 1)
 )
+
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
 
 
 @pytest.mark.parametrize("replace_host_with_build", [True, False])
@@ -561,7 +565,7 @@ def test_noarch_python_min_migrator(tmp_path, name):
         os.path.join(TEST_YAML_PATH, f"noarch_python_min_{name}_after_meta.yaml")
     ) as f:
         recipe_after = f.read()
-    m = NoarchPythonMinMigrator()
+    m = NoarchPythonMinMigrator(total_graph=TOTAL_GRAPH)
     run_test_migration(
         m=m,
         inp=recipe_before,

--- a/tests/test_pip_check_migrator.py
+++ b/tests/test_pip_check_migrator.py
@@ -1,12 +1,15 @@
 import os
 
+import networkx as nx
 import pytest
 from test_migrators import run_test_migration
 
 from conda_forge_tick.migrators import PipCheckMigrator, Version
 
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
 PC = PipCheckMigrator()
-VERSION_PC = Version(set(), piggy_back_migrations=[PC])
+VERSION_PC = Version(set(), piggy_back_migrations=[PC], total_graph=TOTAL_GRAPH)
 
 YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")
 

--- a/tests/test_pypi_org.py
+++ b/tests/test_pypi_org.py
@@ -1,5 +1,6 @@
 import os
 
+import networkx as nx
 import pytest
 from test_migrators import run_test_migration
 
@@ -7,11 +8,13 @@ from conda_forge_tick.migrators import PyPIOrgMigrator, Version
 
 TEST_YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")
 
-
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
 PYPI_ORG = PyPIOrgMigrator()
 VERSION_WITH_PYPI_ORG = Version(
     set(),
     piggy_back_migrations=[PYPI_ORG],
+    total_graph=TOTAL_GRAPH,
 )
 
 

--- a/tests/test_pypi_whl_mini.py
+++ b/tests/test_pypi_whl_mini.py
@@ -1,5 +1,6 @@
 import os
 
+import networkx as nx
 import pytest
 import requests
 from flaky import flaky
@@ -7,11 +8,15 @@ from test_migrators import run_minimigrator, run_test_migration
 
 from conda_forge_tick.migrators import PipWheelMigrator, Version
 
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
+
 wheel_mig = PipWheelMigrator()
 
 version_migrator_whl = Version(
     set(),
     piggy_back_migrations=[wheel_mig],
+    total_graph=TOTAL_GRAPH,
 )
 
 YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")

--- a/tests/test_r_ucrt.py
+++ b/tests/test_r_ucrt.py
@@ -1,12 +1,16 @@
+import networkx as nx
 from flaky import flaky
 from test_migrators import run_test_migration
 
 from conda_forge_tick.migrators import RUCRTCleanup, Version
 
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
 r_ucrt_migrator = RUCRTCleanup()
 version_migrator_rbase = Version(
     set(),
     piggy_back_migrations=[r_ucrt_migrator],
+    total_graph=TOTAL_GRAPH,
 )
 
 rbase_recipe = """\

--- a/tests/test_recipe_v1.py
+++ b/tests/test_recipe_v1.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import networkx as nx
 import pytest
 from flaky import flaky
 from test_migrators import run_test_migration
@@ -17,9 +18,12 @@ from conda_forge_tick.migrators.recipe_v1 import (
 
 YAML_PATH = Path(__file__).parent / "test_v1_yaml"
 
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
 combine_conditions_migrator = Version(
     set(),
     piggy_back_migrations=[CombineV1ConditionsMigrator()],
+    total_graph=TOTAL_GRAPH,
 )
 
 

--- a/tests/test_staticlib.py
+++ b/tests/test_staticlib.py
@@ -19,6 +19,9 @@ from conda_forge_tick.migrators.staticlib import (
 TEST_YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")
 TEST_YAML_PATH_V1 = os.path.join(os.path.dirname(__file__), "test_v1_yaml")
 
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
+
 
 @pytest.mark.parametrize(
     "spec,res",
@@ -290,8 +293,9 @@ def test_staticlib_migrator_llvmlite(tmp_path, yaml_path):
 
     graph = nx.DiGraph()
     graph.add_node(name, payload=pmy)
+    graph.graph["outputs_lut"] = {}
     m = StaticLibMigrator(
-        graph=graph,
+        total_graph=graph,
     )
     run_test_migration(
         m=m,

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -1,6 +1,7 @@
 import os
 import re
 
+import networkx as nx
 import pytest
 from test_migrators import run_test_migration
 
@@ -9,10 +10,13 @@ from conda_forge_tick.migrators import StdlibMigrator, Version
 TEST_YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")
 
 
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
 STDLIB = StdlibMigrator()
 VERSION_WITH_STDLIB = Version(
     set(),
     piggy_back_migrations=[STDLIB],
+    total_graph=TOTAL_GRAPH,
 )
 
 

--- a/tests/test_update_deps.py
+++ b/tests/test_update_deps.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 from pathlib import Path
 
+import networkx as nx
 import pytest
 from flaky import flaky
 from test_migrators import run_test_migration
@@ -20,9 +21,12 @@ from conda_forge_tick.update_deps import (
     make_grayskull_recipe,
 )
 
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
 VERSION = Version(
     set(),
     piggy_back_migrations=[DependencyUpdateMigrator(set())],
+    total_graph=TOTAL_GRAPH,
 )
 
 

--- a/tests/test_url_exists.py
+++ b/tests/test_url_exists.py
@@ -21,7 +21,11 @@ def delay_rerun(*args):
             "http://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-7.6p1.tar.gz",
             True,
         ),
-        ("https://eups.lsst.codes/stack/src/tags/w_2021_07.list", True),
+        pytest.param(
+            "https://eups.lsst.codes/stack/src/tags/w_2021_07.list",
+            True,
+            marks=pytest.mark.xfail(reason="expired HTTPS certificate"),
+        ),
         pytest.param(
             "https://downloads.sourceforge.net/project/healpix/Healpix_3.31/Healpix_3.31_2016Aug26.tar.gz",  # noqa
             True,

--- a/tests/test_use_pip.py
+++ b/tests/test_use_pip.py
@@ -1,12 +1,15 @@
 import os
 
+import networkx as nx
 import pytest
 from test_migrators import run_test_migration
 
 from conda_forge_tick.migrators import PipMigrator, Version
 
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
 PC = PipMigrator()
-VERSION_PC = Version(set(), piggy_back_migrations=[PC])
+VERSION_PC = Version(set(), piggy_back_migrations=[PC], total_graph=TOTAL_GRAPH)
 
 YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")
 

--- a/tests/test_version_migrator.py
+++ b/tests/test_version_migrator.py
@@ -3,6 +3,7 @@ import os
 import random
 from pathlib import Path
 
+import networkx as nx
 import pytest
 from flaky import flaky
 from test_migrators import run_test_migration
@@ -10,7 +11,9 @@ from test_migrators import run_test_migration
 from conda_forge_tick.migrators import Version
 from conda_forge_tick.migrators.version import VersionMigrationError
 
-VERSION = Version(set())
+TOTAL_GRAPH = nx.DiGraph()
+TOTAL_GRAPH.graph["outputs_lut"] = {}
+VERSION = Version(set(), total_graph=TOTAL_GRAPH)
 
 YAML_PATH = Path(__file__).parent / "test_yaml"
 YAML_V1_PATH = Path(__file__).parent / "test_v1_yaml"


### PR DESCRIPTION
I am trying this PR again, with some changes to reduce memory use.