### PR TITLE
fix: use heuristic to prefer correct versions for feedstocks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,6 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.2
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [ --fix ]
       - id: ruff-format

--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -513,11 +513,11 @@ def populate_feedstock_attributes(
     node_attrs["req"] = req
 
     # set name and version
-    keys = [("package", "name"), ("package", "version")]
-    missing_keys = [k[1] for k in keys if k[1] not in yaml_dict.get(k[0], {})]
-    for k in keys:
-        if k[1] not in missing_keys:
-            node_attrs[k[1]] = yaml_dict[k[0]][k[1]]
+    for subkey in ["name", "version"]:
+        for topkey in ["package", "recipe"]:
+            if topkey in yaml_dict and subkey in yaml_dict[topkey]:
+                node_attrs[subkey] = yaml_dict[topkey][subkey]
+                break
 
     # sometimes a version is not given at the top level, so we check outputs
     # we do not know which version to take, but hopefully they are all the same

--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -513,11 +513,11 @@ def populate_feedstock_attributes(
     node_attrs["req"] = req
 
     # set name and version
-    for subkey in ["name", "version"]:
-        for topkey in ["package", "recipe"]:
-            if topkey in yaml_dict and subkey in yaml_dict[topkey]:
-                node_attrs[subkey] = yaml_dict[topkey][subkey]
-                break
+    keys = [("package", "name"), ("package", "version")]
+    missing_keys = [k[1] for k in keys if k[1] not in yaml_dict.get(k[0], {})]
+    for k in keys:
+        if k[1] not in missing_keys:
+            node_attrs[k[1]] = yaml_dict[k[0]][k[1]]
 
     # sometimes a version is not given at the top level, so we check outputs
     # we do not know which version to take, but hopefully they are all the same

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -536,6 +536,39 @@ def _parse_recipes(
     RecipeTypedDict
         A dict conforming to conda-build's rendered output
     """
+    # some heuristics to find the "top-level" name and version
+    # we use these in the following order
+    # 1. Does the output name match the "name" field in the context block
+    #    if present?
+    # 2. Does the output version match the "version" field in the
+    #    context block if present?
+    # 3. Does the output name match the feedstock-name in the extra
+    #    field if present?
+    if len(validated_recipes) > 0:
+        if "name" in validated_recipes[0].get("context", {}):
+            sval = validated_recipes[0]["context"]["name"]
+            skey = "name"
+        elif "version" in validated_recipes[0].get("context", {}):
+            sval = str(validated_recipes[0]["context"]["version"])
+            skey = "version"
+        elif "feedstock-name" in validated_recipes[0].get("extra", {}):
+            sval = validated_recipes[0]["extra"]["feedstock-name"]
+            skey = "name"
+
+        else:
+            sval = None
+            skey = None
+
+        if sval is not None and skey is not None:
+            sind = None
+            for ind, recipe in enumerate(validated_recipes):
+                if recipe.get("package", {}).get(skey, "") == sval:
+                    sind = ind
+                    break
+            if sind is not None:
+                first = validated_recipes.pop(sind)
+                validated_recipes = [first] + validated_recipes
+
     first = validated_recipes[0]
     about = first["about"]
     build = first["build"]
@@ -622,6 +655,9 @@ def _parse_recipes(
         output_data.append(
             {
                 "name": None if package_output is None else package_output.get("name"),
+                "version": None
+                if package_output is None
+                else package_output.get("version"),
                 "requirements": requirements_output_data,
                 "build": build_output_data,
                 "tests": recipe.get("tests", []),

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -554,7 +554,6 @@ def _parse_recipes(
         elif "feedstock-name" in validated_recipes[0].get("extra", {}):
             sval = validated_recipes[0]["extra"]["feedstock-name"]
             skey = "name"
-
         else:
             sval = None
             skey = None

--- a/tests/test_feedstock_parser.py
+++ b/tests/test_feedstock_parser.py
@@ -105,3 +105,14 @@ def test_feedstock_parser_load_feedstock_local_semi_ate_stdf():
     )
     assert attrs["feedstock_name"] == "semi-ate-stdf"
     assert "parsing_error" in attrs
+
+
+def test_feedstock_parser_load_feedstock_local_fenics_basix_version():
+    attrs = load_feedstock_local(
+        "fenics-basix",
+        {},
+    )
+    assert attrs["feedstock_name"] == "fenics-basix"
+    assert attrs["version"] == attrs["meta_yaml"]["outputs"][0]["version"]
+    assert attrs["name"] == attrs["meta_yaml"]["outputs"][0]["name"]
+    assert attrs["name"] == "fenics-basix"


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

For fenics-basix, the ordering of the outputs from rattler-build was causing us to grab the wrong version. It is really hard for the bot know which output has the preferred version. This PR adds some heuristics based on feedstock names and how context variables are set. That should help.

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
