### PR TITLE
feat: record timestamp of last PR attempt and use exp backoff

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -106,8 +106,13 @@ def _increment_pre_pr_migrator_attempt(attrs, migrator_name, *, is_version):
             if version not in vpri["new_version_attempts"]:
                 vpri["new_version_attempts"][version] = 0
             vpri["new_version_attempts"][version] += 1
+
+            if "new_version_attempt_ts" not in vpri:
+                vpri["new_version_attempt_ts"] = {}
+            vpri["new_version_attempt_ts"][version] = int(time.time())
     else:
         pre_key_att = "pre_pr_migrator_attempts"
+        pre_key_att_ts = "pre_pr_migrator_attempt_ts"
 
         with attrs["pr_info"] as pri:
             if pre_key_att not in pri:
@@ -116,19 +121,28 @@ def _increment_pre_pr_migrator_attempt(attrs, migrator_name, *, is_version):
                 pri[pre_key_att][migrator_name] = 0
             pri[pre_key_att][migrator_name] += 1
 
+            if pre_key_att_ts not in pri:
+                pri[pre_key_att_ts] = {}
+            pri[pre_key_att_ts][migrator_name] = int(time.time())
+
 
 def _reset_pre_pr_migrator_fields(attrs, migrator_name, *, is_version):
     if is_version:
         with attrs["version_pr_info"] as vpri:
             version = vpri["new_version"]
-            for _key in ["new_version_errors", "new_version_attempts"]:
+            for _key in [
+                "new_version_errors",
+                "new_version_attempts",
+                "new_version_attempt_ts",
+            ]:
                 if _key in vpri and version in vpri[_key]:
                     vpri[_key].pop(version)
     else:
         pre_key = "pre_pr_migrator_status"
         pre_key_att = "pre_pr_migrator_attempts"
+        pre_key_att_ts = "pre_pr_migrator_attempt_ts"
         with attrs["pr_info"] as pri:
-            for _key in [pre_key, pre_key_att]:
+            for _key in [pre_key, pre_key_att, pre_key_att_ts]:
                 if _key in pri and migrator_name in pri[_key]:
                     pri[_key].pop(migrator_name)
 

--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -173,27 +173,26 @@ def _migrate_schema(name, sub_graph):
                     if key in sub_graph:
                         pri[key].update(sub_graph.pop(key))
 
-                # populate migrator attempts if they are not there
-                for mn in pri[pre_key]:
-                    if mn not in pri[pre_key_att]:
-                        pri[pre_key_att][mn] = 1
-
     with lazy_json_transaction():
         with sub_graph["pr_info"] as pri:
             for mn in pri[pre_key].keys():
                 if mn not in pri[pre_key_att]:
                     pri[pre_key_att][mn] = 1
                 if mn not in pri[pre_key_att_ts]:
-                    # set the attempt to one hour ago
-                    pri[pre_key_att_ts][mn] = int(time.time()) - 3600.0
+                    # set the attempt to one hour ago per try
+                    pri[pre_key_att_ts][mn] = (
+                        int(time.time()) - pri[pre_key_att][mn] * 3600.0
+                    )
 
         with sub_graph["version_pr_info"] as vpri:
             for mn in vpri["new_version_errors"].keys():
                 if mn not in vpri["new_version_attempts"]:
                     vpri["new_version_attempts"][mn] = 1
                 if mn not in vpri["new_version_attempt_ts"]:
-                    # set the attempt to one hour ago
-                    vpri["new_version_attempt_ts"][mn] = int(time.time()) - 3600.0
+                    # set the attempt to one hour ago per try
+                    vpri["new_version_attempt_ts"][mn] = (
+                        int(time.time()) - vpri["new_version_attempts"][mn] * 3600.0
+                    )
 
     keys_to_move = [
         "PRed",

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -711,11 +711,11 @@ class Migrator:
                 )
                 if ts is None:
                     # one hour per attempt
