### PR TITLE
feat: remove max_solver_attempts and refactor to parameterize migrator shares directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,12 +149,6 @@ __migrator:
   # from issuing PRs that will fail to build.
   check_solvable: true
 
-  # The max_solver_attempts controls how many times the bot will try to issue a PR (and
-  # fail due to unsolvable environments) before it deprioritizes the migration of the feedstock.
-  # Once all feedstocks without failed solver attempts have been tried, the bot will randomly
-  # retry the failed feedstocks.
-  max_solver_attempts: 3
-
   # The bot will forcibly make PRs for feedstocks that have failed the solver attempts after
   # this many tries.
   force_pr_after_solver_attempts: 10

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -733,7 +733,7 @@ def run(
     return migrate_return_value, pr_lazy_json
 
 
-def _compute_time_per_migrator(migrators):
+def _compute_time_per_migrator(migrators, max_attempts_for_share=3):
     # we weight each migrator by the number of available nodes to migrate with a
     # a penalty for attempts and accounting for the pr_limit
     # the variables below are
@@ -758,7 +758,7 @@ def _compute_time_per_migrator(migrators):
                     migrator_name=get_migrator_name(migrator),
                     is_version=isinstance(migrator, Version),
                 )
-                if _attempts < getattr(migrator, "max_solver_attempts", 3):
+                if _attempts < max_attempts_for_share:
                     num_to_do += 1.0
 
         num_nodes_not_tried.append(num_to_do)

--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -422,6 +422,10 @@ def migration_factory(
                 ),
                 FORCE_PR_AFTER_SOLVER_ATTEMPTS,
             )
+            # max_solver_attempts was removed from the migrator classes
+            # so we remove it from the config here too
+            if "max_solver_attempts" in migrator_config:
+                del migrator_config["max_solver_attempts"]
 
             age = time.time() - loaded_yaml.get("migrator_ts", time.time())
             age /= 24 * 60 * 60

--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -95,7 +95,6 @@ RNG = secrets.SystemRandom()
 PR_LIMIT = 5
 PR_ATTEMPT_LIMIT_FACTOR = 2
 MAX_PR_LIMIT = 20
