### PR TITLE
Fix typos warning for mutable reference v1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -23,8 +23,8 @@ repos:
         args:
           - --py36-plus
 
-  - repo: https://github.com/crate-ci/typos
-    rev: v1
+  - repo: https://github.com/adhtruong/mirrors-typos
+    rev: v1.35.6
     hooks:
       - id: typos
         exclude: |
@@ -34,7 +34,7 @@ repos:
           )$
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.7
+    rev: v0.12.11
     hooks:
       - id: ruff-check
         args: [ --fix ]


### PR DESCRIPTION
#### Description:

This PR swaps to a new mirror for the typos pre-commit hook in order to fix a mutable tag warning with the original repo. #4310 downgraded typos to v1 due to this problem. I also ran autoupdate on the other hooks.

#### Checklist:

- [X] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
