### PR TITLE
fix: quote windows testing guard

### DIFF
--- a/conda_forge_tick/migrators/cross_compile.py
+++ b/conda_forge_tick/migrators/cross_compile.py
@@ -164,7 +164,7 @@ class GuardTestingWinMigrator(CrossCompilationMigratorBase):
                     or line.strip().startswith("ctest")
                     or line.strip().startswith("make test")
                 ):
-                    lines.insert(i, "if not \"%CONDA_BUILD_SKIP_TESTS%\"==\"1\" (\n")
+                    lines.insert(i, 'if not "%CONDA_BUILD_SKIP_TESTS%"=="1" (\n')
                     insert_after = i + 1
                     while len(lines) > insert_after and lines[insert_after].endswith(
                         "\\\n",

--- a/conda_forge_tick/migrators/cross_compile.py
+++ b/conda_forge_tick/migrators/cross_compile.py
@@ -164,7 +164,7 @@ class GuardTestingWinMigrator(CrossCompilationMigratorBase):
                     or line.strip().startswith("ctest")
                     or line.strip().startswith("make test")
                 ):
-                    lines.insert(i, "if not %CONDA_BUILD_SKIP_TESTS%==1 (\n")
+                    lines.insert(i, "if not \"%CONDA_BUILD_SKIP_TESTS%\"==\"1\" (\n")
                     insert_after = i + 1
                     while len(lines) > insert_after and lines[insert_after].endswith(
                         "\\\n",

--- a/tests/test_cross_compile.py
+++ b/tests/test_cross_compile.py
@@ -171,7 +171,7 @@ def test_cmake(tmp_path):
     ]
     expected_win = [
         "cmake %CMAKE_ARGS% ..\n",
-        "if not %CONDA_BUILD_SKIP_TESTS%==1 (\n",
+        'if not "%CONDA_BUILD_SKIP_TESTS%"=="1" (\n',
         "ctest\n",
         ")\n",
     ]


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

Fixes an issue where the `GuardTestingWinMigrator` would emit:

```cmd
if not %CONDA_BUILD_SKIP_TESTS%==1 (
..
)
```

However, if the variable is not defined this would resolve to:

```cmd
if not ==1 (
..
)
```

which causes a cryptic error. (See https://github.com/conda-forge/freetype-feedstock/pull/61#issuecomment-2835494439)

This PR modifies the migrator such that the following is inserted instead

```cmd
if not "%CONDA_BUILD_SKIP_TESTS%"=="1" (
..
)
```

Which, if `CONDA_BUILD_SKIP_TESTS` is undefined resolves to:

```cmd
if not ""=="1" (
..
)
```
#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
