### PR TITLE
fix: only report direct deps in version PR dep versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       - id: typos
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.4
+    rev: v0.11.5
     hooks:
       - id: ruff
         args: [ --fix ]

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -76,7 +76,7 @@ def _lazy_json_or_dict(data):
         yield data
 
 
-def _make_migrator_graph(graph, migrator, effective=False):
+def _make_migrator_graph(graph, migrator, effective=False, pluck_nodes=True):
     """Prune graph only to nodes that need rebuilds."""
     gx2 = copy.deepcopy(graph)
 
@@ -110,7 +110,10 @@ def _make_migrator_graph(graph, migrator, effective=False):
 
     # the plucking
     for node in nodes_to_pluck:
-        pluck(gx2, node)
+        if pluck_nodes:
+            pluck(gx2, node)
+        else:
+            gx2.remove_node(node)
     gx2.remove_edges_from(nx.selfloop_edges(gx2))
     return gx2
 
@@ -281,6 +284,8 @@ class Migrator:
 
     allowed_schema_versions = [0]
 
+    pluck_nodes = True
+
     build_patterns = (
         (re.compile(r"(\s*?)number:\s*([0-9]+)"), "number: {}"),
         (
@@ -331,11 +336,15 @@ class Migrator:
                     "`effective_graph` to the Migrator."
                 )
 
-            graph = _make_migrator_graph(total_graph, self, effective=False)
+            graph = _make_migrator_graph(
+                total_graph, self, effective=False, pluck_nodes=self.pluck_nodes
+            )
             self.graph = graph
             self._init_kwargs["graph"] = graph
 
-            effective_graph = _make_migrator_graph(self.graph, self, effective=True)
+            effective_graph = _make_migrator_graph(
+                self.graph, self, effective=True, pluck_nodes=self.pluck_nodes
+            )
             self.effective_graph = effective_graph
             self._init_kwargs["effective_graph"] = effective_graph
 

--- a/conda_forge_tick/migrators/version.py
+++ b/conda_forge_tick/migrators/version.py
@@ -67,6 +67,7 @@ class Version(Migrator):
     rerender = True
     name = str(MigratorName.VERSION)
     allowed_schema_versions = {0, 1}
+    pluck_nodes = False
 
     def __init__(
         self,


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

After the report from https://github.com/regro/cf-scripts/issues/4018, I realized what happened only later. Sorry for closing that one too early. This should restrict the list to only direct deps.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

closes #4018 
