### PR TITLE
fix: add static overrides for `symengine` and `memory_allocator`

### DIFF
--- a/conda_forge_tick/pypi_name_mapping_static.yaml
+++ b/conda_forge_tick/pypi_name_mapping_static.yaml
@@ -123,3 +123,11 @@
 - pypi_name: pyyaml
   import_name: yaml
   conda_name: pyyaml
+
+- pypi_name: memory_allocator
+  import_name: memory_allocator
+  conda_name: memory-allocator
+
+- pypi_name: symengine
+  import_name: symengine
+  conda_name: python-symengine


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

- https://github.com/symengine/symengine.py is https://anaconda.org/conda-forge/python-symengine on conda
- https://github.com/sagemath/memory_allocator is https://anaconda.org/conda-forge/memory-allocator on conda (`_` > `-`)

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
