### PR TITLE
Add support for ignoring odd minor versions

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -1221,19 +1221,29 @@ def _update_nodes_with_bot_rerun(gx: nx.DiGraph):
 
 
 def _filter_ignored_versions(attrs, version):
-    versions_to_ignore = get_keys_default(
+    version_updates = get_keys_default(
         attrs,
-        ["conda-forge.yml", "bot", "version_updates", "exclude"],
+        ["conda-forge.yml", "bot", "version_updates"],
         {},
-        [],
+        {},
     )
-    if (
-        str(version).replace("-", ".") in versions_to_ignore
-        or str(version) in versions_to_ignore
-    ):
+
+    version_str = str(version)
+    normalized_version = version_str.replace("-", ".").replace("_", ".")
+
+    versions_to_ignore = version_updates.get("exclude", [])
+    if normalized_version in versions_to_ignore or version_str in versions_to_ignore:
         return False
-    else:
-        return version
+
+    if version_updates.get("even_odd_versions", False):
+        try:
+            version_parts = normalized_version.split(".")
+            if len(version_parts) >= 2 and int(version_parts[1]) % 2 == 1:
+                return False
+        except ValueError:
+            pass
+
+    return version
 
 
 def _update_nodes_with_new_versions(gx):

--- a/conda_forge_tick/cf_tick_schema.json
+++ b/conda_forge_tick/cf_tick_schema.json
@@ -83,6 +83,19 @@
           "default": false,
           "description": "Skip automatic version updates. Useful in cases where the source project's version numbers don't conform to PEP440.",
           "title": "Skip"
+        },
+        "even_odd_versions": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "For projects that follow even/odd versioning schemes (like GNOME), set to true to only accept stable versions (even minor numbers: 1.2.x, 1.4.x) and ignore development versions (odd minor numbers: 1.1.x, 1.3.x). Leave unset for projects that don't follow this versioning scheme.",
+          "title": "Even Odd Versions"
         }
       },
       "title": "BotConfigVersionUpdates",
@@ -106,7 +119,7 @@
     }
   },
   "additionalProperties": false,
