### PR TITLE
fix: do exp backoff comps for retries in days instead of seconds

### DIFF
--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -679,8 +679,9 @@ class Migrator:
         else:
             migrator_name = self.__class__.__name__.lower()
 
-        now = int(time.time())
-        base = 4 * 3600  # 4 hours
+        seconds_to_days = 1.0 / (60.0 * 60.0 * 24.0)
+        now = int(time.time()) * seconds_to_days
+        base = 4 / 24.0  # 4 hours in days
 
         def _get_last_attempt_ts_and_try(node):
             attempts = (
@@ -715,7 +716,7 @@ class Migrator:
             else:
                 ts = -math.inf
 
-            return (ts, attempts)
+            return (ts * seconds_to_days, attempts)
 
         def _attempt_pr(node):
             last_bot_attempt_ts, retries_so_far = _get_last_attempt_ts_and_try(node)


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

We hit an overflow error. This PR keeps the timestamps in integer seconds, but converts to days before doing comparisons.

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