-MAX_SOLVER_ATTEMPTS = 3
 FORCE_PR_AFTER_SOLVER_ATTEMPTS = 10
 CHECK_SOLVABLE_TIMEOUT = 30  # in days
 DEFAULT_MINI_MIGRATORS = [
@@ -295,7 +294,6 @@ def add_rebuild_migration_yaml(
     config: dict,
     migration_name: str,
     nominal_pr_limit: int = PR_LIMIT,
-    max_solver_attempts: int = 3,
     force_pr_after_solver_attempts: int = FORCE_PR_AFTER_SOLVER_ATTEMPTS,
     paused: bool = False,
 ) -> None:
@@ -356,7 +354,6 @@ def add_rebuild_migration_yaml(
         total_graph=gx,
         pr_limit=nominal_pr_limit,
         piggy_back_migrations=piggy_back_migrations,
-        max_solver_attempts=max_solver_attempts,
         force_pr_after_solver_attempts=force_pr_after_solver_attempts,
         paused=paused,
         **config,
@@ -378,7 +375,6 @@ def add_rebuild_migration_yaml(
     final_config = {}
     final_config.update(config)
     final_config["pr_limit"] = migrator.pr_limit
-    final_config["max_solver_attempts"] = max_solver_attempts
     print("final config:\n", pprint.pformat(final_config), flush=True)
     migrators.append(migrator)
 
@@ -419,10 +415,6 @@ def migration_factory(
             migrator_config = loaded_yaml.get("__migrator", {})
             paused = migrator_config.pop("paused", False)
             _pr_limit = min(migrator_config.pop("pr_limit", pr_limit), MAX_PR_LIMIT)
-            max_solver_attempts = min(
-                migrator_config.pop("max_solver_attempts", MAX_SOLVER_ATTEMPTS),
-                MAX_SOLVER_ATTEMPTS,
-            )
             force_pr_after_solver_attempts = min(
                 migrator_config.pop(
                     "force_pr_after_solver_attempts",
@@ -464,7 +456,6 @@ def migration_factory(
                 migration_name=os.path.splitext(yaml_file)[0],
                 config=migrator_config,
                 nominal_pr_limit=_pr_limit,
-                max_solver_attempts=max_solver_attempts,
                 force_pr_after_solver_attempts=force_pr_after_solver_attempts,
                 paused=paused,
             )

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -204,6 +204,12 @@ def make_from_lazy_json_data(data):
             for mini_migrator in kwargs["piggy_back_migrations"]
         ]
 
+    # this keyword was removed from the class init,
+    # so we have to remove it here in case it is still
+    # in the bot metadata
+    if "max_solver_attempts" in kwargs:
+        del kwargs["max_solver_attempts"]
+
     return cls(*data["args"], **kwargs)
 
 
@@ -271,8 +277,6 @@ class Migrator:
     name: str | None
 
     rerender = True
-
-    max_solver_attempts = 3
 
     # bump this if the migrator object needs a change mid migration
     migrator_version = 0

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -184,7 +184,6 @@ class MigrationYaml(GraphMigrator):
         check_solvable=True,
         conda_forge_yml_patches=None,
         ignored_deps_per_node=None,
-        max_solver_attempts=3,
         effective_graph: nx.DiGraph | None = None,
         force_pr_after_solver_attempts=10,
         longterm=False,
@@ -208,7 +207,6 @@ class MigrationYaml(GraphMigrator):
                 "check_solvable": check_solvable,
                 "conda_forge_yml_patches": conda_forge_yml_patches,
                 "ignored_deps_per_node": ignored_deps_per_node,
-                "max_solver_attempts": max_solver_attempts,
                 "effective_graph": effective_graph,
                 "longterm": longterm,
                 "force_pr_after_solver_attempts": force_pr_after_solver_attempts,
@@ -225,7 +223,6 @@ class MigrationYaml(GraphMigrator):
         self.conda_forge_yml_patches = conda_forge_yml_patches
         self.loaded_yaml = yaml_safe_load(self.yaml_contents)
         self.bump_number = bump_number
-        self.max_solver_attempts = max_solver_attempts
         self.longterm = longterm
         self.force_pr_after_solver_attempts = force_pr_after_solver_attempts
         self.paused = paused

--- a/conda_forge_tick/migrators/noarch_python_min.py
+++ b/conda_forge_tick/migrators/noarch_python_min.py
@@ -415,7 +415,6 @@ class NoarchPythonMinMigrator(Migrator):
 
     migrator_version = 1
     bump_number = 1
-    max_solver_attempts = 3
 
     def __init__(
         self,

--- a/conda_forge_tick/migrators/nvtools.py
+++ b/conda_forge_tick/migrators/nvtools.py
@@ -75,8 +75,6 @@ class AddNVIDIATools(Migrator):
 
     rerender = True
 
-    max_solver_attempts = 3
-
     migrator_version = 1
 
     allow_empty_commits = False

--- a/conda_forge_tick/migrators/staticlib.py
+++ b/conda_forge_tick/migrators/staticlib.py
@@ -410,7 +410,6 @@ class StaticLibMigrator(GraphMigrator):
         bump_number: int = 1,
         piggy_back_migrations: Optional[Sequence[MiniMigrator]] = None,
         check_solvable=True,
-        max_solver_attempts=3,
         effective_graph: nx.DiGraph | None = None,
         force_pr_after_solver_attempts=10,
         longterm=False,
@@ -427,7 +426,6 @@ class StaticLibMigrator(GraphMigrator):
                 "bump_number": bump_number,
                 "piggy_back_migrations": piggy_back_migrations,
                 "check_solvable": check_solvable,
-                "max_solver_attempts": max_solver_attempts,
                 "effective_graph": effective_graph,
                 "longterm": longterm,
                 "force_pr_after_solver_attempts": force_pr_after_solver_attempts,
@@ -438,7 +436,6 @@ class StaticLibMigrator(GraphMigrator):
         self.top_level = set()
         self.cycles = set()
         self.bump_number = bump_number
-        self.max_solver_attempts = max_solver_attempts
         self.longterm = longterm
         self.force_pr_after_solver_attempts = force_pr_after_solver_attempts
         self.paused = paused


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

After we moved to exponential backoff, we no longer need this parameter for the migrators. It was used to determine the migrator's share of time. So now we parameterize this directly.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
