### PR TITLE
fix: clean up cruft in source version fetching and include excludes

### DIFF
--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -136,10 +136,44 @@ class AbstractSource(abc.ABC):
 
     @abc.abstractmethod
     def get_version(self, url: str) -> Optional[str]:
+        """Get the version given a url.
+
+        This method should catch all errors and return None if an
+        error is caught. Logging statements at the DEBUG level
+        can be added to help debug errors.
+
+        Parameters
+        ----------
+        url
+            The url used to find the version.
+
+        Returns
+        -------
+        version
+            The version as a string or None if there is an error.
+        """
         pass
 
     @abc.abstractmethod
     def get_url(self, node_attrs: AttrsTypedDict) -> Optional[str]:
+        """Get a url from which to fetch the latest version given the feedstock's
+        node attributes.
+
+        This method should catch all errors and return None if an
+        error is caught. Logging statements at the DEBUG level
+        can be added to help debug errors.
+
+        Parameters
+        ----------
+        node_attrs
+            The feedstock node attributes.
+
+        Returns
+        -------
+        url
+            The url to pass to get `get_version`. Returns None if there is an
+            error.
+        """
         pass
 
 

--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -144,7 +144,8 @@ class AbstractSource(abc.ABC):
         can be added to help debug errors.
 
         The implementation should use the `is_version_ignored` function to ensure the
-        returned version is not supposed to be ignored by the bot.
+        returned version is not supposed to be ignored by the bot. If the version is
+        ignored, return None if there are no other valid versions.
 
         Parameters
         ----------
@@ -156,7 +157,7 @@ class AbstractSource(abc.ABC):
         Returns
         -------
         version
-            The version as a string or None if there is an error.
+            The version as a string or None if there is an error or the version is ignored.
         """
         pass
 

--- a/conda_forge_tick/update_upstream_versions.py
+++ b/conda_forge_tick/update_upstream_versions.py
@@ -141,7 +141,7 @@ def get_latest_version_local(
             if url is None:
                 continue
             logger.debug("Using URL %s", url)
-            ver = source.get_version(url)
+            ver = source.get_version(url, attrs)
             if not ver:
                 logger.debug("Upstream: Could not find version on %s", source.name)
                 continue

--- a/tests/test_update_sources.py
+++ b/tests/test_update_sources.py
@@ -62,7 +62,7 @@ class TestCratesIOGetVersion:
         tier = CratesIO._tier_directory(pkg)
         url = f"https://index.crates.io/{tier}"
 
-        actual = CratesIO().get_version(url)
+        actual = CratesIO().get_version(url, {})
         expected = "0.0.3"
 
         assert actual == expected
@@ -72,7 +72,7 @@ class TestCratesIOGetVersion:
         tier = CratesIO._tier_directory(pkg)
         url = f"https://index.crates.io/{tier}"
 
-        result = CratesIO().get_version(url)
+        result = CratesIO().get_version(url, {})
         assert result is None
 
     @patch("conda_forge_tick.update_sources.requests.get")
@@ -87,5 +87,5 @@ class TestCratesIOGetVersion:
         mock_response.text = '{"name": "syn"}'
         mock_get.return_value = mock_response
 
-        result = CratesIO().get_version(url)
+        result = CratesIO().get_version(url, {})
         assert result is None

--- a/tests/test_upstream_versions.py
+++ b/tests/test_upstream_versions.py
@@ -491,7 +491,7 @@ def test_latest_version_version_sources_no_error(caplog):
     source_b.get_url.assert_called_once_with(attrs)
     assert "Using URL https://source-b.com" in caplog.text
 
-    source_b.get_version.assert_called_once_with("https://source-b.com")
+    source_b.get_version.assert_called_once_with("https://source-b.com", attrs)
     assert "Found version 1.2.3 on Source b it Is" in caplog.text
 
     is_version_ignored_mock.assert_called_once_with(attrs, "1.2.3")

--- a/tests/test_upstream_versions.py
+++ b/tests/test_upstream_versions.py
@@ -1877,7 +1877,9 @@ def test_github_releases(tmpdir, url, feedstock_version):
 
     ghr = GithubReleases()
     url = ghr.get_url(meta_yaml)
-    assert VersionOrder(ghr.get_version(url)) > VersionOrder(feedstock_version)
+    assert VersionOrder(ghr.get_version(url, meta_yaml)) > VersionOrder(
+        feedstock_version
+    )
 
 
 @pytest.mark.parametrize(
@@ -1906,7 +1908,7 @@ def test_github_releases_unusual_version(
     ghr = GithubReleases()
     url = ghr.get_url(meta_yaml)
 
-    version = ghr.get_version(url)
+    version = ghr.get_version(url, meta_yaml)
 
     assert isinstance(version, str)
     assert re.match(regex, version)


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR cleans up some cruft in source version fetching, adds a few type hints, and accounts for excludes when fetching versions.

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
