### PR TITLE
chore: enforce mypy for all files starting with a letter from a-e

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,8 @@ repos:
       - id: ruff-check
         args: [ --fix ]
       - id: ruff-format
+
+  - repo: https://github.com/conda-incubator/pre-commit-mirrors-mypy
+    rev: 1.18.1
+    hooks:
+      - id: mypy-conda

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,9 @@ repos:
     rev: 1.18.1
     hooks:
       - id: mypy-conda
+        exclude: |
+          (?x)^(
+            ^tests\/.*|
+            ^tests_integration\/.*|
+            ^conda_forge_tick\/.*
+          )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,10 +40,10 @@ repos:
         args: [ --fix ]
       - id: ruff-format
 
-  - repo: https://github.com/conda-incubator/pre-commit-mirrors-mypy
-    rev: 1.18.1
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.18.2
     hooks:
-      - id: mypy-conda
+      - id: mypy
         exclude: |
           (?x)^(
             conda_forge_tick\/[f-z].*|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,8 +29,8 @@ repos:
       - id: typos
         exclude: |
           (?x)^(
-            ^tests_integration\/definitions\/.*\/resources\/.*|
-            ^docs\/assets\/.*
+            tests_integration\/definitions\/.*\/resources\/.*|
+            docs\/assets\/.*
           )$
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -46,7 +46,6 @@ repos:
       - id: mypy-conda
         exclude: |
           (?x)^(
-            ^tests\/.*|
-            ^tests_integration\/.*|
-            ^conda_forge_tick\/.*
+            conda_forge_tick\/[f-z].*|
+            tests\/[f-z].*
           )$

--- a/autotick-bot/compute_next_version.py
+++ b/autotick-bot/compute_next_version.py
@@ -41,7 +41,7 @@ else:
     print(f"found current version: {curr_version_line}", file=sys.stderr, flush=True)
 
     # figure out if we bump the major, minor or patch version
-    major_minor, patch = curr_version_line.rsplit(".", 1)
+    major_minor, patch = curr_version_line.rsplit(".", 1)  # type: ignore[union-attr]
     now_major_minor = f"{now.year}.{now.month}"
     if major_minor == now_major_minor:
         new_version = f"{major_minor}.{int(patch) + 1}"

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -497,7 +497,8 @@ def run_with_tmpdir(
         )
 
 
-def _make_and_sync_pr_lazy_json(pr_data) -> LazyJson:
+def _make_and_sync_pr_lazy_json(pr_data) -> LazyJson | Literal[False]:
+    pr_lazy_json: LazyJson | Literal[False]
     if pr_data:
         pr_lazy_json = LazyJson(
             os.path.join("pr_json", f"{pr_data.id}.json"),
@@ -599,7 +600,9 @@ def run(
         )
 
         # spoof this so it looks like the package is done
-        pr_data = get_spoofed_closed_pr_info()
+        pr_data: PullRequestData | PullRequestInfoSpecial | None = (
+            get_spoofed_closed_pr_info()
+        )
         pr_lazy_json = _make_and_sync_pr_lazy_json(pr_data)
         _reset_pre_pr_migrator_fields(
             context.attrs, migrator_name, is_version=is_version_migration
@@ -644,9 +647,8 @@ def run(
             migration_run_data["pr_title"].replace("[bot-automerge]", "").strip()
         )
 
-    pr_data: PullRequestData | PullRequestInfoSpecial | None
     """
-    The PR data for the PR that was created. The contents of this variable
+    pr_data is the PR data for the PR that was created. The contents of this variable
     will be stored in the bot's database. None means: We don't update the PR data.
     """
     if (

--- a/conda_forge_tick/config_schema.py
+++ b/conda_forge_tick/config_schema.py
@@ -1,15 +1,10 @@
 import json
+from enum import StrEnum
 from inspect import cleandoc
 from pathlib import Path
 from typing import Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
-
-try:
-    from enum import StrEnum
-except ImportError:
-    from backports.strenum import StrEnum
-
 
 CF_TICK_SCHEMA_FILE = Path(__file__).resolve().parent / "cf_tick_schema.json"
 

--- a/conda_forge_tick/depfinder_api.py
+++ b/conda_forge_tick/depfinder_api.py
@@ -32,6 +32,7 @@ from collections import defaultdict
 from concurrent.futures._base import as_completed
 from concurrent.futures.thread import ThreadPoolExecutor
 from fnmatch import fnmatch
+from typing import Any
 
 from depfinder.inspection import iterate_over_library
 from depfinder.stdliblist import builtin_modules as _builtin_modules
@@ -69,8 +70,8 @@ def report_conda_forge_names_from_import_map(
         "questionable no match",
         "required no match",
     ]
-    report = {k: set() for k in report_keys}
-    import_to_pkg = {k: {} for k in report_keys}
+    report: dict[str, Any] = {k: set() for k in report_keys}
+    import_to_pkg: dict[str, Any] = {k: {} for k in report_keys}
     futures = {}
 
     with ThreadPoolExecutor() as pool:
@@ -146,13 +147,13 @@ def simple_import_to_pkg_map(
     # run depfinder on source code
     if ignore is None:
         ignore = []
-    total_imports_list = []
+    total_imports_list: list[dict[str, Any]] = []
     for _, _, c in iterate_over_library(
         path_to_source_code,
         custom_namespaces=custom_namespaces,
     ):
         total_imports_list.append(c.total_imports)
-    total_imports = defaultdict(dict)
+    total_imports: dict[str, Any] = defaultdict(dict)
     for total_import in total_imports_list:
         for name, md in total_import.items():
             total_imports[name].update(md)

--- a/conda_forge_tick/deploy.py
+++ b/conda_forge_tick/deploy.py
@@ -2,6 +2,7 @@ import logging
 import os
 import subprocess
 import sys
+from collections.abc import Iterable
 
 from .cli_context import CliContext
 from .git_utils import delete_file_via_gh_api, get_bot_token, push_file_via_gh_api
@@ -93,10 +94,11 @@ def _pull_changes(batch):
     return n_added
 
 
-def _deploy_batch(*, files_to_add, batch, n_added, max_per_batch=200):
+def _deploy_batch(*, files_to_add: Iterable[str], batch, n_added, max_per_batch=200):
     n_added_this_batch = 0
-    while files_to_add and n_added_this_batch < max_per_batch:
-        file = files_to_add.pop()
+    files_queue = list(files_to_add)
+    while files_queue and n_added_this_batch < max_per_batch:
+        file = files_queue.pop()
         if file and os.path.exists(file):
             try:
                 print(f"committing {n_added: >5d}: {file}", flush=True)
@@ -204,7 +206,7 @@ def _reset_and_restore_file(pth):
     subprocess.run(["git", "clean", "-f", "--", pth], capture_output=True, text=True)
 
 
-def deploy(ctx: CliContext, dirs_to_deploy: list[str] = None):
+def deploy(ctx: CliContext, dirs_to_deploy: list[str] | None = None):
     """Deploy the graph to GitHub."""
     if ctx.dry_run:
         print("(dry run) deploying")
@@ -320,7 +322,7 @@ def deploy(ctx: CliContext, dirs_to_deploy: list[str] = None):
 
     batch = 0
     if do_git_ops:
-        files_to_add = list((set(files_to_add) - files_done) | files_to_try_again)
+        files_to_add = (files_to_add - files_done) | files_to_try_again
         n_added = 0
         while files_to_add:
             batch += 1

--- a/conda_forge_tick/deploy.py
+++ b/conda_forge_tick/deploy.py
@@ -2,7 +2,6 @@ import logging
 import os
 import subprocess
 import sys
-from collections.abc import Iterable
 
 from .cli_context import CliContext
 from .git_utils import delete_file_via_gh_api, get_bot_token, push_file_via_gh_api
@@ -94,11 +93,10 @@ def _pull_changes(batch):
     return n_added
 
 
-def _deploy_batch(*, files_to_add: Iterable[str], batch, n_added, max_per_batch=200):
+def _deploy_batch(*, files_to_add: set[str], batch, n_added, max_per_batch=200):
     n_added_this_batch = 0
-    files_queue = list(files_to_add)
-    while files_queue and n_added_this_batch < max_per_batch:
-        file = files_queue.pop()
+    while files_to_add and n_added_this_batch < max_per_batch:
+        file = files_to_add.pop()
         if file and os.path.exists(file):
             try:
                 print(f"committing {n_added: >5d}: {file}", flush=True)

--- a/conda_forge_tick/events/push_events.py
+++ b/conda_forge_tick/events/push_events.py
@@ -13,7 +13,7 @@ from conda_forge_tick.make_graph import (
 )
 
 
-def _update_feedstocks(name: str) -> None:
+def _update_feedstocks(name: str) -> dict | None:
     gh = github_client()
     repo = gh.get_repo(f"conda-forge/{name}-feedstock")
 
@@ -38,6 +38,7 @@ def _react_to_push(name: str, dry_run: bool = False) -> None:
 
     # first update the feedstocks
     all_feedstocks = _update_feedstocks(name)
+    assert all_feedstocks is not None
 
     with lazy_json_override_backends(["github_api"], use_file_cache=False):
         with LazyJson("graph.json") as graph_json:

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -175,6 +175,7 @@ class FileLazyJsonBackend(LazyJsonBackend):
 
     def hkeys(self, name: str) -> List[str]:
         jlen = len(".json")
+        fnames: Iterable[str]
         if name == "lazy_json":
             fnames = glob.glob("*.json")
             fnames = set(fnames) - {

--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -114,7 +114,7 @@ DEFAULT_MINI_MIGRATORS = [
 
 
 def _make_mini_migrators_with_defaults(
-    extra_mini_migrators: list[MiniMigrator] = None,
+    extra_mini_migrators: list[MiniMigrator] | None = None,
 ) -> list[MiniMigrator]:
     extra_mini_migrators = extra_mini_migrators or []
     for klass in DEFAULT_MINI_MIGRATORS:
@@ -125,7 +125,7 @@ def _make_mini_migrators_with_defaults(
 
 def _compute_migrator_pr_limit(
     migrator: Migrator, nominal_pr_limit: int
-) -> (int, int, float):
+) -> tuple[int, int, float]:
     # adaptively set PR limits based on the number of PRs made so far
     number_pred = 0
     for _, v in migrator.graph.nodes.items():

--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -129,7 +129,9 @@ class ArchRebuild(GraphMigrator):
                     fname = os.path.join(d, "arch_rebuild.txt")
                     if os.path.exists(fname):
                         break
-
+                assert fname is not None, (
+                    "Could not find arch_rebuild.txt in migration support dirs"
+                )
                 with open(fname) as f:
                     target_packages = set(f.read().split())
 

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -129,7 +129,7 @@ def _sanitized_muids(pred: List[dict]) -> List["JsonFriendly"]:
 
 def _parse_bad_attr(attrs: "AttrsTypedDict", not_bad_str_start: str) -> bool:
     """Overlook some bad entries."""
-    bad = attrs.get("pr_info", {}).get("bad", False)
+    bad = attrs.get("pr_info", {}).get("bad", False)  # type: ignore[call-overload]
     if isinstance(bad, str):
         bad_bool = not bad.startswith(not_bad_str_start)
     else:
@@ -267,7 +267,7 @@ class Migrator:
     - total_graph: The entire graph of conda-forge feedstocks.
     """
 
-    name: str
+    name: str | None
 
     rerender = True
 
@@ -458,18 +458,19 @@ class Migrator:
             pr_data["data"],
         )
         already_migrated_uids: list["MigrationUidTypedDict"] = list(
-            z["data"] for z in attrs.get("pr_info", {}).get("PRed", [])
+            z["data"]
+            for z in attrs.get("pr_info", {}).get("PRed", [])  # type: ignore[call-overload]
         )
         already_pred = migrator_uid in already_migrated_uids
         if already_pred:
             ind = already_migrated_uids.index(migrator_uid)
             logger.debug("%s: already PRed: uid: %s", __name, migrator_uid)
-            if "PR" in attrs.get("pr_info", {}).get("PRed", [])[ind]:
+            if "PR" in attrs.get("pr_info", {}).get("PRed", [])[ind]:  # type: ignore[call-overload]
                 if isinstance(
-                    attrs.get("pr_info", {}).get("PRed", [])[ind]["PR"],
+                    attrs.get("pr_info", {}).get("PRed", [])[ind]["PR"],  # type: ignore[call-overload]
                     LazyJson,
                 ):
-                    with attrs.get("pr_info", {}).get("PRed", [])[ind][
+                    with attrs.get("pr_info", {}).get("PRed", [])[ind][  # type: ignore[call-overload]
                         "PR"
                     ] as mg_attrs:
                         logger.debug(

--- a/conda_forge_tick/migrators_types.py
+++ b/conda_forge_tick/migrators_types.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Dict, List, Literal, Set, TypedDict, Union
+from typing import List, Literal, TypedDict, Union
 
 PackageName = typing.NewType("PackageName", str)
 
@@ -121,42 +121,40 @@ class PRedElementTypedDict(TypedDict, total=False):
     PR: PR_TD
 
 
-class AttrsTypedDict_(TypedDict, total=False):
-    about: AboutTypedDict
-    build: BuildTypedDict
-    branch: str
-    extra: ExtraTypedDict
-    feedstock_name: str
-    meta_yaml: "RecipeTypedDict"
-    package: PackageTypedDict
-    raw_meta_yaml: str
-    req: Set[str]
-    name: str
-    platforms: List[str]
-    pr_info: typing.Any
-    requirements: RequirementsTypedDict
-    source: SourceTypedDict
-    test: TestTypedDict
-    version: str
-    new_version: Union[str, bool]
-    archived: bool
-    outputs_names: set[str]
-    PRed: List[PRedElementTypedDict]
-    version_pr_info: typing.Any
-    url: str
-    parsing_error: str | Literal[False]
-    # Legacy types in here
-    bad: Union[bool, str]
-
-
 class CondaForgeYamlContents(TypedDict, total=False):
-    provider: Dict[str, str]
+    bot: dict[str, typing.Any]
+    provider: dict[str, str]
 
 
-CondaForgeYaml = TypedDict(
-    "CondaForgeYaml", {"conda-forge.yml": CondaForgeYamlContents}
+AttrsTypedDict = TypedDict(
+    "AttrsTypedDict",
+    {
+        "about": AboutTypedDict,
+        "build": BuildTypedDict,
+        "branch": str,
+        "conda-forge.yml": CondaForgeYamlContents,
+        "extra": ExtraTypedDict,
+        "feedstock_name": str,
+        "meta_yaml": RecipeTypedDict,
+        "package": PackageTypedDict,
+        "raw_meta_yaml": str,
+        "req": set[str],
+        "name": str,
+        "platforms": List[str],
+        "pr_info": typing.Any,
+        "requirements": RequirementsTypedDict,
+        "source": SourceTypedDict,
+        "test": TestTypedDict,
+        "version": str,
+        "new_version": str | bool,
+        "archived": bool,
+        "outputs_names": set[str],
+        "PRed": list[PRedElementTypedDict],
+        "version_pr_info": typing.Any,
+        "url": str,
+        "parsing_error": str | Literal[False],
+        # Legacy types in here
+        "bad": Union[bool, str],
+    },
+    total=False,
 )
-
-
-class AttrsTypedDict(AttrsTypedDict_, CondaForgeYaml):
-    pass

--- a/conda_forge_tick/recipe_parser/_parser.py
+++ b/conda_forge_tick/recipe_parser/_parser.py
@@ -74,7 +74,7 @@ def _config_has_key_with_selectors(cfg: dict, key: str):
     return False
 
 
-def _parse_jinja2_variables(meta_yaml: str) -> dict:
+def _parse_jinja2_variables(meta_yaml: str) -> tuple[dict[str, Any], dict[str, str]]:
     """Parse all assignments of jinja2 variables in a recipe.
 
     For example, the following file
@@ -108,8 +108,8 @@ def _parse_jinja2_variables(meta_yaml: str) -> dict:
     parsed_content = env.parse(meta_yaml)
     all_nodes = list(parsed_content.iter_child_nodes())
 
-    jinja2_exprs = {}
-    jinja2_vals = {}
+    jinja2_exprs: dict[str, str] = {}
+    jinja2_vals: dict[str, Any] = {}
     for i, n in enumerate(all_nodes):
         if isinstance(n, jinja2.nodes.Assign) and isinstance(
             n.node,
@@ -251,7 +251,7 @@ def _unmunge_split_key_value_pairs_with_selectors(lines):
 def _munge_multiline_jinja2(lines):
     """Put a comment slug in front of any multiline jinja2 statements."""
     in_statement = False
-    special_end_slug_re = []
+    special_end_slug_re: list[re.Pattern | None] = []
     new_lines = []
     for line in lines:
         if line.strip().startswith("{%") and "%}" not in line:
@@ -298,7 +298,7 @@ def _unmunge_multiline_jinja2(lines):
     return new_lines
 
 
-def _demunge_jinja2_vars(meta: Union[dict, list], sentinel: str) -> Union[dict, list]:
+def _demunge_jinja2_vars(meta: dict | list | str, sentinel: str) -> dict | list | str:
     """Recursively iterate through dictionary / list and replace any instance
     in any string of `<{` with '{{'.
     """

--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -99,9 +99,9 @@ def write_version_migrator_status(migrator, mctx):
                 )
                 if _ok_version(version_from_data):
                     if _ok_version(version_from_attrs):
-                        new_version = max(
+                        new_version: str | bool = max(
                             [version_from_data, version_from_attrs],
-                            key=lambda x: VersionOrder(x.replace("-", ".")),
+                            key=lambda x: VersionOrder(x.replace("-", ".")),  # type: ignore[union-attr]
                         )
                     else:
                         new_version = version_from_data
@@ -130,7 +130,7 @@ def write_version_migrator_status(migrator, mctx):
                 if new_version_is_ok:
                     attempts = vpri.get("new_version_attempts", {}).get(new_version, 0)
                     if attempts == 0:
-                        out["queued"][node] = new_version
+                        out["queued"][node] = new_version  # type: ignore[assignment]
                     else:
                         out["errors"][node] = f"{attempts:.2f} attempts - " + vpri.get(
                             "new_version_errors",

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,6 +4,8 @@
 check_untyped_defs = True
 warn_unreachable = True
 allow_redefinition = True
+# remove the following flag if mypy is applied to the entire codebase
+follow_imports = silent
 files = conda_forge_tick/**/*.py
 
 [mypy-depfinder.*]

--- a/tests/test_auto_tick.py
+++ b/tests/test_auto_tick.py
@@ -21,9 +21,12 @@ from conda_forge_tick.git_utils import (
     GitPlatformBackend,
     RepositoryNotFoundError,
 )
+from conda_forge_tick.migrators_types import AttrsTypedDict
 from conda_forge_tick.version_filters import filter_version
 
-demo_attrs = {"conda-forge.yml": {"provider": {"default_branch": "main"}}}
+demo_attrs: AttrsTypedDict = {
+    "conda-forge.yml": {"provider": {"default_branch": "main"}}
+}
 
 
 def test_prepare_feedstock_repository_success():
@@ -341,7 +344,9 @@ def test_run_with_tmpdir(
 
 def test_filter_version():
     """Test filter_version."""
-    attrs_no_filter = {"conda-forge.yml": {"bot": {"version_updates": {}}}}
+    attrs_no_filter: AttrsTypedDict = {
+        "conda-forge.yml": {"bot": {"version_updates": {}}}
+    }
     assert filter_version(attrs_no_filter, "1.2.3") == "1.2.3"
     assert filter_version(attrs_no_filter, False) is False
 

--- a/tests/test_container_tasks.py
+++ b/tests/test_container_tasks.py
@@ -7,6 +7,7 @@ import pprint
 import shutil
 import subprocess
 import tempfile
+from typing import Any
 
 import conda_smithy
 import networkx as nx
@@ -601,7 +602,7 @@ def test_container_tasks_is_recipe_solvable_containerized(use_containers):
 
 
 yaml_rebuild = MigrationYaml(yaml_contents="{}", name="hi", total_graph=TOTAL_GRAPH)
-yaml_rebuild.cycles = []
+yaml_rebuild.cycles = set()
 
 
 @pytest.mark.skipif(
@@ -618,7 +619,7 @@ def test_migration_runner_run_migration_containerized_yaml_rebuild(tmpdir):
         subprocess.run(["git", "init", "-b", "main"])
     # Load the meta.yaml (this is done in the graph)
     try:
-        pmy = parse_meta_yaml(sample_yaml_rebuild)
+        pmy: dict[str, Any] = parse_meta_yaml(sample_yaml_rebuild)  # type: ignore[assignment]
     except Exception:
         pmy = {}
     if pmy:


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

This will ultimately be the way we enable mypy for all files in this repo: Step by step. This PR enables mypy for all top-level modules and tests starting with a letter from a to e.

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