-  "description": "Dictates the behavior of the conda-forge auto-tick bot which issues\nautomatic version updates/migrations for feedstocks.\n\nA valid example is:\n\n```yaml\nbot:\n    # can the bot automerge PRs it makes on this feedstock\n    automerge: true\n    # only automerge on successful version PRs, migrations are not automerged\n    automerge: 'version'\n    # only automerge on successful migration PRs, versions are not automerged\n    automerge: 'migration'\n\n    # only open PRs if resulting environment is solvable, useful for tightly coupled packages\n    check_solvable: true\n\n    # The bot.inspection key in the conda-forge.yml can have one of seven possible values and controls\n    # the bots behaviour for automatic dependency updates:\n    inspection: hint  # generate hints using source code (backwards compatible)\n    inspection: hint-all  # generate hints using all methods\n    inspection: hint-source  # generate hints using only source code\n    inspection: hint-grayskull  # generate hints using only grayskull\n    inspection: update-all  # update recipe using all methods\n    inspection: update-source  # update recipe using only source code\n    inspection: update-grayskull  # update recipe using only grayskull\n    inspection: disabled # don't update recipe, don't generate hints\n\n    # any branches listed in this section will get bot migration PRs in addition\n    # to the default branch\n    abi_migration_branches:\n        - 'v1.10.x'\n\n    version_updates:\n        # use this for packages that are updated too frequently\n        random_fraction_to_keep: 0.1  # keeps 10% of versions at random\n        exclude:\n            - '08.14'\n```\n\nThe `abi_migration_branches` feature is useful to, for example, add a\nlong-term support (LTS) branch for a package.",
+  "description": "Dictates the behavior of the conda-forge auto-tick bot which issues\nautomatic version updates/migrations for feedstocks.\n\nA valid example is:\n\n```yaml\nbot:\n    # can the bot automerge PRs it makes on this feedstock\n    automerge: true\n    # only automerge on successful version PRs, migrations are not automerged\n    automerge: 'version'\n    # only automerge on successful migration PRs, versions are not automerged\n    automerge: 'migration'\n\n    # only open PRs if resulting environment is solvable, useful for tightly coupled packages\n    check_solvable: true\n\n    # The bot.inspection key in the conda-forge.yml can have one of seven possible values and controls\n    # the bots behaviour for automatic dependency updates:\n    inspection: hint  # generate hints using source code (backwards compatible)\n    inspection: hint-all  # generate hints using all methods\n    inspection: hint-source  # generate hints using only source code\n    inspection: hint-grayskull  # generate hints using only grayskull\n    inspection: update-all  # update recipe using all methods\n    inspection: update-source  # update recipe using only source code\n    inspection: update-grayskull  # update recipe using only grayskull\n    inspection: disabled # don't update recipe, don't generate hints\n\n    # any branches listed in this section will get bot migration PRs in addition\n    # to the default branch\n    abi_migration_branches:\n        - 'v1.10.x'\n\n    version_updates:\n        # use this for packages that are updated too frequently\n        random_fraction_to_keep: 0.1  # keeps 10% of versions at random\n        exclude:\n            - '08.14'\n        # even/odd version filtering for unstable versions\n        even_odd_versions: true\n```\n\nThe `abi_migration_branches` feature is useful to, for example, add a\nlong-term support (LTS) branch for a package.",
   "properties": {
     "automerge": {
       "anyOf": [

--- a/conda_forge_tick/config_schema.py
+++ b/conda_forge_tick/config_schema.py
@@ -101,6 +101,14 @@ class BotConfigVersionUpdates(BaseModel):
         "PEP440.",
     )
 
+    even_odd_versions: Optional[bool] = Field(
+        default=None,
+        description="For projects that follow even/odd versioning schemes (like GNOME), "
+        "set to true to only accept stable versions (even minor numbers: 1.2.x, 1.4.x) "
+        "and ignore development versions (odd minor numbers: 1.1.x, 1.3.x). "
+        "Leave unset for projects that don't follow this versioning scheme.",
+    )
+
 
 class BotConfig(BaseModel):
     """
@@ -142,6 +150,8 @@ class BotConfig(BaseModel):
             random_fraction_to_keep: 0.1  # keeps 10% of versions at random
             exclude:
                 - '08.14'
+            # even/odd version filtering for unstable versions
+            even_odd_versions: true
     ```
 
     The `abi_migration_branches` feature is useful to, for example, add a

--- a/conda_forge_tick/migrators/version.py
+++ b/conda_forge_tick/migrators/version.py
@@ -23,6 +23,7 @@ from conda_forge_tick.utils import (
     get_recipe_schema_version,
     sanitize_string,
 )
+from conda_forge_tick.version_filters import is_version_ignored
 
 if typing.TYPE_CHECKING:
     from conda_forge_tick.migrators_types import (
@@ -236,20 +237,7 @@ class Version(Migrator):
             )
             return True
 
-        ignore_filter = False
-        versions_to_ignore = get_keys_default(
-            attrs,
-            ["conda-forge.yml", "bot", "version_updates", "exclude"],
-            {},
-            [],
-        )
-        if (
-            str(new_version).replace("-", ".") in versions_to_ignore
-            or str(new_version) in versions_to_ignore
-        ):
-            ignore_filter = True
-
-        if ignore_filter:
+        if is_version_ignored(attrs, str(new_version)):
             logger.debug(
                 "Skip due to ignored version %s for feedstock %s, skipping!",
                 new_version,
@@ -277,7 +265,6 @@ class Version(Migrator):
             or too_many_prs
             or version_filter
             or skip_filter
-            or ignore_filter
             or skip_me
         )
 

--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -17,7 +17,6 @@ import yaml
 from conda.models.version import VersionOrder
 from graphviz import Source
 
-from conda_forge_tick.auto_tick import _filter_ignored_versions
 from conda_forge_tick.contexts import FeedstockContext, MigratorSessionContext
 from conda_forge_tick.lazy_json_backends import LazyJson, get_all_keys_for_hashmap
 from conda_forge_tick.make_migrators import load_migrators
@@ -40,6 +39,7 @@ from conda_forge_tick.utils import (
     get_migrator_name,
     load_existing_graph,
 )
+from conda_forge_tick.version_filters import filter_version
 
 GH_MERGE_STATE_STATUS = [
     "behind",
@@ -89,11 +89,11 @@ def write_version_migrator_status(migrator, mctx):
                 continue
 
             with attrs["version_pr_info"] as vpri:
-                version_from_data = _filter_ignored_versions(
+                version_from_data = filter_version(
                     attrs,
                     version_data.get("new_version", False),
                 )
-                version_from_attrs = _filter_ignored_versions(
+                version_from_attrs = filter_version(
                     attrs,
                     vpri.get("new_version", False),
                 )

--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -73,15 +73,28 @@ def ignore_version(attrs: Mapping[str, Any], version: str) -> bool:
     bool
         True if the version should be ignored, False otherwise.
     """
-    versions_to_ignore = get_keys_default(
+    version_updates = get_keys_default(
         attrs,
-        ["conda-forge.yml", "bot", "version_updates", "exclude"],
+        ["conda-forge.yml", "bot", "version_updates"],
         {},
-        [],
+        {},
     )
-    return (
-        version.replace("-", ".") in versions_to_ignore or version in versions_to_ignore
-    )
+
+    normalized_version = version.replace("-", ".").replace("_", ".")
+
+    versions_to_ignore = version_updates.get("exclude", [])
+    if normalized_version in versions_to_ignore or version in versions_to_ignore:
+        return True
+
+    if version_updates.get("even_odd_versions", False):
+        try:
+            version_parts = normalized_version.split(".")
+            if len(version_parts) >= 2 and int(version_parts[1]) % 2 == 1:
+                return True
+        except ValueError:
+            pass
+
+    return False
 
 
 def get_latest_version_local(

--- a/conda_forge_tick/version_filters.py
+++ b/conda_forge_tick/version_filters.py
@@ -1,0 +1,81 @@
+"""Version filtering utilities for conda-forge bot.
+
+This module provides centralized logic for filtering versions based on
+various criteria configured in conda-forge.yml files.
+"""
+
+import logging
+from typing import Any, Mapping, Union
+
+from conda_forge_tick.utils import get_keys_default
+
+logger = logging.getLogger(__name__)
+
+
+def is_version_ignored(attrs: Mapping[str, Any], version: str) -> bool:
+    """Check if a version should be ignored based on the `conda-forge.yml` file.
+
+    It handles both explicit version exclusions and odd/even version filtering.
+
+    Parameters
+    ----------
+    attrs
+        The node attributes containing conda-forge.yml configuration.
+    version
+        The version string to check.
+
+    Returns
+    -------
+    bool
+        True if the version should be ignored, False otherwise.
+    """
+    version_updates = get_keys_default(
+        attrs,
+        ["conda-forge.yml", "bot", "version_updates"],
+        {},
+        {},
+    )
+
+    normalized_version = version.replace("-", ".").replace("_", ".")
+
+    versions_to_ignore = version_updates.get("exclude", [])
+    if normalized_version in versions_to_ignore or version in versions_to_ignore:
+        logger.debug("Version %s is explicitly excluded in conda-forge.yml", version)
+        return True
+
+    if version_updates.get("even_odd_versions", False):
+        try:
+            version_parts = normalized_version.split(".")
+            if len(version_parts) >= 2 and int(version_parts[1]) % 2 == 1:
+                logger.debug(
+                    "Version %s has odd minor version (%s) and even_odd_versions is enabled",
+                    version,
+                    version_parts[1],
+                )
+                return True
+        except (ValueError, IndexError):
+            logger.debug("Could not parse version %s for odd/even filtering", version)
+            pass
+
+    return False
+
+
+def filter_version(attrs: Mapping[str, Any], version) -> Union[str, bool]:
+    """Filter a version, returning False if ignored, version otherwise.
+
+    Parameters
+    ----------
+    attrs
+        The node attributes containing conda-forge.yml configuration.
+    version
+        The version to check (can be string, False, or other types).
+
+    Returns
+    -------
+    Union[str, bool]
+        False if the version should be ignored, the original version otherwise.
+    """
+    if version and is_version_ignored(attrs, str(version)):
+        return False
+    else:
+        return version

--- a/tests/test_upstream_versions.py
+++ b/tests/test_upstream_versions.py
@@ -391,6 +391,115 @@ def test_ignore_version_true(attrs, version):
 
 
 @pytest.mark.parametrize(
+    "version, even_odd_filtering, expected",
+    [
+        ("1.1.0", True, True),
+        ("1.2.0", True, False),
+        ("1.3.5", True, True),
+        ("1.4.1", True, False),
+        ("2.0.0", True, False),
+        ("2.1.0", True, True),
+        ("1.0.0", False, False),
+        ("1.1.0", False, False),
+        ("1.2.5", False, False),
+        ("1.3.1", False, False),
+        ("1.1-alpha", True, True),
+        ("1.2-beta", True, False),
+        ("1.3_rc1", True, True),
+        ("1.4_final", True, False),
+        ("1", True, False),
+        ("1.x", True, False),
+        ("invalid", True, False),
+    ],
+)
+def test_ignore_version_even_odd_filtering(version, even_odd_filtering, expected):
+    attrs = {
+        "conda-forge.yml": {
+            "bot": {"version_updates": {"even_odd_versions": even_odd_filtering}}
+        }
+    }
+    assert ignore_version(attrs, version) is expected
+
+
+@pytest.mark.parametrize(
+    "attrs, version, expected",
+    [
+        (
+            {
+                "conda-forge.yml": {
+                    "bot": {"version_updates": {"even_odd_versions": True}}
+                }
+            },
+            "1.1.0",
+            True,
+        ),
+        (
+            {
+                "conda-forge.yml": {
+                    "bot": {"version_updates": {"even_odd_versions": True}}
+                }
+            },
+            "1.2.0",
+            False,
+        ),
+        (
+            {
+                "conda-forge.yml": {
+                    "bot": {"version_updates": {"even_odd_versions": False}}
+                }
+            },
+            "1.1.0",
+            False,
+        ),
+        (
+            {
+                "conda-forge.yml": {
+                    "bot": {"version_updates": {"even_odd_versions": False}}
+                }
+            },
+            "1.2.0",
+            False,
+        ),
+        (
+            {
+                "conda-forge.yml": {
+                    "bot": {
+                        "version_updates": {
+                            "exclude": ["1.2.0"],
+                            "even_odd_versions": True,
+                        },
+                    },
+                },
+            },
+            "1.2.0",
+            True,
+        ),
+        (
+            {
+                "conda-forge.yml": {
+                    "bot": {
+                        "version_updates": {
+                            "exclude": ["1.3.0"],
+                            "even_odd_versions": True,
+                        },
+                    },
+                },
+            },
+            "1.1.0",
+            True,
+        ),
+        (
+            {"conda-forge.yml": {"bot": {"version_updates": {}}}},
+            "1.1.0",
+            False,
+        ),
+    ],
+)
+def test_ignore_version_even_odd_integration(attrs, version, expected):
+    assert ignore_version(attrs, version) is expected
+
+
+@pytest.mark.parametrize(
     "name, inp, curr_ver, ver, source, urls",
     latest_url_npm_test_list,
 )

--- a/tests/test_upstream_versions.py
+++ b/tests/test_upstream_versions.py
@@ -31,12 +31,12 @@ from conda_forge_tick.update_upstream_versions import (
     _update_upstream_versions_sequential,
     filter_nodes_for_job,
     get_latest_version,
-    ignore_version,
     include_node,
     main,
     update_upstream_versions,
 )
 from conda_forge_tick.utils import parse_meta_yaml
+from conda_forge_tick.version_filters import is_version_ignored
 
 YAML_PATH = os.path.join(os.path.dirname(__file__), "test_yaml")
 
@@ -346,157 +346,22 @@ latest_url_rawurl_test_list = [
 ]
 
 
-@pytest.mark.parametrize(
-    "attrs",
-    [
-        {"key": "value"},
-        {"conda-forge.yml": {"key": "value"}},
-        {"conda-forge.yml": {"bot": {"key": "value"}}},
-        {"conda-forge.yml": {"bot": {"version_updates": {"key": "value"}}}},
-        {"conda-forge.yml": {"bot": {"version_updates": {"exclude": []}}}},
-        {
-            "conda-forge.yml": {
-                "bot": {
-                    "version_updates": {
-                        "exclude": ["12.3", "1.23", "1.2", "2.3", "1.2.3.4"],
-                    },
-                },
-            },
-        },
-    ],
-)
-def test_ignore_version_false(attrs):
-    assert ignore_version(attrs, "1.2.3") is False
+def test_is_version_ignored():
+    """Test is_version_ignored."""
+    attrs_no_filter = {"conda-forge.yml": {"bot": {"version_updates": {}}}}
+    assert is_version_ignored(attrs_no_filter, "1.2.3") is False
 
-
-@pytest.mark.parametrize(
-    "attrs",
-    [
-        {"conda-forge.yml": {"bot": {"version_updates": {"exclude": ["1.2.3"]}}}},
-        {
-            "conda-forge.yml": {
-                "bot": {"version_updates": {"exclude": ["3.2.1", "1.2.3"]}},
-            },
-        },
-        {
-            "conda-forge.yml": {
-                "bot": {"version_updates": {"exclude": ["1.2.3", "3.2.1"]}},
-            },
-        },
-    ],
-)
-@pytest.mark.parametrize("version", ["1.2.3", "1.2-3"])
-def test_ignore_version_true(attrs, version):
-    assert ignore_version(attrs, version) is True
-
-
-@pytest.mark.parametrize(
-    "version, even_odd_filtering, expected",
-    [
-        ("1.1.0", True, True),
-        ("1.2.0", True, False),
-        ("1.3.5", True, True),
-        ("1.4.1", True, False),
-        ("2.0.0", True, False),
-        ("2.1.0", True, True),
-        ("1.0.0", False, False),
-        ("1.1.0", False, False),
-        ("1.2.5", False, False),
-        ("1.3.1", False, False),
-        ("1.1-alpha", True, True),
-        ("1.2-beta", True, False),
-        ("1.3_rc1", True, True),
-        ("1.4_final", True, False),
-        ("1", True, False),
-        ("1.x", True, False),
-        ("invalid", True, False),
-    ],
-)
-def test_ignore_version_even_odd_filtering(version, even_odd_filtering, expected):
-    attrs = {
-        "conda-forge.yml": {
-            "bot": {"version_updates": {"even_odd_versions": even_odd_filtering}}
-        }
+    attrs_exclude = {
+        "conda-forge.yml": {"bot": {"version_updates": {"exclude": ["1.2.3"]}}}
     }
-    assert ignore_version(attrs, version) is expected
+    assert is_version_ignored(attrs_exclude, "1.2.3") is True
+    assert is_version_ignored(attrs_exclude, "1.2.4") is False
 
-
-@pytest.mark.parametrize(
-    "attrs, version, expected",
-    [
-        (
-            {
-                "conda-forge.yml": {
-                    "bot": {"version_updates": {"even_odd_versions": True}}
-                }
-            },
-            "1.1.0",
-            True,
-        ),
-        (
-            {
-                "conda-forge.yml": {
-                    "bot": {"version_updates": {"even_odd_versions": True}}
-                }
-            },
-            "1.2.0",
-            False,
-        ),
-        (
-            {
-                "conda-forge.yml": {
-                    "bot": {"version_updates": {"even_odd_versions": False}}
-                }
-            },
-            "1.1.0",
-            False,
-        ),
-        (
-            {
-                "conda-forge.yml": {
-                    "bot": {"version_updates": {"even_odd_versions": False}}
-                }
-            },
-            "1.2.0",
-            False,
-        ),
-        (
-            {
-                "conda-forge.yml": {
-                    "bot": {
-                        "version_updates": {
-                            "exclude": ["1.2.0"],
-                            "even_odd_versions": True,
-                        },
-                    },
-                },
-            },
-            "1.2.0",
-            True,
-        ),
-        (
-            {
-                "conda-forge.yml": {
-                    "bot": {
-                        "version_updates": {
-                            "exclude": ["1.3.0"],
-                            "even_odd_versions": True,
-                        },
-                    },
-                },
-            },
-            "1.1.0",
-            True,
-        ),
-        (
-            {"conda-forge.yml": {"bot": {"version_updates": {}}}},
-            "1.1.0",
-            False,
-        ),
-    ],
-)
-def test_ignore_version_even_odd_integration(attrs, version, expected):
-    assert ignore_version(attrs, version) is expected
+    attrs_odd_even = {
+        "conda-forge.yml": {"bot": {"version_updates": {"even_odd_versions": True}}}
+    }
+    assert is_version_ignored(attrs_odd_even, "1.1.0") is True  # Odd minor
+    assert is_version_ignored(attrs_odd_even, "1.2.0") is False  # Even minor
 
 
 @pytest.mark.parametrize(
@@ -596,8 +461,8 @@ def test_latest_version_version_sources_no_error(caplog):
     source_b.get_version.return_value = "1.2.3"
 
     with patch(
-        "conda_forge_tick.update_upstream_versions.ignore_version", return_value=False
-    ) as ignore_version_mock:
+        "conda_forge_tick.version_filters.is_version_ignored", return_value=False
+    ) as is_version_ignored_mock:
         result = get_latest_version(
             "crazy-package",
             attrs,
@@ -626,7 +491,7 @@ def test_latest_version_version_sources_no_error(caplog):
     source_b.get_version.assert_called_once_with("https://source-b.com")
     assert "Found version 1.2.3 on Source b it Is" in caplog.text
 
-    ignore_version_mock.assert_called_once_with(attrs, "1.2.3")
+    is_version_ignored_mock.assert_called_once_with(attrs, "1.2.3")
 
     assert result == {"new_version": "1.2.3"}
 
@@ -645,7 +510,7 @@ def test_latest_version_skip_error_success(caplog):
     source_b.get_version.return_value = "1.2.3"
 
     with patch(
-        "conda_forge_tick.update_upstream_versions.ignore_version", return_value=False
+        "conda_forge_tick.version_filters.is_version_ignored", return_value=False
     ):
         result = get_latest_version(
             "crazy-package",
@@ -698,7 +563,7 @@ def test_latest_version_error_and_no_new_version(caplog):
     assert "Cannot find version on any source, exceptions occurred" in caplog.text
 
 
-def test_latest_version_ignore_version(caplog):
+def test_latest_version_is_version_ignored(caplog):
     caplog.set_level(logging.DEBUG)
 
     source_a = Mock(AbstractSource)
@@ -707,7 +572,7 @@ def test_latest_version_ignore_version(caplog):
     source_a.get_version.return_value = "1.2.3"
 
     with patch(
-        "conda_forge_tick.update_upstream_versions.ignore_version", return_value=True
+        "conda_forge_tick.version_filters.is_version_ignored", return_value=True
     ):
         result = get_latest_version(
             "crazy-package",

--- a/tests/test_upstream_versions.py
+++ b/tests/test_upstream_versions.py
@@ -461,7 +461,8 @@ def test_latest_version_version_sources_no_error(caplog):
     source_b.get_version.return_value = "1.2.3"
 
     with patch(
-        "conda_forge_tick.version_filters.is_version_ignored", return_value=False
+        "conda_forge_tick.update_upstream_versions.is_version_ignored",
+        return_value=False,
     ) as is_version_ignored_mock:
         result = get_latest_version(
             "crazy-package",
@@ -510,7 +511,8 @@ def test_latest_version_skip_error_success(caplog):
     source_b.get_version.return_value = "1.2.3"
 
     with patch(
-        "conda_forge_tick.version_filters.is_version_ignored", return_value=False
+        "conda_forge_tick.update_upstream_versions.is_version_ignored",
+        return_value=False,
     ):
         result = get_latest_version(
             "crazy-package",
@@ -572,7 +574,8 @@ def test_latest_version_is_version_ignored(caplog):
     source_a.get_version.return_value = "1.2.3"
 
     with patch(
-        "conda_forge_tick.version_filters.is_version_ignored", return_value=True
+        "conda_forge_tick.update_upstream_versions.is_version_ignored",
+        return_value=True,
     ):
         result = get_latest_version(
             "crazy-package",

--- a/tests/test_version_filters.py
+++ b/tests/test_version_filters.py
@@ -3,14 +3,14 @@
 from conda_forge_tick.version_filters import filter_version, is_version_ignored
 
 
-def test_no_filtering_config():
+def test_version_filters_no_filtering_config():
     """Test that versions are not ignored when no filtering is configured."""
     attrs = {"conda-forge.yml": {"bot": {"version_updates": {}}}}
     assert is_version_ignored(attrs, "1.2.3") is False
     assert is_version_ignored(attrs, "2.0.0") is False
 
 
-def test_explicit_exclusions():
+def test_version_filters_explicit_exclusions():
     """Test explicit version exclusions."""
     attrs = {
         "conda-forge.yml": {"bot": {"version_updates": {"exclude": ["1.2.3", "2.0.0"]}}}
@@ -20,7 +20,7 @@ def test_explicit_exclusions():
     assert is_version_ignored(attrs, "1.2.4") is False
 
 
-def test_normalized_version_exclusions():
+def test_version_filters_normalized_version_exclusions():
     """Test that version normalization works for exclusions."""
     attrs = {"conda-forge.yml": {"bot": {"version_updates": {"exclude": ["1.2.3"]}}}}
     # Test that dashes and underscores are normalized to dots
@@ -29,7 +29,7 @@ def test_normalized_version_exclusions():
     assert is_version_ignored(attrs, "1.2.3") is True
 
 
-def test_odd_even_filtering_disabled():
+def test_version_filters_odd_even_filtering_disabled():
     """Test that odd/even filtering is disabled by default."""
     attrs = {"conda-forge.yml": {"bot": {"version_updates": {}}}}
     # These have odd minor versions but should not be filtered
@@ -37,7 +37,7 @@ def test_odd_even_filtering_disabled():
     assert is_version_ignored(attrs, "2.3.5") is False
 
 
-def test_odd_even_filtering_enabled():
+def test_version_filters_odd_even_filtering_enabled():
     """Test odd/even version filtering when enabled."""
     attrs = {
         "conda-forge.yml": {"bot": {"version_updates": {"even_odd_versions": True}}}
@@ -53,7 +53,7 @@ def test_odd_even_filtering_enabled():
     assert is_version_ignored(attrs, "0.4.2") is False
 
 
-def test_odd_even_filtering_with_normalization():
+def test_version_filters_odd_even_filtering_with_normalization():
     """Test odd/even filtering with version normalization."""
     attrs = {
         "conda-forge.yml": {"bot": {"version_updates": {"even_odd_versions": True}}}
@@ -64,7 +64,7 @@ def test_odd_even_filtering_with_normalization():
     assert is_version_ignored(attrs, "2-2-0") is False
 
 
-def test_odd_even_filtering_invalid_version():
+def test_version_filters_odd_even_filtering_invalid_version():
     """Test that invalid versions don't cause errors in odd/even filtering."""
     attrs = {
         "conda-forge.yml": {"bot": {"version_updates": {"even_odd_versions": True}}}
@@ -75,7 +75,7 @@ def test_odd_even_filtering_invalid_version():
     assert is_version_ignored(attrs, "1.a.0") is False  # Non-numeric minor
 
 
-def test_combined_filtering():
+def test_version_filters_combined_filtering():
     """Test that both exclusions and odd/even filtering work together."""
     attrs = {
         "conda-forge.yml": {
@@ -92,14 +92,14 @@ def test_combined_filtering():
     assert is_version_ignored(attrs, "1.2.0") is False
 
 
-def test_empty_attrs():
+def test_version_filters_empty_attrs():
     """Test behavior with empty or missing attributes."""
     assert is_version_ignored({}, "1.2.3") is False
     assert is_version_ignored({"conda-forge.yml": {}}, "1.2.3") is False
     assert is_version_ignored({"conda-forge.yml": {"bot": {}}}, "1.2.3") is False
 
 
-def test_filter_version_basic():
+def test_version_filters_filter_version_basic():
     """Test basic filter_version functionality."""
     attrs_no_filter = {"conda-forge.yml": {"bot": {"version_updates": {}}}}
     assert filter_version(attrs_no_filter, "1.2.3") == "1.2.3"
@@ -112,7 +112,7 @@ def test_filter_version_basic():
     assert filter_version(attrs_exclude, "1.2.4") == "1.2.4"
 
 
-def test_filter_version_odd_even():
+def test_version_filters_filter_version_odd_even():
     """Test filter_version with odd/even filtering."""
     attrs = {
         "conda-forge.yml": {"bot": {"version_updates": {"even_odd_versions": True}}}

--- a/tests/test_version_filters.py
+++ b/tests/test_version_filters.py
@@ -1,0 +1,121 @@
+"""Tests for conda_forge_tick.version_filters module."""
+
+from conda_forge_tick.version_filters import filter_version, is_version_ignored
+
+
+def test_no_filtering_config():
+    """Test that versions are not ignored when no filtering is configured."""
+    attrs = {"conda-forge.yml": {"bot": {"version_updates": {}}}}
+    assert is_version_ignored(attrs, "1.2.3") is False
+    assert is_version_ignored(attrs, "2.0.0") is False
+
+
+def test_explicit_exclusions():
+    """Test explicit version exclusions."""
+    attrs = {
+        "conda-forge.yml": {"bot": {"version_updates": {"exclude": ["1.2.3", "2.0.0"]}}}
+    }
+    assert is_version_ignored(attrs, "1.2.3") is True
+    assert is_version_ignored(attrs, "2.0.0") is True
+    assert is_version_ignored(attrs, "1.2.4") is False
+
+
+def test_normalized_version_exclusions():
+    """Test that version normalization works for exclusions."""
+    attrs = {"conda-forge.yml": {"bot": {"version_updates": {"exclude": ["1.2.3"]}}}}
+    # Test that dashes and underscores are normalized to dots
+    assert is_version_ignored(attrs, "1-2-3") is True
+    assert is_version_ignored(attrs, "1_2_3") is True
+    assert is_version_ignored(attrs, "1.2.3") is True
+
+
+def test_odd_even_filtering_disabled():
+    """Test that odd/even filtering is disabled by default."""
+    attrs = {"conda-forge.yml": {"bot": {"version_updates": {}}}}
+    # These have odd minor versions but should not be filtered
+    assert is_version_ignored(attrs, "1.1.0") is False
+    assert is_version_ignored(attrs, "2.3.5") is False
+
+
+def test_odd_even_filtering_enabled():
+    """Test odd/even version filtering when enabled."""
+    attrs = {
+        "conda-forge.yml": {"bot": {"version_updates": {"even_odd_versions": True}}}
+    }
+    # Odd minor versions should be filtered out
+    assert is_version_ignored(attrs, "1.1.0") is True
+    assert is_version_ignored(attrs, "2.3.5") is True
+    assert is_version_ignored(attrs, "0.1.2") is True
+
+    # Even minor versions should not be filtered
+    assert is_version_ignored(attrs, "1.0.0") is False
+    assert is_version_ignored(attrs, "2.2.5") is False
+    assert is_version_ignored(attrs, "0.4.2") is False
+
+
+def test_odd_even_filtering_with_normalization():
+    """Test odd/even filtering with version normalization."""
+    attrs = {
+        "conda-forge.yml": {"bot": {"version_updates": {"even_odd_versions": True}}}
+    }
+    # Test with dashes and underscores
+    assert is_version_ignored(attrs, "1-1-0") is True
+    assert is_version_ignored(attrs, "1_1_0") is True
+    assert is_version_ignored(attrs, "2-2-0") is False
+
+
+def test_odd_even_filtering_invalid_version():
+    """Test that invalid versions don't cause errors in odd/even filtering."""
+    attrs = {
+        "conda-forge.yml": {"bot": {"version_updates": {"even_odd_versions": True}}}
+    }
+    # These should not cause errors and should not be filtered
+    assert is_version_ignored(attrs, "invalid") is False
+    assert is_version_ignored(attrs, "1") is False  # Only one part
+    assert is_version_ignored(attrs, "1.a.0") is False  # Non-numeric minor
+
+
+def test_combined_filtering():
+    """Test that both exclusions and odd/even filtering work together."""
+    attrs = {
+        "conda-forge.yml": {
+            "bot": {
+                "version_updates": {"exclude": ["1.0.0"], "even_odd_versions": True}
+            }
+        }
+    }
+    # Should be filtered due to explicit exclusion
+    assert is_version_ignored(attrs, "1.0.0") is True
+    # Should be filtered due to odd minor version
+    assert is_version_ignored(attrs, "1.1.0") is True
+    # Should not be filtered (even minor, not excluded)
+    assert is_version_ignored(attrs, "1.2.0") is False
+
+
+def test_empty_attrs():
+    """Test behavior with empty or missing attributes."""
+    assert is_version_ignored({}, "1.2.3") is False
+    assert is_version_ignored({"conda-forge.yml": {}}, "1.2.3") is False
+    assert is_version_ignored({"conda-forge.yml": {"bot": {}}}, "1.2.3") is False
+
+
+def test_filter_version_basic():
+    """Test basic filter_version functionality."""
+    attrs_no_filter = {"conda-forge.yml": {"bot": {"version_updates": {}}}}
+    assert filter_version(attrs_no_filter, "1.2.3") == "1.2.3"
+    assert filter_version(attrs_no_filter, False) is False
+
+    attrs_exclude = {
+        "conda-forge.yml": {"bot": {"version_updates": {"exclude": ["1.2.3"]}}}
+    }
+    assert filter_version(attrs_exclude, "1.2.3") is False
+    assert filter_version(attrs_exclude, "1.2.4") == "1.2.4"
+
+
+def test_filter_version_odd_even():
+    """Test filter_version with odd/even filtering."""
+    attrs = {
+        "conda-forge.yml": {"bot": {"version_updates": {"even_odd_versions": True}}}
+    }
+    assert filter_version(attrs, "1.1.0") is False  # Odd minor -> filtered
+    assert filter_version(attrs, "1.2.0") == "1.2.0"  # Even minor -> kept


### PR DESCRIPTION
#### Description:

 Adds support for ignoring odd minor version updates for odd/even version schemes.

I think we want to ignore them both for checking and storing upstream version changes and for auto tick of the version, but please let me know if there is a different architecture we want.

#### Checklist:

- [X] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

Closes #1152.