-                    return now - (3600 * attempts)
-                else:
-                    return ts
+                    ts = now - (3600 * attempts)
             else:
-                return -math.inf
+                ts = -math.inf
+
+            return (ts, attempts)
 
         def _attempt_pr(node):
             last_bot_attempt_ts, retries_so_far = _get_last_attempt_ts_and_try(node)

--- a/conda_forge_tick/models/pr_info.py
+++ b/conda_forge_tick/models/pr_info.py
@@ -104,8 +104,9 @@ class MigrationPullRequestData(StrictBaseModel):
 
     migrator_name: MigratorName
     """
-    The name of the migrator that created the PR. As opposed to `pre_pr_migrator_status` and `pre_pr_migrator_attempts`
-    below, the names of migrators appear here with spaces and not necessarily in lowercase.
+    The name of the migrator that created the PR. As opposed to `pre_pr_migrator_status`, `pre_pr_migrator_attempt_ts`,
+    and `pre_pr_migrator_attempts` below, the names of migrators appear here with spaces and not necessarily in
+    lowercase.
     """
 
     migrator_version: int
@@ -313,11 +314,25 @@ class PrInfoValid(StrictBaseModel):
     If a migration is eventually successful, the corresponding key is removed from the dictionary.
     """
 
+    pre_pr_migrator_attempt_ts: NoneIsEmptyDict[str, int] = {}
+    """
+    A dictionary (migration name -> timestamp) of the timestamp as `int(time.time())` of most recent
+    attempt to make the migration PR.
+
+    Note: The names of migrators appear here without spaces and in lowercase. This is not always the case.
+
+    If a migration is eventually successful, the corresponding key is removed from the dictionary.
+    """
+
     @model_validator(mode="after")
     def check_pre_pr_migrations(self) -> Self:
         if self.pre_pr_migrator_status.keys() != self.pre_pr_migrator_attempts.keys():
             raise ValueError(
                 "The keys (migration names) of pre_pr_migrator_status and pre_pr_migrator_attempts must match."
+            )
+        if self.pre_pr_migrator_status.keys() != self.pre_pr_migrator_attempt_ts.keys():
+            raise ValueError(
+                "The keys (migration names) of pre_pr_migrator_status and pre_pr_migrator_attempt_ts must match."
             )
         return self
 

--- a/conda_forge_tick/models/version_pr_info.py
+++ b/conda_forge_tick/models/version_pr_info.py
@@ -24,6 +24,12 @@ class VersionPrInfo(StrictBaseModel):
     increases the count by a fraction that is specified in auto_tick.run (03/2024: 0.2).
     """
 
+    new_version_attempt_ts: NoneIsEmptyDict[str, int] = {}
+    """
+    Mapping (version -> timestamp) of the timestamp as `int(time.time())` of most recent
+    attempt to make the version PR.
+    """
+
     new_version_errors: NoneIsEmptyDict[str, str] = {}
     """
     Mapping (version -> error message) to describe the errors that occurred when trying to update the versions in the
@@ -41,6 +47,17 @@ class VersionPrInfo(StrictBaseModel):
         if wrong_versions:
             raise ValueError(
                 f"new_version_errors contains at least one version not in new_version_attempts: {wrong_versions}"
+            )
+
+        wrong_versions = [
+            version
+            for version in self.new_version_errors
+            if version not in self.new_version_attempt_ts
+        ]
+
+        if wrong_versions:
+            raise ValueError(
+                f"new_version_errors contains at least one version not in new_version_attempt_ts: {wrong_versions}"
             )
 
 


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

Per #4749, this PR adds the timestamp of the last solver attempt to the bot metadata and uses exp backoff to retry PRs. I have updated the pydantic model and added hooks into all of the schema handling. Some of the schema handling sections are likely not needed since this data was never recorded in the old bot model. However, it is easier to treat things uniformly. 

We should actually remove the schema migration handling code at some point and bake in the new schemas, but not today.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
