### PR TITLE
style(ruff): enforce logging style

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -166,12 +166,14 @@ def _prepare_feedstock_repository(
         backend.fork(context.git_repo_owner, context.git_repo_name)
     except RepositoryNotFoundError:
         logger.warning(
-            f"Could not fork {context.git_repo_owner}/{context.git_repo_name}: Not Found"
+            "Could not fork %s/%s: Not Found",
+            context.git_repo_owner,
+            context.git_repo_name,
         )
 
         error_message = f"{context.feedstock_name}: Git repository not found."
         logger.critical(
-            f"Failed to migrate {context.feedstock_name}, {error_message}",
+            "Failed to migrate %s, %s", context.feedstock_name, error_message
         )
 
         with context.attrs["pr_info"] as pri:
@@ -635,8 +637,11 @@ def run(
         except DuplicatePullRequestError:
             # This shouldn't happen too often anymore since we won't double PR
             logger.warning(
-                f"Attempted to create a duplicate PR for merging {git_backend.user}:{branch_name} "
-                f"into {context.git_repo_owner}:{base_branch}. Ignoring."
+                "Attempted to create a duplicate PR for merging %s:%s into %s:%s. Ignoring.",
+                git_backend.user,
+                branch_name,
+                context.git_repo_owner,
+                base_branch,
             )
             # Don't update the PR data
             pr_data = None
@@ -791,7 +796,7 @@ def _run_migrator_on_feedstock_branch(
 
             if is_github_api_limit_reached():
                 logger.warning("GitHub API error", exc_info=e)
-                break_loop = True
+                break_loop
 
     except VersionMigrationError as e:
         logger.exception("VERSION MIGRATION ERROR", exc_info=e)
@@ -1150,7 +1155,9 @@ def _update_nodes_with_bot_rerun(gx: nx.DiGraph):
                             # maybe add a pass check info here ? (if using DEBUG)
                         except Exception as e:
                             logger.error(
-                                f"BOT-RERUN : could not proceed check with {node}, {e}",
+                                "BOT-RERUN : could not proceed check with %s, %s",
+                                node,
+                                e,
                             )
                             raise e
                         # if there is a valid PR and it isn't currently listed as rerun

--- a/conda_forge_tick/container_cli.py
+++ b/conda_forge_tick/container_cli.py
@@ -141,13 +141,15 @@ def _provide_source_code():
     with tempfile.TemporaryDirectory() as tmpdir:
         input_recipe_dir = "/cf_feedstock_ops_dir/recipe_dir"
         logger.debug(
-            f"input container recipe dir {input_recipe_dir}: {os.listdir(input_recipe_dir)}"
+            "input container recipe dir %s: %s",
+            input_recipe_dir,
+            os.listdir(input_recipe_dir),
         )
 
         recipe_dir = os.path.join(tmpdir, os.path.basename(input_recipe_dir))
         sync_dirs(input_recipe_dir, recipe_dir, ignore_dot_git=True, update_git=False)
         logger.debug(
-            f"copied container recipe dir {recipe_dir}: {os.listdir(recipe_dir)}"
+            "copied container recipe dir %s: %s", recipe_dir, os.listdir(recipe_dir)
         )
 
         output_source_code = "/cf_feedstock_ops_dir/source_dir"
@@ -180,7 +182,7 @@ def _execute_git_cmds_and_report(*, cmds, cwd, msg):
             _output += gitret.stdout
             gitret.check_returncode()
     except Exception as e:
-        logger.error(f"{msg}\noutput: {_output}", exc_info=e)
+        logger.error("%s\noutput: %s", msg, _output, exc_info=e)
         raise e
 
 
@@ -203,7 +205,9 @@ def _migrate_feedstock(*, feedstock_name, default_branch, attrs, input_kwargs):
         assert len(input_fs_dir) == 1, f"expected one feedstock, got {input_fs_dir}"
         input_fs_dir = input_fs_dir[0]
         logger.debug(
-            f"input container feedstock dir {input_fs_dir}: {os.listdir(input_fs_dir)}"
+            "input container feedstock dir %s: %s",
+            input_fs_dir,
+            os.listdir(input_fs_dir),
         )
         input_permissions = os.path.join(
             "/cf_feedstock_ops_dir",
@@ -214,7 +218,9 @@ def _migrate_feedstock(*, feedstock_name, default_branch, attrs, input_kwargs):
 
         fs_dir = os.path.join(tmpdir, os.path.basename(input_fs_dir))
         sync_dirs(input_fs_dir, fs_dir, ignore_dot_git=True, update_git=False)
-        logger.debug(f"copied container feedstock dir {fs_dir}: {os.listdir(fs_dir)}")
+        logger.debug(
+            "copied container feedstock dir %s: %s", fs_dir, os.listdir(fs_dir)
+        )
 
         reset_permissions_with_user_execute(fs_dir, input_permissions)
 
@@ -257,7 +263,9 @@ def _update_version(*, version, hash_type):
         assert len(input_fs_dir) == 1, f"expected one feedstock, got {input_fs_dir}"
         input_fs_dir = input_fs_dir[0]
         logger.debug(
-            f"input container feedstock dir {input_fs_dir}: {os.listdir(input_fs_dir)}"
+            "input container feedstock dir %s: %s",
+            input_fs_dir,
+            os.listdir(input_fs_dir),
         )
         input_permissions = os.path.join(
             "/cf_feedstock_ops_dir",
@@ -268,7 +276,9 @@ def _update_version(*, version, hash_type):
 
         fs_dir = os.path.join(tmpdir, os.path.basename(input_fs_dir))
         sync_dirs(input_fs_dir, fs_dir, ignore_dot_git=True, update_git=False)
-        logger.debug(f"copied container feedstock dir {fs_dir}: {os.listdir(fs_dir)}")
+        logger.debug(
+            "copied container feedstock dir %s: %s", fs_dir, os.listdir(fs_dir)
+        )
 
         reset_permissions_with_user_execute(fs_dir, input_permissions)
 
@@ -382,7 +392,8 @@ def _check_solvable(
     logger = logging.getLogger("conda_forge_tick.container")
 
     logger.debug(
-        f"input container feedstock dir /cf_feedstock_ops_dir: {os.listdir('/cf_feedstock_ops_dir')}"
+        "input container feedstock dir /cf_feedstock_ops_dir: %s",
+        os.listdir("/cf_feedstock_ops_dir"),
     )
 
     data = {}

--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -204,7 +204,7 @@ def _fetch_static_repo(name, dest):
 
     if r.status_code != 200:
         logger.error(
-            f"Something odd happened when fetching feedstock {name}: {r.status_code}",
+            "Something odd happened when fetching feedstock %s: %s", name, r.status_code
         )
         return r
 
@@ -318,7 +318,7 @@ def populate_feedstock_attributes(
             variant_yamls = []
             plat_archs = []
             for cbc_path in ci_support_files:
-                logger.debug(f"parsing conda-build config: {cbc_path}")
+                logger.debug("parsing conda-build config: %s", cbc_path)
                 cbc_name = cbc_path.name
                 cbc_name_parts = cbc_name.replace(".yaml", "").split("_")
                 plat = cbc_name_parts[0]
@@ -369,7 +369,7 @@ def populate_feedstock_attributes(
 
                 # sometimes the requirements come out to None or [None]
                 # and this ruins the aggregated meta_yaml / breaks stuff
-                logger.debug(f"getting reqs for config: {cbc_path}")
+                logger.debug("getting reqs for config: %s", cbc_path)
                 if "requirements" in variant_yamls[-1]:
                     variant_yamls[-1]["requirements"] = _clean_req_nones(
                         variant_yamls[-1]["requirements"],
@@ -384,7 +384,7 @@ def populate_feedstock_attributes(
                             )
 
                 # collapse them down
-                logger.debug(f"collapsing reqs for {name}")
+                logger.debug("collapsing reqs for %s", name)
                 final_cfgs = {}
                 for plat_arch, varyml in zip(plat_archs, variant_yamls):
                     if plat_arch not in final_cfgs:
@@ -430,7 +430,7 @@ def populate_feedstock_attributes(
     sorted_variant_yamls = [x for _, x in sorted(zip(plat_archs, variant_yamls))]
     yaml_dict = ChainDB(*sorted_variant_yamls)
     if not yaml_dict:
-        logger.error(f"Something odd happened when parsing recipe {name}")
+        logger.error("Something odd happened when parsing recipe %s", name)
         node_attrs["parsing_error"] = (
             "feedstock parsing error: could not combine metadata dicts across platforms"
         )

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -215,7 +215,9 @@ class GitCli:
             )
         except subprocess.CalledProcessError as e:
             logger.info(
-                f"Command '{' '.join(map(str, git_command))}' failed.\nstdout:\n{e.stdout or '<None>'}\nend of stdout"
+                "Command '%s' failed.\nstdout:\n%s\nend of stdout",
+                " ".join(map(str, git_command)),
+                e.stdout or "<None>",
             )
             raise GitCliError(f"Error running git command: {repr(e)}")
 
@@ -494,9 +496,9 @@ class GitCli:
                     f"Could not clone {origin_url} - does the remote exist?"
                 )
             logger.info(
-                f"Cloning {origin_url} into {target_dir} was not successful - "
-                f"trying to reset hard since the directory already exists. This will fail if the target directory is "
-                f"not a git repository."
+                "Cloning %s into %s was not successful - trying to reset hard since the directory already exists. This will fail if the target directory is not a git repository.",
+                origin_url,
+                target_dir,
             )
             self.reset_hard(target_dir)
 
@@ -533,13 +535,11 @@ class GitCli:
 
         try:
             logger.info(
-                f"Trying to checkout branch {new_branch} without creating a new branch"
+                "Trying to checkout branch %s without creating a new branch", new_branch
             )
             self.checkout_branch(target_dir, new_branch)
         except GitCliError:
-            logger.info(
-                f"It seems branch {new_branch} does not exist. Creating it.",
-            )
+            logger.info("It seems branch %s does not exist. Creating it.", new_branch)
             self.checkout_new_branch(target_dir, new_branch, start_point=base_branch)
 
 
@@ -809,8 +809,7 @@ class GitHubBackend(GitPlatformBackend):
             )
         except Exception as e:
             logger.warning(
-                f"GitHub API error fetching repo {owner}/{repo_name}.",
-                exc_info=e,
+                "GitHub API error fetching repo %s/%s.", owner, repo_name, exc_info=e
             )
             raise e
 
@@ -849,7 +848,7 @@ class GitHubBackend(GitPlatformBackend):
 
         repo = self._get_repo(owner, repo_name)
 
-        logger.debug(f"Forking {owner}/{repo_name}.")
+        logger.debug("Forking %s/%s.", owner, repo_name)
         repo.create_fork()
 
         # Sleep to make sure the fork is created before we go after it
@@ -866,7 +865,11 @@ class GitHubBackend(GitPlatformBackend):
             return
 
         logger.info(
-            f"Syncing default branch of {fork_owner}/{repo_name} with {upstream_owner}/{repo_name}..."
+            "Syncing default branch of %s/%s with %s/%s...",
+            fork_owner,
+            repo_name,
+            upstream_owner,
+            repo_name,
         )
 
         fork.rename_branch(fork.default_branch, upstream_repo.default_branch)
@@ -906,8 +909,8 @@ class GitHubBackend(GitPlatformBackend):
             return remaining_limit
 
         logger.info(
-            "GitHub API limit reached, will reset at "
-            f"{datetime.utcfromtimestamp(reset_timestamp).strftime('%Y-%m-%dT%H:%M:%SZ')}"
+            "GitHub API limit reached, will reset at %s",
+            datetime.utcfromtimestamp(reset_timestamp).strftime("%Y-%m-%dT%H:%M:%SZ"),
         )
 
         return remaining_limit
@@ -1031,12 +1034,16 @@ class DryRunBackend(GitPlatformBackend):
         self, owner: str, repo_name: str, git_dir: Path, branch: str
     ):
         logger.debug(
-            f"Dry Run: Pushing changes from {git_dir} to {owner}/{repo_name} on branch {branch}."
+            "Dry Run: Pushing changes from %s to %s/%s on branch %s.",
+            git_dir,
+            owner,
+            repo_name,
+            branch,
         )
 
     def fork(self, owner: str, repo_name: str):
         if repo_name in self._repos:
-            logger.debug(f"Fork of {repo_name} already exists. Doing nothing.")
+            logger.debug("Fork of %s already exists. Doing nothing.", repo_name)
             return
 
         if not self.does_repository_exist(owner, repo_name):
@@ -1045,13 +1052,13 @@ class DryRunBackend(GitPlatformBackend):
             )
 
         logger.debug(
-            f"Dry Run: Creating fork of {owner}/{repo_name} for user {self._USER}."
+            "Dry Run: Creating fork of %s/%s for user %s.", owner, repo_name, self._USER
         )
         self._repos[repo_name] = owner
 
     def _sync_default_branch(self, upstream_owner: str, upstream_repo: str):
         logger.debug(
-            f"Dry Run: Syncing default branch of {upstream_owner}/{upstream_repo}."
+            "Dry Run: Syncing default branch of %s/%s.", upstream_owner, upstream_repo
         )
 
     @property

--- a/conda_forge_tick/import_to_pkg.py
+++ b/conda_forge_tick/import_to_pkg.py
@@ -197,22 +197,18 @@ def extract_pkg_from_import(name):
 def _fetch_arch(arch):
     # Generate a set a urls to generate for an channel/arch combo
     try:
-        logger.info(f"fetching {arch}")
+        logger.info("fetching %s", arch)
         r = requests.get(
             f"https://conda.anaconda.org/conda-forge/{arch}/repodata.json.bz2"
         )
         r.raise_for_status()
         repodata = orjson.loads(bz2.BZ2File(io.BytesIO(r.content)).read())
     except Exception as e:
-        logger.error(f"Failed to fetch {arch}: {e}")
+        logger.error("Failed to fetch %s: %s", arch, e)
         return
 
-    logger.info(
-        "    found %d .conda artifacts" % (len(repodata["packages.conda"])),
-    )
-    logger.info(
-        "    found %d .tar.bz2 artifacts" % (len(repodata["packages"])),
-    )
+    logger.info("    found %d .conda artifacts", len(repodata["packages.conda"]))
+    logger.info("    found %d .tar.bz2 artifacts", len(repodata["packages"]))
     for p in repodata["packages.conda"]:
         yield f"{arch}/{p}"
 
@@ -282,7 +278,7 @@ def _get_imports_and_files(file):
                 backend="oci",
             )
     except Exception as e:
-        logger.error(f"Failed to get artifact info for {file}: {e}")
+        logger.error("Failed to get artifact info for %s: %s", file, e)
         data = None
 
     if data is None:
@@ -327,9 +323,10 @@ def _main_import_to_pkg(max_artifacts: int):
         return
     new_files = all_files - indexed_files
     logger.info(
-        f"Found {len(new_files)} new files to index "
-        f"out of {len(all_files)} total "
-        f"({(1 - len(new_files) / len(all_files)) * 100:0.4}% indexed).",
+        "Found %d new files to index out of %d total (%.4f%% indexed).",
+        len(new_files),
+        len(all_files),
+        (1 - len(new_files) / len(all_files)) * 100 if len(all_files) else 0.0,
     )
 
     with ProcessPoolExecutor(max_workers=4) as exc:

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -228,7 +228,7 @@ class GithubLazyJsonBackend(LazyJsonBackend):
         cls._n_requests += 1
         if cls._n_requests % 20 == 0:
             logger.info(
-                f"Made {cls._n_requests} requests to the GitHub online backend.",
+                "Made %d requests to the GitHub online backend.", cls._n_requests
             )
         if cls._n_requests == 20:
             logger.warning(

--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -216,11 +216,14 @@ def _build_graph_process_pool(
                 f.result()
                 if n_left % 100 == 0:
                     logger.info(
-                        f"nodes left {n_left: >5d} - eta {int(eta): >5d}s: finished {name}"
+                        "nodes left %5d - eta %5ds: finished %s", n_left, int(eta), name
                     )
             except Exception as e:
                 logger.error(
-                    f"nodes left {n_left: >5d} - eta {int(eta): >5d}s: error adding {name} to the graph",
+                    "nodes left %5d - eta %5ds: error adding %s to the graph",
+                    n_left,
+                    int(eta),
+                    name,
                     exc_info=e,
                 )
 
@@ -237,7 +240,7 @@ def _build_graph_sequential(
         try:
             get_attrs(name, mark_not_archived=mark_not_archived)
         except Exception as e:
-            logger.error(f"Error updating node {name}", exc_info=e)
+            logger.error("Error updating node %s", name, exc_info=e)
 
 
 def _get_all_deps_for_node(attrs, outputs_lut):
@@ -333,7 +336,7 @@ def _update_graph_nodes(
         mark_not_archived=mark_not_archived,
     )
     logger.info("feedstock fetch loop completed")
-    logger.info(f"memory usage: {psutil.virtual_memory()}")
+    logger.info("memory usage: %s", psutil.virtual_memory())
 
 
 def _update_nodes_with_archived(names):
@@ -366,9 +369,9 @@ def main(
     tot_names_for_this_job = _get_names_for_job(tot_names, job, n_jobs)
     names_for_this_job = _get_names_for_job(names, job, n_jobs)
     archived_names_for_this_job = _get_names_for_job(archived_names, job, n_jobs)
-    logger.info(f"total # of nodes across all backends: {len(tot_names)}")
-    logger.info(f"active nodes: {len(names)}")
-    logger.info(f"archived nodes: {len(archived_names)}")
+    logger.info("total # of nodes across all backends: %d", len(tot_names))
+    logger.info("active nodes: %d", len(names))
+    logger.info("archived nodes: %d", len(archived_names))
 
     if update_nodes_and_edges:
         gx = load_graph()

--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -1033,7 +1033,7 @@ def dump_migrators(migrators: MutableSequence[Migrator], dry_run: bool = False) 
                     lzj.update(data)
 
             except Exception as e:
-                logger.error(f"Error dumping migrator {migrator} to JSON!", exc_info=e)
+                logger.error("Error dumping migrator %s to JSON!", migrator, exc_info=e)
 
         migrators_to_remove = old_migrators - new_migrators
         for migrator in migrators_to_remove:

--- a/conda_forge_tick/migration_runner.py
+++ b/conda_forge_tick/migration_runner.py
@@ -138,9 +138,13 @@ def run_migration_containerized(
 
         chmod_plus_rwX(tmpdir, recursive=True)
 
-        logger.debug(f"host feedstock dir {feedstock_dir}: {os.listdir(feedstock_dir)}")
         logger.debug(
-            f"copied host feedstock dir {tmp_feedstock_dir}: {os.listdir(tmp_feedstock_dir)}"
+            "host feedstock dir %s: %s", feedstock_dir, os.listdir(feedstock_dir)
+        )
+        logger.debug(
+            "copied host feedstock dir %s: %s",
+            tmp_feedstock_dir,
+            os.listdir(tmp_feedstock_dir),
         )
 
         mfile = os.path.join(tmpdir, "migrator.json")

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -437,7 +437,7 @@ class Migrator:
         __name = attrs.get("name", "")
 
         if attrs.get("archived", False):
-            logger.debug("%s: archived" % __name)
+            logger.debug("%s: archived", __name)
 
         bad_attr = _parse_bad_attr(attrs, not_bad_str_start)
         if bad_attr:
@@ -468,7 +468,7 @@ class Migrator:
         already_pred = migrator_uid in already_migrated_uids
         if already_pred:
             ind = already_migrated_uids.index(migrator_uid)
-            logger.debug(f"{__name}: already PRed: uid: {migrator_uid}")
+            logger.debug("%s: already PRed: uid: %s", __name, migrator_uid)
             if "PR" in attrs.get("pr_info", {}).get("PRed", [])[ind]:
                 if isinstance(
                     attrs.get("pr_info", {}).get("PRed", [])[ind]["PR"],
@@ -478,14 +478,12 @@ class Migrator:
                         "PR"
                     ] as mg_attrs:
                         logger.debug(
-                            "{}: already PRed: PR file: {}".format(
-                                __name, mg_attrs.file_name
-                            ),
+                            "%s: already PRed: PR file: %s", __name, mg_attrs.file_name
                         )
 
                         html_url = mg_attrs.get("html_url", "no url")
 
-                        logger.debug(f"{__name}: already PRed: url: {html_url}")
+                        logger.debug("%s: already PRed: url: %s", __name, html_url)
 
         return already_pred
 
@@ -512,7 +510,7 @@ class Migrator:
                 [],
             )
         except Exception:
-            logger.exception(f"Invalid value for {attrs.get('conda-forge.yml', {})=}")
+            logger.exception("Invalid value for %r", attrs.get("conda-forge.yml", {}))
         # make sure this is always a string
         return [str(b) for b in branches]
 
@@ -844,7 +842,7 @@ class GraphMigrator(Migrator):
             if muid not in _sanitized_muids(
                 payload.get("pr_info", {}).get("PRed", []),
             ):
-                logger.debug("not yet built: %s" % node)
+                logger.debug("not yet built: %s", node)
                 return True
 
             # This is due to some PRed_json loss due to bad graph deploy outage
@@ -860,7 +858,7 @@ class GraphMigrator(Migrator):
                 m_pred_json
                 and m_pred_json.get("PR", {"state": "open"}).get("state", "") == "open"
             ):
-                logger.debug("not yet built: %s" % node)
+                logger.debug("not yet built: %s", node)
                 return True
 
         return False

--- a/conda_forge_tick/migrators/cross_compile.py
+++ b/conda_forge_tick/migrators/cross_compile.py
@@ -512,7 +512,7 @@ class CrossCompilationForARMAndPower(MiniMigrator):
         with pushd(recipe_dir):
             if not os.path.exists("../conda-forge.yml"):
                 name = attrs.get("feedstock_name")
-                logger.info(f"no conda-forge.yml for {name}")
+                logger.info("no conda-forge.yml for %s", name)
                 return
 
             with open("../conda-forge.yml") as f:
@@ -527,7 +527,7 @@ class CrossCompilationForARMAndPower(MiniMigrator):
                         config["build_platform"][arch] = "linux_64"
                 with open("../conda-forge.yml", "w") as f:
                     name = attrs.get("feedstock_name")
-                    logger.info(f"new conda-forge.yml for {name}:={config}")
+                    logger.info("new conda-forge.yml for %s:=%s", name, config)
                     yaml_safe_dump(config, f)
 
             if not os.path.exists("build.sh"):

--- a/conda_forge_tick/migrators/license.py
+++ b/conda_forge_tick/migrators/license.py
@@ -184,7 +184,7 @@ def _scrape_license_string(pkg):
     if pkg.startswith("r-"):
         pkg = pkg[2:]
 
-    logger.info("LICENSE running cran skeleton for pkg %s" % pkg)
+    logger.info("LICENSE running cran skeleton for pkg %s", pkg)
 
     with tempfile.TemporaryDirectory() as tmpdir, pushd(tmpdir):
         subprocess.run(
@@ -242,7 +242,7 @@ def _scrape_license_string(pkg):
 def _do_r_license_munging(pkg, recipe_dir):
     try:
         d = _scrape_license_string(pkg)
-        logger.info("LICENSE R package license data: %s" % d)
+        logger.info("LICENSE R package license data: %s", d)
 
         with open(os.path.join(recipe_dir, "meta.yaml")) as fp:
             cmeta = CondaMetaYAML(fp.read())
@@ -259,7 +259,7 @@ def _do_r_license_munging(pkg, recipe_dir):
             cmeta.dump(fp)
 
     except Exception as e:
-        logger.info("LICENSE R license ERROR: %s" % repr(e))
+        logger.info("LICENSE R license ERROR: %s", repr(e))
         pass
 
 

--- a/conda_forge_tick/migrators/nvtools.py
+++ b/conda_forge_tick/migrators/nvtools.py
@@ -13,6 +13,8 @@ from conda_forge_tick.utils import (
 
 from .core import Migrator
 
+logger = logging.getLogger(__name__)
+
 
 def _file_contains(filename: str, string: str) -> bool:
     """Return whether the given file contains the given string."""
@@ -123,17 +125,17 @@ class AddNVIDIATools(Migrator):
 
         # STEP 1: Add cf-nvidia-tools to build requirements
         if _file_contains(meta, "cf-nvidia-tools"):
-            logging.debug("cf-nvidia-tools already in meta.yaml; not adding again.")
+            logger.debug("cf-nvidia-tools already in meta.yaml; not adding again.")
         else:
             if _insert_subsection(
                 meta,
                 "requirements",
                 "build",
-                "    - cf-nvidia-tools 1  # [linux]\n",
+                ["    - cf-nvidia-tools 1  # [linux]\n"],
             ):
-                logging.debug("cf-nvidia-tools added to meta.yaml.")
+                logger.debug("cf-nvidia-tools added to meta.yaml.")
             else:
-                logging.warning(
+                logger.warning(
                     "cf-nvidia-tools migration failed to add cf-nvidia-tools to meta.yaml. Manual migration required."
                 )
 
@@ -141,30 +143,28 @@ class AddNVIDIATools(Migrator):
         build = os.path.join(recipe_dir, "build.sh")
         if os.path.isfile(build):
             if _file_contains(build, "check-glibc"):
-                logging.debug(
-                    "build.sh already contains check-glibc; not adding again."
-                )
+                logger.debug("build.sh already contains check-glibc; not adding again.")
             else:
                 with open(build, "a") as file:
                     file.write(
                         '\ncheck-glibc "$PREFIX"/lib*/*.so.* "$PREFIX"/bin/* "$PREFIX"/targets/*/lib*/*.so.* "$PREFIX"/targets/*/bin/*\n'
                     )
-                logging.debug("Added check-glibc to build.sh")
+                logger.debug("Added check-glibc to build.sh")
         else:
             if _file_contains(meta, "check-glibc"):
-                logging.debug(
+                logger.debug(
                     "meta.yaml already contains check-glibc; not adding again."
                 )
             else:
                 if _insert_subsection(
                     meta,
+                    "requirements",
                     "build",
-                    "script",
-                    '    - check-glibc "$PREFIX"/lib*/*.so.* "$PREFIX"/bin/* "$PREFIX"/targets/*/lib*/*.so.* "$PREFIX"/targets/*/bin/*  # [linux]\n',
+                    ["    - check-glibc  # [linux]\n"],
                 ):
-                    logging.debug("Added check-glibc to meta.yaml")
+                    logger.debug("Added check-glibc to meta.yaml")
                 else:
-                    logging.warning(
+                    logger.warning(
                         "cf-nvidia-tools migration failed to add check-glibc to meta.yaml. Manual migration required."
                     )
 

--- a/conda_forge_tick/migrators/pip_wheel_dep.py
+++ b/conda_forge_tick/migrators/pip_wheel_dep.py
@@ -71,7 +71,7 @@ class PipWheelMigrator(MiniMigrator):
             return True
 
         version: str = self._get_version(attrs)
-        logger.debug(f"Checking if PyPI has a wheel for {version}")
+        logger.debug("Checking if PyPI has a wheel for %s", version)
         wheel_url, _ = self.determine_wheel(source_url, version)
 
         if wheel_url is None:

--- a/conda_forge_tick/migrators/staticlib.py
+++ b/conda_forge_tick/migrators/staticlib.py
@@ -478,7 +478,7 @@ class StaticLibMigrator(GraphMigrator):
                 platform_arches=platform_arches,
                 raw_meta_yaml=payload.get("raw_meta_yaml") or "",
             )[0]:
-                logger.debug("not yet built for new static libs: %s" % node)
+                logger.debug("not yet built for new static libs: %s", node)
                 return True
 
         return False

--- a/conda_forge_tick/provide_source_code.py
+++ b/conda_forge_tick/provide_source_code.py
@@ -75,9 +75,11 @@ def provide_source_code_containerized(recipe_dir):
 
         chmod_plus_rwX(tmpdir)
 
-        logger.debug(f"host recipe dir {recipe_dir}: {os.listdir(recipe_dir)}")
+        logger.debug("host recipe dir %s: %s", recipe_dir, os.listdir(recipe_dir))
         logger.debug(
-            f"copied host recipe dir {tmp_recipe_dir}: {os.listdir(tmp_recipe_dir)}"
+            "copied host recipe dir %s: %s",
+            tmp_recipe_dir,
+            os.listdir(tmp_recipe_dir),
         )
 
         tmp_source_dir = os.path.join(tmpdir, "source_dir")

--- a/conda_forge_tick/solver_checks.py
+++ b/conda_forge_tick/solver_checks.py
@@ -71,8 +71,9 @@ def is_recipe_solvable(
             str(logging.getLevelName(logger.getEffectiveLevel())).upper()
         )
         logger.debug(
-            f"is_recipe_solver log-level={logging.getLevelName(logger.getEffectiveLevel())}"
-            f" -> verbosity={verbosity}"
+            "is_recipe_solver log-level=%i -> verbosity=%i",
+            logging.getLevelName(logger.getEffectiveLevel()),
+            verbosity,
         )
 
     if should_use_container(use_container=use_container):
@@ -133,9 +134,13 @@ def _is_recipe_solvable_containerized(
             feedstock_dir, tmp_feedstock_dir, ignore_dot_git=True, update_git=False
         )
 
-        logger.debug(f"host feedstock dir {feedstock_dir}: {os.listdir(feedstock_dir)}")
         logger.debug(
-            f"copied host feedstock dir {tmp_feedstock_dir}: {os.listdir(tmp_feedstock_dir)}"
+            "host feedstock dir %s: %s", feedstock_dir, os.listdir(feedstock_dir)
+        )
+        logger.debug(
+            "copied host feedstock dir %s: %s",
+            tmp_feedstock_dir,
+            os.listdir(tmp_feedstock_dir),
         )
 
         data = run_container_operation(

--- a/conda_forge_tick/update_prs.py
+++ b/conda_forge_tick/update_prs.py
@@ -118,23 +118,22 @@ def _update_pr(update_function, dry_run, gx, job, n_jobs):
                     with pr_json as attrs:
                         attrs.update(**res)
             except (github3.GitHubError, github.GithubException) as e:
-                logger.error(f"GITHUB ERROR ON FEEDSTOCK: {name}")
+                logger.error("GITHUB ERROR ON FEEDSTOCK: %s", name)
                 failed_refresh += 1
                 if is_github_api_limit_reached():
                     logger.warning("GitHub API error", exc_info=e)
                     break
             except (github3.exceptions.ConnectionError, github.GithubException):
-                logger.error(f"GITHUB ERROR ON FEEDSTOCK: {name}")
+                logger.error("GITHUB ERROR ON FEEDSTOCK: %s", name)
                 failed_refresh += 1
             except Exception:
                 import traceback
 
                 logger.critical(
-                    "ERROR ON FEEDSTOCK: {}: {} - {}".format(
-                        name,
-                        gx.nodes[name]["payload"]["pr_info"]["PRed"][i],
-                        traceback.format_exc(),
-                    ),
+                    "ERROR ON FEEDSTOCK: %s: %s - %s",
+                    name,
+                    gx.nodes[name]["payload"]["pr_info"]["PRed"][i],
+                    traceback.format_exc(),
                 )
                 raise
 
@@ -151,8 +150,8 @@ def update_pr_combined(
         _combined_update_function, dry_run, gx, job, n_jobs
     )
 
-    logger.info(f"JSON Refresh failed for {failed_refresh} PRs")
-    logger.info(f"JSON Refresh succeed for {succeeded_refresh} PRs")
+    logger.info("JSON Refresh failed for %i PRs", failed_refresh)
+    logger.info("JSON Refresh succeed for %i PRs", succeeded_refresh)
     return gx
 
 

--- a/conda_forge_tick/update_recipe/version.py
+++ b/conda_forge_tick/update_recipe/version.py
@@ -642,9 +642,13 @@ def _update_version_feedstock_dir_containerized(feedstock_dir, version, hash_typ
 
         chmod_plus_rwX(tmpdir, recursive=True)
 
-        logger.debug(f"host feedstock dir {feedstock_dir}: {os.listdir(feedstock_dir)}")
         logger.debug(
-            f"copied host feedstock dir {tmp_feedstock_dir}: {os.listdir(tmp_feedstock_dir)}"
+            "host feedstock dir %s: %s", feedstock_dir, os.listdir(feedstock_dir)
+        )
+        logger.debug(
+            "copied host feedstock dir %s: %s",
+            tmp_feedstock_dir,
+            os.listdir(tmp_feedstock_dir),
         )
 
         args = [

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -247,7 +247,7 @@ class CRAN(AbstractSource):
                 CRAN_INDEX = self._get_cran_index(session)
                 logger.debug("Cran source initialized")
             except Exception:
-                logger.error("Cran initialization failed", exc_info=True)
+                logger.exception("Cran initialization failed")
                 CRAN_INDEX = {}
 
     def _get_cran_index(self, session: requests.Session) -> dict:
@@ -332,7 +332,7 @@ class ROSDistro(AbstractSource):
                 ROS_DISTRO_INDEX = self.parse_idx("melodic")
                 logger.info("ROS Distro source initialized")
             except Exception:
-                logger.error("ROS Distro initialization failed", exc_info=True)
+                logger.exception("ROS Distro initialization failed")
                 ROS_DISTRO_INDEX = {}
 
     def get_url(self, meta_yaml: "RecipeTypedDict") -> Optional[str]:
@@ -565,7 +565,7 @@ class Github(VersionFromFeed):
         self.version_prefix = self.get_version_prefix(version, split_url)
         if self.version_prefix is None:
             return
-        logger.debug(f"Found version prefix from url: {self.version_prefix}")
+        logger.debug("Found version prefix from url: %s", self.version_prefix)
         self.ver_prefix_remove = [self.version_prefix] + self.ver_prefix_remove
 
     def get_version_prefix(self, version: str, split_url: list[str]):

--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -123,19 +123,25 @@ def get_latest_version_local(
                     break
             else:
                 logger.warning(
-                    f"Package {name} requests version source '{vs}' which is not available. Skipping.",
+                    "Package %s requests version source '%s' which is not available. Skipping.",
+                    name,
+                    vs,
                 )
 
         sources_to_use = sources_to_use_list
 
         logger.debug(
-            f"{name} defines the following custom version sources: {[source.name for source in sources_to_use]}",
+            "%s defines the following custom version sources: %s",
+            name,
+            [source.name for source in sources_to_use],
         )
         skipped_sources = [
             source.name for source in sources if source not in sources_to_use
         ]
         if skipped_sources:
-            logger.debug(f"Therefore, we skip the following sources: {skipped_sources}")
+            logger.debug(
+                "Therefore, we skip the following sources: %s", skipped_sources
+            )
         else:
             logger.debug("No sources are skipped.")
 
@@ -145,21 +151,24 @@ def get_latest_version_local(
     exceptions = []
     for source in sources_to_use:
         try:
-            logger.debug(f"Fetching latest version for {name} from {source.name}...")
+            logger.debug("Fetching latest version for %s from %s...", name, source.name)
             url = source.get_url(attrs)
             if url is None:
                 continue
-            logger.debug(f"Using URL {url}")
+            logger.debug("Using URL %s", url)
             ver = source.get_version(url)
             if not ver:
-                logger.debug(f"Upstream: Could not find version on {source.name}")
+                logger.debug("Upstream: Could not find version on %s", source.name)
                 continue
-            logger.debug(f"Found version {ver} on {source.name}")
+            logger.debug("Found version %s on %s", ver, source.name)
             version_data["new_version"] = ver
             break
         except Exception as e:
             logger.error(
-                f"An exception occurred while fetching {name} from {source.name}: {e}",
+                "An exception occurred while fetching %s from %s.",
+                name,
+                source.name,
+                exc_info=e,
             )
             exceptions.append(e)
 
@@ -177,7 +186,7 @@ def get_latest_version_local(
 
     if ignore_version(attrs, new_version):
         logger.debug(
-            f"Ignoring version {new_version} because it is in the exclude list.",
+            "Ignoring version %s because it is in the exclude list.", new_version
         )
         version_data["new_version"] = False
 
@@ -290,30 +299,31 @@ def include_node(package_name: str, payload_attrs: Mapping) -> bool:
 
     if payload_attrs.get("parsing_error"):
         logger.debug(
-            f"Skipping {package_name} because it is marked as having a parsing error. The error is printed below.\n"
-            f"{payload_attrs['parsing_error']}",
+            "Skipping %s because it is marked as having a parsing error. The error is printed below.\n%s",
+            package_name,
+            payload_attrs["parsing_error"],
         )
         return False
 
     if payload_attrs.get("archived"):
-        logger.debug(
-            f"Skipping {package_name} because it is marked as archived.",
-        )
+        logger.debug("Skipping %s because it is marked as archived.", package_name)
         return False
 
     if pr_info.get("bad") and "Upstream" not in pr_info.get("bad"):
         logger.debug(
-            f"Skipping {package_name} because its corresponding Pull Request is "
-            f"marked as bad with a non-upstream issue. The error is printed below.\n"
-            f"{pr_info['bad']}",
+            "Skipping %s because its corresponding Pull Request is "
+            "marked as bad with a non-upstream issue. The error is printed below.\n%s",
+            package_name,
+            pr_info["bad"],
         )
         return False
 
     if pr_info.get("bad"):
         logger.debug(
-            f"Note: {package_name} has a bad Pull Request, but this is marked as an upstream issue. "
-            f"Therefore, it will be included in the update process. The error is printed below.\n"
-            f"{pr_info['bad']}",
+            "Note: %s has a bad Pull Request, but this is marked as an upstream issue. "
+            "Therefore, it will be included in the update process. The error is printed below.\n%s",
+            package_name,
+            pr_info["bad"],
         )
         # no return here
 
@@ -338,12 +348,17 @@ def _update_upstream_versions_sequential(
                 se = repr(e)
             except Exception as ee:
                 se = f"Bad exception string: {ee}"
-            logger.warning(f"Warning: Error getting upstream version of {node}: {se}")
+            logger.warning(
+                "Warning: Error getting upstream version of %s: %s", node, se
+            )
             version_data["bad"] = "Upstream: Error getting upstream version"
         else:
             logger.info(
-                f"# {node_count:<5} - {node} - {attrs.get('version')} "
-                f"-> {version_data.get('new_version')}",
+                "# %-5s - %s - %s -> %s",
+                node_count,
+                node,
+                attrs.get("version"),
+                version_data.get("new_version"),
             )
 
         logger.debug("writing out file")
@@ -399,21 +414,21 @@ def _update_upstream_versions_process_pool(
                 except Exception as ee:
                     se = f"Bad exception string: {ee}"
                 logger.error(
-                    "itr % 5d - eta % 5ds: "
-                    "Error getting upstream version of %s: %s"
-                    % (n_left, eta, node, se),
+                    "itr % 5d - eta % 5ds: Error getting upstream version of %s: %s",
+                    n_left,
+                    eta,
+                    node,
+                    se,
                 )
                 version_data["bad"] = "Upstream: Error getting upstream version"
             else:
                 logger.info(
-                    "itr % 5d - eta % 5ds: %s - %s -> %s"
-                    % (
-                        n_left,
-                        eta,
-                        node,
-                        attrs.get("version", "<no-version>"),
-                        version_data["new_version"],
-                    ),
+                    "itr % 5d - eta % 5ds: %s - %s -> %s",
+                    n_left,
+                    eta,
+                    node,
+                    attrs.get("version", "<no-version>"),
+                    version_data["new_version"],
                 )
             # writing out file
             lazyjson = LazyJson(f"versions/{node}.json")
@@ -456,7 +471,7 @@ def update_upstream_versions(
     :param package: The package to update. If None, update all packages.
     """
     if package and package not in gx.nodes:
-        logger.error(f"Package {package} not found in graph. Exiting.")
+        logger.error("Package %s not found in graph. Exiting.", package)
         return
 
     # In the future, we should have some sort of typed graph structure
@@ -467,7 +482,7 @@ def update_upstream_versions(
     job_nodes = filter_nodes_for_job(all_nodes, job, n_jobs)
 
     if not job_nodes:
-        logger.info(f"No packages to update for job {job}")
+        logger.info("No packages to update for job %i", job)
         return
 
     def extract_payload(node: Tuple[str, Mapping[str, Mapping]]) -> Tuple[str, Mapping]:

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -990,12 +990,10 @@ def _parse_meta_yaml_impl(
 
             def _run_parsing():
                 logger.debug(
-                    "parsing for platform %s with cbc %s and arch %s"
-                    % (
-                        platform,
-                        cbc_path,
-                        arch,
-                    ),
+                    "parsing for platform %s with cbc %s and arch %s",
+                    platform,
+                    cbc_path,
+                    arch,
                 )
                 config = conda_build.config.get_or_merge_config(
                     None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ write_to_template = "__version__ = '{version}'\n"
 extend-exclude = ["conda_forge_tick/migrators/disabled/legacy.py"]
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "W"]
+select = ["E", "F", "I", "W", "LOG", "G"]
 ignore = ["E501"]
 preview = true
 


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

Thorughout the code, we use different logging styles: `logger.log(f"a: {a}")` (f-string), and `logger.log("a: %s", a)`. In a previous discussion with Jaime, we agreed upon using the latter style because it allows deferred evaluation of arguments.

This PR introduces the ruff rulesets `LOG` and `G` to enforce a consistent style. 

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
