### PR TITLE
feat: optionally turn off remaking dirty PRs

### DIFF
--- a/conda_forge_tick/cf_tick_schema.json
+++ b/conda_forge_tick/cf_tick_schema.json
@@ -201,6 +201,19 @@
       "default": false,
       "description": "Update packages in `host` that are used for static linking. For bot to issue update PRs, you must have both an abstract specification of the library (e.g., `llvmdev 15.0.*`) and a concrete specification (e.g., `llvmdev 15.0.7 *_5`). The bot will find the latest package that satisfies the abstract specification and update the concrete specification to this latest package.",
       "title": "Update Static Libs"
+    },
+    "remake_prs_with_conflicts": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": true,
+      "description": "Automatically remake untouched bot PRs with conflicts.",
+      "title": "Remake Prs With Conflicts"
     }
   },
   "title": "BotConfig",

--- a/conda_forge_tick/config_schema.py
+++ b/conda_forge_tick/config_schema.py
@@ -192,6 +192,11 @@ class BotConfig(BaseModel):
         "latest package.",
     )
 
+    remake_prs_with_conflicts: Optional[bool] = Field(
+        default=True,
+        description="Automatically remake untouched bot PRs with conflicts.",
+    )
+
 
 if __name__ == "__main__":
     # This is used to generate the model dump for conda-smithy internal use

--- a/conda_forge_tick/events/pr_events.py
+++ b/conda_forge_tick/events/pr_events.py
@@ -3,6 +3,7 @@ import copy
 from conda_forge_tick.git_utils import (
     close_out_dirty_prs,
     close_out_labels,
+    get_keys_default,
     refresh_pr,
 )
 from conda_forge_tick.lazy_json_backends import (
@@ -11,11 +12,26 @@ from conda_forge_tick.lazy_json_backends import (
 )
 
 
+def _backout_node_from_html_url(html_url):
+    """Get the node name from a URL like `https://github.com/conda-forge/pygraphblas-feedstock/pull/17`."""
+    return html_url.split("/conda-forge/")[1].split("/")[0].rsplit("-", maxsplit=1)[0]
+
+
 def _react_to_pr(uid: str, dry_run: bool = False) -> None:
     with lazy_json_override_backends(["github_api"], use_file_cache=False):
         pr_json = LazyJson(f"pr_json/{uid}.json")
 
         with pr_json:
+            if pr_json.get("html_url", None) is not None:
+                node_name = _backout_node_from_html_url(pr_json.get("html_url", None))
+                node = LazyJson(f"node_attrs/{node_name}.json")
+                remake_prs_with_conflicts = get_keys_default(
+                    node,
+                    ["conda-forge.yml", "bot", "remake_prs_with_conflicts"],
+                    {},
+                    True,
+                )
+
             if pr_json.get("state", None) != "closed":
                 pr_data = refresh_pr(copy.deepcopy(pr_json.data), dry_run=dry_run)
                 if pr_data is not None:
@@ -38,29 +54,30 @@ def _react_to_pr(uid: str, dry_run: bool = False) -> None:
                         print("closed PR due to bot-rerun label", flush=True)
                     pr_json.update(pr_data)
 
-            if pr_json.get("state", None) != "closed":
-                pr_data = refresh_pr(copy.deepcopy(pr_json.data), dry_run=dry_run)
-                if pr_data is not None:
-                    if (
-                        "Last-Modified" in pr_json
-                        and "Last-Modified" in pr_data
-                        and pr_json["Last-Modified"] != pr_data["Last-Modified"]
-                    ):
-                        print("refreshed PR data", flush=True)
-                    pr_json.update(pr_data)
+            if remake_prs_with_conflicts:
+                if pr_json.get("state", None) != "closed":
+                    pr_data = refresh_pr(copy.deepcopy(pr_json.data), dry_run=dry_run)
+                    if pr_data is not None:
+                        if (
+                            "Last-Modified" in pr_json
+                            and "Last-Modified" in pr_data
+                            and pr_json["Last-Modified"] != pr_data["Last-Modified"]
+                        ):
+                            print("refreshed PR data", flush=True)
+                        pr_json.update(pr_data)
 
-            if pr_json.get("state", None) != "closed":
-                pr_data = close_out_dirty_prs(
-                    copy.deepcopy(pr_json.data), dry_run=dry_run
-                )
-                if pr_data is not None:
-                    if (
-                        "Last-Modified" in pr_json
-                        and "Last-Modified" in pr_data
-                        and pr_json["Last-Modified"] != pr_data["Last-Modified"]
-                    ):
-                        print("closed PR due to merge conflicts", flush=True)
-                    pr_json.update(pr_data)
+                if pr_json.get("state", None) != "closed":
+                    pr_data = close_out_dirty_prs(
+                        copy.deepcopy(pr_json.data), dry_run=dry_run
+                    )
+                    if pr_data is not None:
+                        if (
+                            "Last-Modified" in pr_json
+                            and "Last-Modified" in pr_data
+                            and pr_json["Last-Modified"] != pr_data["Last-Modified"]
+                        ):
+                            print("closed PR due to merge conflicts", flush=True)
+                        pr_json.update(pr_data)
 
 
 def react_to_pr(uid: str, dry_run: bool = False) -> None:

--- a/conda_forge_tick/events/pr_events.py
+++ b/conda_forge_tick/events/pr_events.py
@@ -3,13 +3,13 @@ import copy
 from conda_forge_tick.git_utils import (
     close_out_dirty_prs,
     close_out_labels,
-    get_keys_default,
     refresh_pr,
 )
 from conda_forge_tick.lazy_json_backends import (
     LazyJson,
     lazy_json_override_backends,
 )
+from conda_forge_tick.utils import get_keys_default
 
 
 def _backout_node_from_html_url(html_url):

--- a/conda_forge_tick/events/pr_events.py
+++ b/conda_forge_tick/events/pr_events.py
@@ -31,6 +31,8 @@ def _react_to_pr(uid: str, dry_run: bool = False) -> None:
                     {},
                     True,
                 )
+            else:
+                remake_prs_with_conflicts = True
 
             if pr_json.get("state", None) != "closed":
                 pr_data = refresh_pr(copy.deepcopy(pr_json.data), dry_run=dry_run)

--- a/conda_forge_tick/update_prs.py
+++ b/conda_forge_tick/update_prs.py
@@ -13,10 +13,10 @@ from conda_forge_tick.cli_context import CliContext
 from conda_forge_tick.git_utils import (
     close_out_dirty_prs,
     close_out_labels,
-    get_keys_default,
     is_github_api_limit_reached,
     refresh_pr,
 )
+from conda_forge_tick.utils import get_keys_default
 
 from .executors import executor
 from .utils import load_existing_graph


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR adds a bot option `remake_prs_with_conflicts` that can be set to `False` to optionally turn off remaking PRs with conflicts.

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

Closes #4300 
