### PR TITLE
fix: Downpin bcrypt to fix integration tests

### DIFF
--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -3,9 +3,9 @@ metadata:
     - url: conda-forge
       used_env_vars: []
   content_hash:
-    linux-64: 37d933f5821813c132eac100d6b94a7cb73090fc971459fc01b2491573dd930b
-    osx-64: 88ec521ae9595618964b18f4bba971836980cdb2f35204af7cc82dbacec94201
-    osx-arm64: 85621b635f7be6352eec0fefcf738bc36a1d328d8311b640d226bdc3144d2b83
+    linux-64: 4746c4d8b3dcec89888fcdb8e5cd29296cbcd5815eb6ddaf7ac430fa639849cf
+    osx-64: afe25ac2889e03fda7d2e6f67b6e5090549611a3858bd0e6cfe388df3a26e866
+    osx-arm64: 9bc9c0eb694f9daaff74560e9b5392947b970109edc9f8d57ae7dc2a7d937ea4
   platforms:
     - osx-arm64
     - linux-64
@@ -36,8 +36,7 @@ package:
     name: _openmp_mutex
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+    url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
     version: '4.5'
   - category: main
     dependencies:
@@ -168,8 +167,7 @@ package:
     name: anyio
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/anyio-4.11.0-pyhcf101f3_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.11.0-pyhcf101f3_0.conda
     version: 4.11.0
   - category: main
     dependencies:
@@ -185,8 +183,7 @@ package:
     name: anyio
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/anyio-4.11.0-pyhcf101f3_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.11.0-pyhcf101f3_0.conda
     version: 4.11.0
   - category: main
     dependencies:
@@ -202,8 +199,7 @@ package:
     name: anyio
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/anyio-4.11.0-pyhcf101f3_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.11.0-pyhcf101f3_0.conda
     version: 4.11.0
   - category: main
     dependencies:
@@ -215,8 +211,7 @@ package:
     name: appdirs
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyhd8ed1ab_1.conda
     version: 1.4.4
   - category: main
     dependencies:
@@ -228,8 +223,7 @@ package:
     name: appdirs
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyhd8ed1ab_1.conda
     version: 1.4.4
   - category: main
     dependencies:
@@ -241,8 +235,7 @@ package:
     name: appdirs
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyhd8ed1ab_1.conda
     version: 1.4.4
   - category: main
     dependencies:
@@ -254,8 +247,7 @@ package:
     name: archspec
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.5-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.5-pyhd8ed1ab_0.conda
     version: 0.2.5
   - category: main
     dependencies:
@@ -267,8 +259,7 @@ package:
     name: archspec
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.5-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.5-pyhd8ed1ab_0.conda
     version: 0.2.5
   - category: main
     dependencies:
@@ -280,8 +271,7 @@ package:
     name: archspec
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.5-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.5-pyhd8ed1ab_0.conda
     version: 0.2.5
   - category: main
     dependencies:
@@ -388,8 +378,7 @@ package:
     name: asgiref
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/asgiref-3.7.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/asgiref-3.7.2-pyhd8ed1ab_0.conda
     version: 3.7.2
   - category: main
     dependencies:
@@ -402,8 +391,7 @@ package:
     name: asgiref
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/asgiref-3.7.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/asgiref-3.7.2-pyhd8ed1ab_0.conda
     version: 3.7.2
   - category: main
     dependencies:
@@ -416,8 +404,7 @@ package:
     name: asgiref
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/asgiref-3.7.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/asgiref-3.7.2-pyhd8ed1ab_0.conda
     version: 3.7.2
   - category: main
     dependencies:
@@ -466,8 +453,7 @@ package:
     name: atk-1.0
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
     version: 2.38.0
   - category: main
     dependencies:
@@ -482,8 +468,7 @@ package:
     name: atk-1.0
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/atk-1.0-2.38.0-h4bec284_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/atk-1.0-2.38.0-h4bec284_2.conda
     version: 2.38.0
   - category: main
     dependencies:
@@ -498,8 +483,7 @@ package:
     name: atk-1.0
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/atk-1.0-2.38.0-hd03087b_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/atk-1.0-2.38.0-hd03087b_2.conda
     version: 2.38.0
   - category: main
     dependencies:
@@ -511,8 +495,7 @@ package:
     name: attrs
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
     version: 25.3.0
   - category: main
     dependencies:
@@ -524,8 +507,7 @@ package:
     name: attrs
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
     version: 25.3.0
   - category: main
     dependencies:
@@ -537,8 +519,7 @@ package:
     name: attrs
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
     version: 25.3.0
   - category: main
     dependencies:
@@ -550,8 +531,7 @@ package:
     name: backoff
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
     version: 2.2.1
   - category: main
     dependencies:
@@ -563,8 +543,7 @@ package:
     name: backoff
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
     version: 2.2.1
   - category: main
     dependencies:
@@ -576,8 +555,7 @@ package:
     name: backoff
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
     version: 2.2.1
   - category: main
     dependencies:
@@ -589,8 +567,7 @@ package:
     name: backports
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
     version: '1.0'
   - category: main
     dependencies:
@@ -602,8 +579,7 @@ package:
     name: backports
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
     version: '1.0'
   - category: main
     dependencies:
@@ -615,8 +591,7 @@ package:
     name: backports
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
     version: '1.0'
   - category: main
     dependencies:
@@ -706,45 +681,44 @@ package:
       python: ''
       python_abi: 3.11.*
     hash:
-      md5: efd25d13f36cf308c0aad577e30756fd
-      sha256: aa0013acd0d0acb6971130667e9e9d7d2587a1785722a94183952ffb28b104d5
+      md5: a38a9c54436b8c434efdbeefdb2321de
+      sha256: 3b8f244e416324c7c5ce17807c44da9b9d9ae4db9ab50329e9c408b298ca91d4
     manager: conda
     name: bcrypt
     optional: false
     platform: linux-64
     url:
-      https://conda.anaconda.org/conda-forge/linux-64/bcrypt-5.0.0-py311h902ca64_0.conda
-    version: 5.0.0
+      https://conda.anaconda.org/conda-forge/linux-64/bcrypt-4.3.0-py311h902ca64_2.conda
+    version: 4.3.0
   - category: main
     dependencies:
       __osx: '>=10.13'
       python: ''
       python_abi: 3.11.*
     hash:
-      md5: 61571f7217997b528a3d98bfd0961efc
-      sha256: e3646b8c93cc6b38f075dc5ad91bc7acc1cde9cba9ae10298be94850444aa71b
+      md5: 84047424fc198521bb06af78da690ef9
+      sha256: d194ff5296c718a1fd68b3acdd86c45c76698b2292b67797fe8cd27da512f3fb
     manager: conda
     name: bcrypt
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/bcrypt-5.0.0-py311hd2a4513_0.conda
-    version: 5.0.0
+    url: https://conda.anaconda.org/conda-forge/osx-64/bcrypt-4.3.0-py311hd3d88a1_2.conda
+    version: 4.3.0
   - category: main
     dependencies:
       __osx: '>=11.0'
       python: 3.11.*
       python_abi: 3.11.*
     hash:
-      md5: 4fe332d645e3536d8295b53925e3d3b5
-      sha256: 5df7af7bcfe8b8c21362f5751fffc18af81232275eaa3b91ba31c041a65aa1cf
+      md5: 2f35f4574ada623ca2ae6e0843c53600
+      sha256: c2fd37a65dc126e615a711c2bbc0f40c589a9f0784444b3bfdf550aab3dade72
     manager: conda
     name: bcrypt
     optional: false
     platform: osx-arm64
     url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/bcrypt-5.0.0-py311h71babbd_0.conda
-    version: 5.0.0
+      https://conda.anaconda.org/conda-forge/osx-arm64/bcrypt-4.3.0-py311h1c3fc1a_2.conda
+    version: 4.3.0
   - category: main
     dependencies:
       python: '>=3.10'
@@ -800,8 +774,7 @@ package:
     name: blinker
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
     version: 1.9.0
   - category: main
     dependencies:
@@ -813,8 +786,7 @@ package:
     name: blinker
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
     version: 1.9.0
   - category: main
     dependencies:
@@ -826,8 +798,7 @@ package:
     name: blinker
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
     version: 1.9.0
   - category: main
     dependencies:
@@ -839,8 +810,7 @@ package:
     name: boltons
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/boltons-25.0.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/boltons-25.0.0-pyhd8ed1ab_0.conda
     version: 25.0.0
   - category: main
     dependencies:
@@ -852,8 +822,7 @@ package:
     name: boltons
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/boltons-25.0.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/boltons-25.0.0-pyhd8ed1ab_0.conda
     version: 25.0.0
   - category: main
     dependencies:
@@ -865,8 +834,7 @@ package:
     name: boltons
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/boltons-25.0.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/boltons-25.0.0-pyhd8ed1ab_0.conda
     version: 25.0.0
   - category: main
     dependencies:
@@ -878,8 +846,7 @@ package:
     name: boolean.py
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/boolean.py-5.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/boolean.py-5.0-pyhd8ed1ab_0.conda
     version: '5.0'
   - category: main
     dependencies:
@@ -891,8 +858,7 @@ package:
     name: boolean.py
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/boolean.py-5.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/boolean.py-5.0-pyhd8ed1ab_0.conda
     version: '5.0'
   - category: main
     dependencies:
@@ -904,8 +870,7 @@ package:
     name: boolean.py
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/boolean.py-5.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/boolean.py-5.0-pyhd8ed1ab_0.conda
     version: '5.0'
   - category: main
     dependencies:
@@ -968,8 +933,7 @@ package:
     name: brotli
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/brotli-1.0.9-h166bdaf_9.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.0.9-h166bdaf_9.conda
     version: 1.0.9
   - category: main
     dependencies:
@@ -983,8 +947,7 @@ package:
     name: brotli
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/brotli-1.0.9-hb7f2c08_9.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.0.9-hb7f2c08_9.conda
     version: 1.0.9
   - category: main
     dependencies:
@@ -998,8 +961,7 @@ package:
     name: brotli
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.0.9-h1a8c8d9_9.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.0.9-h1a8c8d9_9.conda
     version: 1.0.9
   - category: main
     dependencies:
@@ -1027,8 +989,7 @@ package:
     name: brotli-bin
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.0.9-hb7f2c08_9.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.0.9-hb7f2c08_9.conda
     version: 1.0.9
   - category: main
     dependencies:
@@ -1101,8 +1062,7 @@ package:
     name: bzip2
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
     version: 1.0.8
   - category: main
     dependencies:
@@ -1114,8 +1074,7 @@ package:
     name: bzip2
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_8.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_8.conda
     version: 1.0.8
   - category: main
     dependencies:
@@ -1127,8 +1086,7 @@ package:
     name: bzip2
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
     version: 1.0.8
   - category: main
     dependencies:
@@ -1141,8 +1099,7 @@ package:
     name: c-ares
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.5-hb9d3cd8_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.5-hb9d3cd8_0.conda
     version: 1.34.5
   - category: main
     dependencies:
@@ -1154,8 +1111,7 @@ package:
     name: c-ares
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.5-hf13058a_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.5-hf13058a_0.conda
     version: 1.34.5
   - category: main
     dependencies:
@@ -1167,8 +1123,7 @@ package:
     name: c-ares
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.5-h5505292_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.5-h5505292_0.conda
     version: 1.34.5
   - category: main
     dependencies:
@@ -1365,8 +1320,7 @@ package:
     name: cairo
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
     version: 1.18.4
   - category: main
     dependencies:
@@ -1388,8 +1342,7 @@ package:
     name: cairo
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.4-h950ec3b_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.4-h950ec3b_0.conda
     version: 1.18.4
   - category: main
     dependencies:
@@ -1411,8 +1364,7 @@ package:
     name: cairo
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.4-h6a3b0d2_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.4-h6a3b0d2_0.conda
     version: 1.18.4
   - category: main
     dependencies:
@@ -1426,8 +1378,7 @@ package:
     name: cctools
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/cctools-1024.3-h8f84d09_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/cctools-1024.3-h8f84d09_2.conda
     version: '1024.3'
   - category: main
     dependencies:
@@ -1441,8 +1392,7 @@ package:
     name: cctools
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/cctools-1024.3-hd01ab73_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-1024.3-hd01ab73_2.conda
     version: '1024.3'
   - category: main
     dependencies:
@@ -1536,8 +1486,7 @@ package:
     name: cffi
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py311h5b438cf_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py311h5b438cf_0.conda
     version: 2.0.0
   - category: main
     dependencies:
@@ -1553,8 +1502,7 @@ package:
     name: cffi
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/cffi-2.0.0-py311h8ebb5ae_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/cffi-2.0.0-py311h8ebb5ae_0.conda
     version: 2.0.0
   - category: main
     dependencies:
@@ -1583,8 +1531,7 @@ package:
     name: cfgv
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
     version: 3.3.1
   - category: main
     dependencies:
@@ -1596,8 +1543,7 @@ package:
     name: cfgv
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
     version: 3.3.1
   - category: main
     dependencies:
@@ -1609,8 +1555,7 @@ package:
     name: cfgv
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
     version: 3.3.1
   - category: main
     dependencies:
@@ -1622,8 +1567,7 @@ package:
     name: chardet
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/chardet-5.2.0-pyhd8ed1ab_3.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/chardet-5.2.0-pyhd8ed1ab_3.conda
     version: 5.2.0
   - category: main
     dependencies:
@@ -1635,8 +1579,7 @@ package:
     name: chardet
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/chardet-5.2.0-pyhd8ed1ab_3.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/chardet-5.2.0-pyhd8ed1ab_3.conda
     version: 5.2.0
   - category: main
     dependencies:
@@ -1648,8 +1591,7 @@ package:
     name: chardet
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/chardet-5.2.0-pyhd8ed1ab_3.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/chardet-5.2.0-pyhd8ed1ab_3.conda
     version: 5.2.0
   - category: main
     dependencies:
@@ -1705,8 +1647,7 @@ package:
     name: cirun
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/cirun-0.30-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/cirun-0.30-pyhd8ed1ab_1.conda
     version: '0.30'
   - category: main
     dependencies:
@@ -1723,8 +1664,7 @@ package:
     name: cirun
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/cirun-0.30-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/cirun-0.30-pyhd8ed1ab_1.conda
     version: '0.30'
   - category: main
     dependencies:
@@ -1741,8 +1681,7 @@ package:
     name: cirun
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/cirun-0.30-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/cirun-0.30-pyhd8ed1ab_1.conda
     version: '0.30'
   - category: main
     dependencies:
@@ -1755,8 +1694,7 @@ package:
     name: click
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
     version: 8.1.8
   - category: main
     dependencies:
@@ -1769,8 +1707,7 @@ package:
     name: click
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
     version: 8.1.8
   - category: main
     dependencies:
@@ -1783,8 +1720,7 @@ package:
     name: click
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
     version: 8.1.8
   - category: main
     dependencies:
@@ -1879,8 +1815,7 @@ package:
     name: codecov
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/codecov-2.1.13-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/codecov-2.1.13-pyhd8ed1ab_1.conda
     version: 2.1.13
   - category: main
     dependencies:
@@ -1894,8 +1829,7 @@ package:
     name: codecov
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/codecov-2.1.13-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/codecov-2.1.13-pyhd8ed1ab_1.conda
     version: 2.1.13
   - category: main
     dependencies:
@@ -1909,8 +1843,7 @@ package:
     name: codecov
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/codecov-2.1.13-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/codecov-2.1.13-pyhd8ed1ab_1.conda
     version: 2.1.13
   - category: main
     dependencies:
@@ -1922,8 +1855,7 @@ package:
     name: colorama
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
     version: 0.4.6
   - category: main
     dependencies:
@@ -1935,8 +1867,7 @@ package:
     name: colorama
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
     version: 0.4.6
   - category: main
     dependencies:
@@ -1948,8 +1879,7 @@ package:
     name: colorama
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
     version: 0.4.6
   - category: main
     dependencies:
@@ -2014,8 +1944,7 @@ package:
     name: conda
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/conda-25.7.0-py311h6eed73b_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/conda-25.7.0-py311h6eed73b_0.conda
     version: 25.7.0
   - category: main
     dependencies:
@@ -3419,8 +3348,7 @@ package:
     name: crashtest
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/crashtest-0.4.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/crashtest-0.4.1-pyhd8ed1ab_1.conda
     version: 0.4.1
   - category: main
     dependencies:
@@ -3432,8 +3360,7 @@ package:
     name: crashtest
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/crashtest-0.4.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/crashtest-0.4.1-pyhd8ed1ab_1.conda
     version: 0.4.1
   - category: main
     dependencies:
@@ -3445,8 +3372,7 @@ package:
     name: crashtest
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/crashtest-0.4.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/crashtest-0.4.1-pyhd8ed1ab_1.conda
     version: 0.4.1
   - category: main
     dependencies:
@@ -3514,8 +3440,7 @@ package:
     name: curl
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/curl-8.14.1-h332b0f4_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/curl-8.14.1-h332b0f4_0.conda
     version: 8.14.1
   - category: main
     dependencies:
@@ -3533,8 +3458,7 @@ package:
     name: curl
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/curl-8.14.1-h5dec5d8_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/curl-8.14.1-h5dec5d8_0.conda
     version: 8.14.1
   - category: main
     dependencies:
@@ -3552,8 +3476,7 @@ package:
     name: curl
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/curl-8.14.1-h73640d1_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/curl-8.14.1-h73640d1_0.conda
     version: 8.14.1
   - category: main
     dependencies:
@@ -3565,8 +3488,7 @@ package:
     name: cycler
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
     version: 0.12.1
   - category: main
     dependencies:
@@ -3578,8 +3500,7 @@ package:
     name: cycler
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
     version: 0.12.1
   - category: main
     dependencies:
@@ -3591,8 +3512,7 @@ package:
     name: cycler
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
     version: 0.12.1
   - category: main
     dependencies:
@@ -3721,8 +3641,7 @@ package:
     name: dbus
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h3c4dab8_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h3c4dab8_0.conda
     version: 1.16.2
   - category: main
     dependencies:
@@ -3824,8 +3743,7 @@ package:
     name: distlib
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
     version: 0.4.0
   - category: main
     dependencies:
@@ -3837,8 +3755,7 @@ package:
     name: distlib
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
     version: 0.4.0
   - category: main
     dependencies:
@@ -3850,8 +3767,7 @@ package:
     name: distlib
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
     version: 0.4.0
   - category: main
     dependencies:
@@ -3950,8 +3866,7 @@ package:
     name: distro
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
     version: 1.9.0
   - category: main
     dependencies:
@@ -3963,8 +3878,7 @@ package:
     name: distro
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
     version: 1.9.0
   - category: main
     dependencies:
@@ -3976,8 +3890,7 @@ package:
     name: distro
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
     version: 1.9.0
   - category: main
     dependencies:
@@ -3993,8 +3906,7 @@ package:
     name: dnspython
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/dnspython-2.6.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.6.1-pyhd8ed1ab_0.conda
     version: 2.6.1
   - category: main
     dependencies:
@@ -4010,8 +3922,7 @@ package:
     name: dnspython
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/dnspython-2.6.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.6.1-pyhd8ed1ab_0.conda
     version: 2.6.1
   - category: main
     dependencies:
@@ -4027,8 +3938,7 @@ package:
     name: dnspython
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/dnspython-2.6.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.6.1-pyhd8ed1ab_0.conda
     version: 2.6.1
   - category: main
     dependencies:
@@ -4089,8 +3999,7 @@ package:
     name: editables
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_1.conda
     version: '0.5'
   - category: main
     dependencies:
@@ -4102,8 +4011,7 @@ package:
     name: editables
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_1.conda
     version: '0.5'
   - category: main
     dependencies:
@@ -4115,8 +4023,7 @@ package:
     name: editables
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_1.conda
     version: '0.5'
   - category: main
     dependencies:
@@ -4279,8 +4186,7 @@ package:
     name: epoxy
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
     version: 1.5.10
   - category: main
     dependencies:
@@ -4292,8 +4198,7 @@ package:
     name: epoxy
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/epoxy-1.5.10-h8616949_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/epoxy-1.5.10-h8616949_2.conda
     version: 1.5.10
   - category: main
     dependencies:
@@ -4305,8 +4210,7 @@ package:
     name: epoxy
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/epoxy-1.5.10-hc919400_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/epoxy-1.5.10-hc919400_2.conda
     version: 1.5.10
   - category: main
     dependencies:
@@ -4318,8 +4222,7 @@ package:
     name: evalidate
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/evalidate-2.0.5-pyhe01879c_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/evalidate-2.0.5-pyhe01879c_0.conda
     version: 2.0.5
   - category: main
     dependencies:
@@ -4331,8 +4234,7 @@ package:
     name: evalidate
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/evalidate-2.0.5-pyhe01879c_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/evalidate-2.0.5-pyhe01879c_0.conda
     version: 2.0.5
   - category: main
     dependencies:
@@ -4344,8 +4246,7 @@ package:
     name: evalidate
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/evalidate-2.0.5-pyhe01879c_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/evalidate-2.0.5-pyhe01879c_0.conda
     version: 2.0.5
   - category: main
     dependencies:
@@ -4399,8 +4300,7 @@ package:
     name: execnet
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_1.conda
     version: 2.1.1
   - category: main
     dependencies:
@@ -4412,8 +4312,7 @@ package:
     name: execnet
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_1.conda
     version: 2.1.1
   - category: main
     dependencies:
@@ -4425,8 +4324,7 @@ package:
     name: execnet
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_1.conda
     version: 2.1.1
   - category: main
     dependencies:
@@ -4444,8 +4342,7 @@ package:
     name: fastapi
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/fastapi-0.118.0-h793b878_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.118.0-h793b878_0.conda
     version: 0.118.0
   - category: main
     dependencies:
@@ -4463,8 +4360,7 @@ package:
     name: fastapi
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/fastapi-0.118.0-h793b878_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.118.0-h793b878_0.conda
     version: 0.118.0
   - category: main
     dependencies:
@@ -4482,8 +4378,7 @@ package:
     name: fastapi
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/fastapi-0.118.0-h793b878_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.118.0-h793b878_0.conda
     version: 0.118.0
   - category: main
     dependencies:
@@ -4633,8 +4528,7 @@ package:
     name: filelock
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/filelock-3.19.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.19.1-pyhd8ed1ab_0.conda
     version: 3.19.1
   - category: main
     dependencies:
@@ -4646,8 +4540,7 @@ package:
     name: filelock
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/filelock-3.19.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.19.1-pyhd8ed1ab_0.conda
     version: 3.19.1
   - category: main
     dependencies:
@@ -4659,8 +4552,7 @@ package:
     name: filelock
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/filelock-3.19.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.19.1-pyhd8ed1ab_0.conda
     version: 3.19.1
   - category: main
     dependencies:
@@ -4678,8 +4570,7 @@ package:
     name: flask
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/flask-2.3.3-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/flask-2.3.3-pyhd8ed1ab_0.conda
     version: 2.3.3
   - category: main
     dependencies:
@@ -4697,8 +4588,7 @@ package:
     name: flask
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/flask-2.3.3-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/flask-2.3.3-pyhd8ed1ab_0.conda
     version: 2.3.3
   - category: main
     dependencies:
@@ -4716,8 +4606,7 @@ package:
     name: flask
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/flask-2.3.3-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/flask-2.3.3-pyhd8ed1ab_0.conda
     version: 2.3.3
   - category: main
     dependencies:
@@ -4731,8 +4620,7 @@ package:
     name: fmt
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/fmt-11.2.0-h07f6e7f_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.2.0-h07f6e7f_0.conda
     version: 11.2.0
   - category: main
     dependencies:
@@ -4745,8 +4633,7 @@ package:
     name: fmt
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/fmt-11.2.0-hbf61d64_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/fmt-11.2.0-hbf61d64_0.conda
     version: 11.2.0
   - category: main
     dependencies:
@@ -4759,8 +4646,7 @@ package:
     name: fmt
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/fmt-11.2.0-h440487c_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-11.2.0-h440487c_0.conda
     version: 11.2.0
   - category: main
     dependencies: {}
@@ -4937,8 +4823,7 @@ package:
     name: fontconfig
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.15.0-h37eeddb_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.15.0-h37eeddb_1.conda
     version: 2.15.0
   - category: main
     dependencies:
@@ -4966,8 +4851,7 @@ package:
     name: fonts-conda-ecosystem
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+    url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
     version: '1'
   - category: main
     dependencies:
@@ -4979,8 +4863,7 @@ package:
     name: fonts-conda-ecosystem
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+    url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
     version: '1'
   - category: main
     dependencies:
@@ -4992,8 +4875,7 @@ package:
     name: fonts-conda-ecosystem
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+    url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
     version: '1'
   - category: main
     dependencies:
@@ -5008,8 +4890,7 @@ package:
     name: fonts-conda-forge
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+    url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
     version: '1'
   - category: main
     dependencies:
@@ -5024,8 +4905,7 @@ package:
     name: fonts-conda-forge
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+    url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
     version: '1'
   - category: main
     dependencies:
@@ -5040,8 +4920,7 @@ package:
     name: fonts-conda-forge
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+    url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
     version: '1'
   - category: main
     dependencies:
@@ -5109,8 +4988,7 @@ package:
     name: freetype
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.1-ha770c72_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.1-ha770c72_0.conda
     version: 2.14.1
   - category: main
     dependencies:
@@ -5123,8 +5001,7 @@ package:
     name: freetype
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/freetype-2.14.1-h694c41f_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.14.1-h694c41f_0.conda
     version: 2.14.1
   - category: main
     dependencies:
@@ -5151,8 +5028,7 @@ package:
     name: fribidi
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
     version: 1.0.16
   - category: main
     dependencies:
@@ -5164,8 +5040,7 @@ package:
     name: fribidi
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/fribidi-1.0.16-h8616949_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/fribidi-1.0.16-h8616949_0.conda
     version: 1.0.16
   - category: main
     dependencies:
@@ -5177,8 +5052,7 @@ package:
     name: fribidi
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.16-hc919400_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.16-hc919400_0.conda
     version: 1.0.16
   - category: main
     dependencies:
@@ -5236,8 +5110,7 @@ package:
     name: fsspec
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.9.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.9.0-pyhd8ed1ab_0.conda
     version: 2025.9.0
   - category: main
     dependencies:
@@ -5249,8 +5122,7 @@ package:
     name: fsspec
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.9.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.9.0-pyhd8ed1ab_0.conda
     version: 2025.9.0
   - category: main
     dependencies:
@@ -5262,8 +5134,7 @@ package:
     name: fsspec
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.9.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.9.0-pyhd8ed1ab_0.conda
     version: 2025.9.0
   - category: main
     dependencies:
@@ -5361,8 +5232,7 @@ package:
     name: git
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/git-2.49.0-pl5321h3bb66fe_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/git-2.49.0-pl5321h3bb66fe_2.conda
     version: 2.49.0
   - category: main
     dependencies:
@@ -5396,8 +5266,7 @@ package:
     name: gitdb
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
     version: 4.0.12
   - category: main
     dependencies:
@@ -5410,8 +5279,7 @@ package:
     name: gitdb
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
     version: 4.0.12
   - category: main
     dependencies:
@@ -5424,8 +5292,7 @@ package:
     name: gitdb
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
     version: 4.0.12
   - category: main
     dependencies:
@@ -5550,8 +5417,7 @@ package:
     name: glib-tools
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/glib-tools-2.84.3-h35d42e9_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/glib-tools-2.84.3-h35d42e9_0.conda
     version: 2.84.3
   - category: main
     dependencies:
@@ -5579,8 +5445,7 @@ package:
     name: gmp
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
     version: 6.3.0
   - category: main
     dependencies:
@@ -5593,8 +5458,7 @@ package:
     name: gmp
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-hf036a51_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-hf036a51_2.conda
     version: 6.3.0
   - category: main
     dependencies:
@@ -5607,8 +5471,7 @@ package:
     name: gmp
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
     version: 6.3.0
   - category: main
     dependencies:
@@ -5636,8 +5499,7 @@ package:
     name: graphite2
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/graphite2-1.3.14-h21dd04a_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/graphite2-1.3.14-h21dd04a_2.conda
     version: 1.3.14
   - category: main
     dependencies:
@@ -5678,8 +5540,7 @@ package:
     name: graphviz
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/graphviz-13.1.2-h87b6fe6_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/graphviz-13.1.2-h87b6fe6_0.conda
     version: 13.1.2
   - category: main
     dependencies:
@@ -5705,8 +5566,7 @@ package:
     name: graphviz
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/graphviz-13.1.2-h42bfd48_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/graphviz-13.1.2-h42bfd48_0.conda
     version: 13.1.2
   - category: main
     dependencies:
@@ -5760,8 +5620,7 @@ package:
     name: grayskull
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/grayskull-2.9.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/grayskull-2.9.1-pyhd8ed1ab_0.conda
     version: 2.9.1
   - category: main
     dependencies:
@@ -5788,8 +5647,7 @@ package:
     name: grayskull
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/grayskull-2.9.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/grayskull-2.9.1-pyhd8ed1ab_0.conda
     version: 2.9.1
   - category: main
     dependencies:
@@ -5816,8 +5674,7 @@ package:
     name: grayskull
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/grayskull-2.9.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/grayskull-2.9.1-pyhd8ed1ab_0.conda
     version: 2.9.1
   - category: main
     dependencies:
@@ -5859,8 +5716,7 @@ package:
     name: gtk3
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h0c6a113_5.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h0c6a113_5.conda
     version: 3.24.43
   - category: main
     dependencies:
@@ -5886,8 +5742,7 @@ package:
     name: gtk3
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/gtk3-3.24.43-h70b172e_5.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/gtk3-3.24.43-h70b172e_5.conda
     version: 3.24.43
   - category: main
     dependencies:
@@ -5913,8 +5768,7 @@ package:
     name: gtk3
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/gtk3-3.24.43-h07173f4_5.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/gtk3-3.24.43-h07173f4_5.conda
     version: 3.24.43
   - category: main
     dependencies:
@@ -5928,8 +5782,7 @@ package:
     name: gts
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
     version: 0.7.6
   - category: main
     dependencies:
@@ -5942,8 +5795,7 @@ package:
     name: gts
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/gts-0.7.6-h53e17e3_4.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/gts-0.7.6-h53e17e3_4.conda
     version: 0.7.6
   - category: main
     dependencies:
@@ -5956,8 +5808,7 @@ package:
     name: gts
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/gts-0.7.6-he42f4ea_4.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/gts-0.7.6-he42f4ea_4.conda
     version: 0.7.6
   - category: main
     dependencies:
@@ -5970,8 +5821,7 @@ package:
     name: h11
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
     version: 0.14.0
   - category: main
     dependencies:
@@ -5984,8 +5834,7 @@ package:
     name: h11
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
     version: 0.14.0
   - category: main
     dependencies:
@@ -5998,8 +5847,7 @@ package:
     name: h11
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
     version: 0.14.0
   - category: main
     dependencies:
@@ -6013,8 +5861,7 @@ package:
     name: h2
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
     version: 4.3.0
   - category: main
     dependencies:
@@ -6028,8 +5875,7 @@ package:
     name: h2
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
     version: 4.3.0
   - category: main
     dependencies:
@@ -6043,8 +5889,7 @@ package:
     name: h2
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
     version: 4.3.0
   - category: main
     dependencies:
@@ -6066,8 +5911,7 @@ package:
     name: harfbuzz
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-11.4.5-h15599e2_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-11.4.5-h15599e2_0.conda
     version: 11.4.5
   - category: main
     dependencies:
@@ -6088,8 +5932,7 @@ package:
     name: harfbuzz
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-11.4.5-h0ffbb26_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-11.4.5-h0ffbb26_0.conda
     version: 11.4.5
   - category: main
     dependencies:
@@ -6139,8 +5982,7 @@ package:
     name: hatch
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/hatch-1.14.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/hatch-1.14.1-pyhd8ed1ab_0.conda
     version: 1.14.1
   - category: main
     dependencies:
@@ -6168,8 +6010,7 @@ package:
     name: hatch
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/hatch-1.14.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/hatch-1.14.1-pyhd8ed1ab_0.conda
     version: 1.14.1
   - category: main
     dependencies:
@@ -6197,8 +6038,7 @@ package:
     name: hatch
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/hatch-1.14.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/hatch-1.14.1-pyhd8ed1ab_0.conda
     version: 1.14.1
   - category: main
     dependencies:
@@ -6306,8 +6146,7 @@ package:
     name: hpack
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
     version: 4.1.0
   - category: main
     dependencies:
@@ -6319,8 +6158,7 @@ package:
     name: hpack
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
     version: 4.1.0
   - category: main
     dependencies:
@@ -6332,8 +6170,7 @@ package:
     name: hpack
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
     version: 4.1.0
   - category: main
     dependencies:
@@ -6350,8 +6187,7 @@ package:
     name: httpcore
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
     version: 1.0.7
   - category: main
     dependencies:
@@ -6368,8 +6204,7 @@ package:
     name: httpcore
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
     version: 1.0.7
   - category: main
     dependencies:
@@ -6386,8 +6221,7 @@ package:
     name: httpcore
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
     version: 1.0.7
   - category: main
     dependencies:
@@ -6449,8 +6283,7 @@ package:
     name: httpx
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
     version: 0.28.1
   - category: main
     dependencies:
@@ -6466,8 +6299,7 @@ package:
     name: httpx
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
     version: 0.28.1
   - category: main
     dependencies:
@@ -6483,8 +6315,7 @@ package:
     name: httpx
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
     version: 0.28.1
   - category: main
     dependencies:
@@ -6579,8 +6410,7 @@ package:
     name: icu
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
     version: '75.1'
   - category: main
     dependencies:
@@ -6604,8 +6434,7 @@ package:
     name: icu
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
     version: '75.1'
   - category: main
     dependencies:
@@ -6618,8 +6447,7 @@ package:
     name: identify
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/identify-2.6.14-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.14-pyhd8ed1ab_0.conda
     version: 2.6.14
   - category: main
     dependencies:
@@ -6632,8 +6460,7 @@ package:
     name: identify
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/identify-2.6.14-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.14-pyhd8ed1ab_0.conda
     version: 2.6.14
   - category: main
     dependencies:
@@ -6646,8 +6473,7 @@ package:
     name: identify
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/identify-2.6.14-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.14-pyhd8ed1ab_0.conda
     version: 2.6.14
   - category: main
     dependencies:
@@ -6659,8 +6485,7 @@ package:
     name: idna
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
     version: '3.10'
   - category: main
     dependencies:
@@ -6672,8 +6497,7 @@ package:
     name: idna
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
     version: '3.10'
   - category: main
     dependencies:
@@ -6685,8 +6509,7 @@ package:
     name: idna
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
     version: '3.10'
   - category: main
     dependencies:
@@ -6782,8 +6605,7 @@ package:
     name: iniconfig
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
     version: 2.0.0
   - category: main
     dependencies:
@@ -6795,8 +6617,7 @@ package:
     name: iniconfig
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
     version: 2.0.0
   - category: main
     dependencies:
@@ -6808,8 +6629,7 @@ package:
     name: iniconfig
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
     version: 2.0.0
   - category: main
     dependencies:
@@ -6821,8 +6641,7 @@ package:
     name: isodate
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/isodate-0.7.2-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/isodate-0.7.2-pyhd8ed1ab_1.conda
     version: 0.7.2
   - category: main
     dependencies:
@@ -6834,8 +6653,7 @@ package:
     name: isodate
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/isodate-0.7.2-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/isodate-0.7.2-pyhd8ed1ab_1.conda
     version: 0.7.2
   - category: main
     dependencies:
@@ -6847,8 +6665,7 @@ package:
     name: isodate
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/isodate-0.7.2-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/isodate-0.7.2-pyhd8ed1ab_1.conda
     version: 0.7.2
   - category: main
     dependencies:
@@ -7025,8 +6842,7 @@ package:
     name: jeepney
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/jeepney-0.9.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/jeepney-0.9.0-pyhd8ed1ab_0.conda
     version: 0.9.0
   - category: main
     dependencies:
@@ -7039,8 +6855,7 @@ package:
     name: jinja2
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
     version: 3.1.6
   - category: main
     dependencies:
@@ -7053,8 +6868,7 @@ package:
     name: jinja2
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
     version: 3.1.6
   - category: main
     dependencies:
@@ -7067,8 +6881,7 @@ package:
     name: jinja2
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
     version: 3.1.6
   - category: main
     dependencies:
@@ -7080,8 +6893,7 @@ package:
     name: jmespath
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
     version: 1.0.1
   - category: main
     dependencies:
@@ -7093,8 +6905,7 @@ package:
     name: jmespath
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
     version: 1.0.1
   - category: main
     dependencies:
@@ -7106,8 +6917,7 @@ package:
     name: jmespath
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
     version: 1.0.1
   - category: main
     dependencies:
@@ -7120,8 +6930,7 @@ package:
     name: jsonpatch
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda
     version: '1.33'
   - category: main
     dependencies:
@@ -7134,8 +6943,7 @@ package:
     name: jsonpatch
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda
     version: '1.33'
   - category: main
     dependencies:
@@ -7148,8 +6956,7 @@ package:
     name: jsonpatch
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda
     version: '1.33'
   - category: main
     dependencies:
@@ -7343,8 +7150,7 @@ package:
     name: keyring
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/keyring-25.6.0-pyha804496_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/keyring-25.6.0-pyha804496_0.conda
     version: 25.6.0
   - category: main
     dependencies:
@@ -7362,8 +7168,7 @@ package:
     name: keyring
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/keyring-25.6.0-pyh534df25_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/keyring-25.6.0-pyh534df25_0.conda
     version: 25.6.0
   - category: main
     dependencies:
@@ -7381,8 +7186,7 @@ package:
     name: keyring
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/keyring-25.6.0-pyh534df25_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/keyring-25.6.0-pyh534df25_0.conda
     version: 25.6.0
   - category: main
     dependencies:
@@ -7395,8 +7199,7 @@ package:
     name: keyutils
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
     version: 1.6.3
   - category: main
     dependencies:
@@ -7461,8 +7264,7 @@ package:
     name: krb5
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
     version: 1.21.3
   - category: main
     dependencies:
@@ -7477,8 +7279,7 @@ package:
     name: krb5
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
     version: 1.21.3
   - category: main
     dependencies:
@@ -7493,8 +7294,7 @@ package:
     name: krb5
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
     version: 1.21.3
   - category: main
     dependencies:
@@ -7509,8 +7309,7 @@ package:
     name: lcms2
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.17-h717163a_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.17-h717163a_0.conda
     version: '2.17'
   - category: main
     dependencies:
@@ -7524,8 +7323,7 @@ package:
     name: lcms2
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.17-h72f5680_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.17-h72f5680_0.conda
     version: '2.17'
   - category: main
     dependencies:
@@ -7539,8 +7337,7 @@ package:
     name: lcms2
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.17-h7eeda09_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.17-h7eeda09_0.conda
     version: '2.17'
   - category: main
     dependencies:
@@ -7553,8 +7350,7 @@ package:
     name: ld64
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/ld64-955.13-h2b71b23_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/ld64-955.13-h2b71b23_2.conda
     version: '955.13'
   - category: main
     dependencies:
@@ -7567,8 +7363,7 @@ package:
     name: ld64
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/ld64-955.13-he86490a_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-955.13-he86490a_2.conda
     version: '955.13'
   - category: main
     dependencies:
@@ -7628,8 +7423,7 @@ package:
     name: ldap3
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/ldap3-2.9.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/ldap3-2.9.1-pyhd8ed1ab_1.conda
     version: 2.9.1
   - category: main
     dependencies:
@@ -7642,8 +7436,7 @@ package:
     name: ldap3
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/ldap3-2.9.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/ldap3-2.9.1-pyhd8ed1ab_1.conda
     version: 2.9.1
   - category: main
     dependencies:
@@ -7656,8 +7449,7 @@ package:
     name: ldap3
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/ldap3-2.9.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/ldap3-2.9.1-pyhd8ed1ab_1.conda
     version: 2.9.1
   - category: main
     dependencies:
@@ -7671,8 +7463,7 @@ package:
     name: lerc
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
     version: 4.0.0
   - category: main
     dependencies:
@@ -7685,8 +7476,7 @@ package:
     name: lerc
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hcca01a6_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hcca01a6_1.conda
     version: 4.0.0
   - category: main
     dependencies:
@@ -7699,8 +7489,7 @@ package:
     name: lerc
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-hd64df32_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-hd64df32_1.conda
     version: 4.0.0
   - category: main
     dependencies:
@@ -8063,8 +7852,7 @@ package:
     name: libcups
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-hb8b1518_5.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-hb8b1518_5.conda
     version: 2.3.3
   - category: main
     dependencies:
@@ -8083,8 +7871,7 @@ package:
     name: libcurl
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.14.1-h332b0f4_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.14.1-h332b0f4_0.conda
     version: 8.14.1
   - category: main
     dependencies:
@@ -8102,8 +7889,7 @@ package:
     name: libcurl
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.14.1-h5dec5d8_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.14.1-h5dec5d8_0.conda
     version: 8.14.1
   - category: main
     dependencies:
@@ -8121,8 +7907,7 @@ package:
     name: libcurl
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.14.1-h73640d1_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.14.1-h73640d1_0.conda
     version: 8.14.1
   - category: main
     dependencies:
@@ -8134,8 +7919,7 @@ package:
     name: libcxx
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libcxx-21.1.2-h3d58e20_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-21.1.2-h3d58e20_0.conda
     version: 21.1.2
   - category: main
     dependencies:
@@ -8147,8 +7931,7 @@ package:
     name: libcxx
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.2-hf598326_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.2-hf598326_0.conda
     version: 21.1.2
   - category: main
     dependencies:
@@ -8161,8 +7944,7 @@ package:
     name: libdeflate
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.24-h86f0d12_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.24-h86f0d12_0.conda
     version: '1.24'
   - category: main
     dependencies:
@@ -8174,8 +7956,7 @@ package:
     name: libdeflate
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.24-hcc1b750_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.24-hcc1b750_0.conda
     version: '1.24'
   - category: main
     dependencies:
@@ -8202,8 +7983,7 @@ package:
     name: libdrm
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
     version: 2.4.125
   - category: main
     dependencies:
@@ -8259,8 +8039,7 @@ package:
     name: libegl
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
     version: 1.7.0
   - category: main
     dependencies:
@@ -8288,8 +8067,7 @@ package:
     name: libev
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
     version: '4.33'
   - category: main
     dependencies: {}
@@ -8300,8 +8078,7 @@ package:
     name: libev
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
     version: '4.33'
   - category: main
     dependencies: {}
@@ -8312,8 +8089,7 @@ package:
     name: libev
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
     version: '4.33'
   - category: main
     dependencies:
@@ -8326,8 +8102,7 @@ package:
     name: libexpat
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
     version: 2.7.1
   - category: main
     dependencies:
@@ -8339,8 +8114,7 @@ package:
     name: libexpat
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.1-h21dd04a_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.1-h21dd04a_0.conda
     version: 2.7.1
   - category: main
     dependencies:
@@ -8352,8 +8126,7 @@ package:
     name: libexpat
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
     version: 2.7.1
   - category: main
     dependencies:
@@ -8366,8 +8139,7 @@ package:
     name: libffi
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
     version: 3.4.6
   - category: main
     dependencies:
@@ -8379,8 +8151,7 @@ package:
     name: libffi
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.6-h281671d_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.6-h281671d_1.conda
     version: 3.4.6
   - category: main
     dependencies:
@@ -8392,8 +8163,7 @@ package:
     name: libffi
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
     version: 3.4.6
   - category: main
     dependencies:
@@ -8491,8 +8261,7 @@ package:
     name: libgcc
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_5.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_5.conda
     version: 15.1.0
   - category: main
     dependencies:
@@ -8528,8 +8297,7 @@ package:
     name: libgd
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
     version: 2.3.3
   - category: main
     dependencies:
@@ -8552,8 +8320,7 @@ package:
     name: libgd
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libgd-2.3.3-h8555400_11.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libgd-2.3.3-h8555400_11.conda
     version: 2.3.3
   - category: main
     dependencies:
@@ -8576,8 +8343,7 @@ package:
     name: libgd
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/libgd-2.3.3-hb2c3a21_11.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libgd-2.3.3-hb2c3a21_11.conda
     version: 2.3.3
   - category: main
     dependencies:
@@ -8719,8 +8485,7 @@ package:
     name: libgit2
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libgit2-1.9.1-h014eb84_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgit2-1.9.1-h014eb84_0.conda
     version: 1.9.1
   - category: main
     dependencies:
@@ -8738,8 +8503,7 @@ package:
     name: libgit2
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libgit2-1.9.1-h1b783f7_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libgit2-1.9.1-h1b783f7_0.conda
     version: 1.9.1
   - category: main
     dependencies:
@@ -8757,8 +8521,7 @@ package:
     name: libgit2
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/libgit2-1.9.1-h41192e5_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libgit2-1.9.1-h41192e5_0.conda
     version: 1.9.1
   - category: main
     dependencies:
@@ -8772,8 +8535,7 @@ package:
     name: libgl
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
     version: 1.7.0
   - category: main
     dependencies:
@@ -8805,8 +8567,7 @@ package:
     name: libglib
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libglib-2.84.3-hf39c6af_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.84.3-hf39c6af_0.conda
     version: 2.84.3
   - category: main
     dependencies:
@@ -8823,8 +8584,7 @@ package:
     name: libglib
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libglib-2.84.3-h5fed8df_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.84.3-h5fed8df_0.conda
     version: 2.84.3
   - category: main
     dependencies:
@@ -8841,8 +8601,7 @@ package:
     name: libglib
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.84.3-h587fa63_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.84.3-h587fa63_0.conda
     version: 2.84.3
   - category: main
     dependencies:
@@ -8854,8 +8613,7 @@ package:
     name: libglvnd
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
     version: 1.7.0
   - category: main
     dependencies:
@@ -8869,8 +8627,7 @@ package:
     name: libglx
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
     version: 1.7.0
   - category: main
     dependencies:
@@ -8898,8 +8655,7 @@ package:
     name: libgomp
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_5.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_5.conda
     version: 15.1.0
   - category: main
     dependencies:
@@ -8912,8 +8668,7 @@ package:
     name: libiconv
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
     version: '1.18'
   - category: main
     dependencies:
@@ -8925,8 +8680,7 @@ package:
     name: libiconv
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h57a12c2_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h57a12c2_2.conda
     version: '1.18'
   - category: main
     dependencies:
@@ -8938,8 +8692,7 @@ package:
     name: libiconv
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
     version: '1.18'
   - category: main
     dependencies:
@@ -8955,8 +8708,7 @@ package:
     name: libidn2
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.8-ha4ef2c3_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.8-ha4ef2c3_0.conda
     version: 2.3.8
   - category: main
     dependencies:
@@ -8972,8 +8724,7 @@ package:
     name: libidn2
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libidn2-2.3.8-he8ff88c_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libidn2-2.3.8-he8ff88c_0.conda
     version: 2.3.8
   - category: main
     dependencies:
@@ -8989,8 +8740,7 @@ package:
     name: libidn2
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/libidn2-2.3.8-h38aa460_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libidn2-2.3.8-h38aa460_0.conda
     version: 2.3.8
   - category: main
     dependencies:
@@ -9003,8 +8753,7 @@ package:
     name: libintl
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libintl-0.25.1-h3184127_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.25.1-h3184127_1.conda
     version: 0.25.1
   - category: main
     dependencies:
@@ -9017,8 +8766,7 @@ package:
     name: libintl
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
     version: 0.25.1
   - category: main
     dependencies:
@@ -9112,8 +8860,7 @@ package:
     name: liblief
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/liblief-0.16.6-h5888daf_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/liblief-0.16.6-h5888daf_0.conda
     version: 0.16.6
   - category: main
     dependencies:
@@ -9127,8 +8874,7 @@ package:
     name: liblief
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/liblief-0.16.6-h240833e_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/liblief-0.16.6-h240833e_0.conda
     version: 0.16.6
   - category: main
     dependencies:
@@ -9142,8 +8888,7 @@ package:
     name: liblief
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/liblief-0.16.6-h286801f_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/liblief-0.16.6-h286801f_0.conda
     version: 0.16.6
   - category: main
     dependencies:
@@ -9176,8 +8921,7 @@ package:
     name: libllvm20
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libllvm20-20.1.8-h9b4ebcc_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libllvm20-20.1.8-h9b4ebcc_0.conda
     version: 20.1.8
   - category: main
     dependencies:
@@ -9190,8 +8934,7 @@ package:
     name: liblzma
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
     version: 5.8.1
   - category: main
     dependencies:
@@ -9203,8 +8946,7 @@ package:
     name: liblzma
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.1-hd471939_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.1-hd471939_2.conda
     version: 5.8.1
   - category: main
     dependencies:
@@ -9216,8 +8958,7 @@ package:
     name: liblzma
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
     version: 5.8.1
   - category: main
     dependencies:
@@ -9243,8 +8984,7 @@ package:
     name: libmamba
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libmamba-2.3.2-hae34dd5_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libmamba-2.3.2-hae34dd5_0.conda
     version: 2.3.2
   - category: main
     dependencies:
@@ -9269,8 +9009,7 @@ package:
     name: libmamba
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libmamba-2.3.2-he8ad368_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libmamba-2.3.2-he8ad368_0.conda
     version: 2.3.2
   - category: main
     dependencies:
@@ -9295,8 +9034,7 @@ package:
     name: libmamba
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/libmamba-2.3.2-he5fc5d6_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libmamba-2.3.2-he5fc5d6_0.conda
     version: 2.3.2
   - category: main
     dependencies:
@@ -9399,8 +9137,7 @@ package:
     name: libnghttp2
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.67.0-h3338091_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.67.0-h3338091_0.conda
     version: 1.67.0
   - category: main
     dependencies:
@@ -9431,8 +9168,7 @@ package:
     name: libnsl
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
     version: 2.0.1
   - category: main
     dependencies:
@@ -9508,8 +9244,7 @@ package:
     name: libpng
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.50-h421ea60_1.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.50-h421ea60_1.conda
     version: 1.6.50
   - category: main
     dependencies:
@@ -9522,8 +9257,7 @@ package:
     name: libpng
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.50-h84aeda2_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.50-h84aeda2_1.conda
     version: 1.6.50
   - category: main
     dependencies:
@@ -9536,8 +9270,7 @@ package:
     name: libpng
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.50-h280e0eb_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.50-h280e0eb_1.conda
     version: 1.6.50
   - category: main
     dependencies:
@@ -9607,8 +9340,7 @@ package:
     name: librsvg
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-he92a37e_3.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-he92a37e_3.conda
     version: 2.58.4
   - category: main
     dependencies:
@@ -9625,8 +9357,7 @@ package:
     name: librsvg
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/librsvg-2.58.4-h21a6cfa_3.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/librsvg-2.58.4-h21a6cfa_3.conda
     version: 2.58.4
   - category: main
     dependencies:
@@ -9643,8 +9374,7 @@ package:
     name: librsvg
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.58.4-h266df6f_3.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.58.4-h266df6f_3.conda
     version: 2.58.4
   - category: main
     dependencies:
@@ -9669,8 +9399,7 @@ package:
     name: libsodium
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
     version: 1.0.20
   - category: main
     dependencies:
@@ -9698,8 +9427,7 @@ package:
     name: libsolv
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libsolv-0.7.35-h9463b59_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libsolv-0.7.35-h9463b59_0.conda
     version: 0.7.35
   - category: main
     dependencies:
@@ -9713,8 +9441,7 @@ package:
     name: libsolv
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libsolv-0.7.35-h6fd32b5_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libsolv-0.7.35-h6fd32b5_0.conda
     version: 0.7.35
   - category: main
     dependencies:
@@ -9728,8 +9455,7 @@ package:
     name: libsolv
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/libsolv-0.7.35-h5f525b2_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libsolv-0.7.35-h5f525b2_0.conda
     version: 0.7.35
   - category: main
     dependencies:
@@ -9757,8 +9483,7 @@ package:
     name: libsqlite
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.50.4-h39a8b3b_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.50.4-h39a8b3b_0.conda
     version: 3.50.4
   - category: main
     dependencies:
@@ -9788,8 +9513,7 @@ package:
     name: libssh2
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
     version: 1.11.1
   - category: main
     dependencies:
@@ -9803,8 +9527,7 @@ package:
     name: libssh2
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-hed3591d_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-hed3591d_0.conda
     version: 1.11.1
   - category: main
     dependencies:
@@ -9817,8 +9540,7 @@ package:
     name: libssh2
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
     version: 1.11.1
   - category: main
     dependencies:
@@ -9866,8 +9588,7 @@ package:
     name: libtiff
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h8261f1e_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h8261f1e_0.conda
     version: 4.7.1
   - category: main
     dependencies:
@@ -9887,8 +9608,7 @@ package:
     name: libtiff
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.1-haa3b502_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.1-haa3b502_0.conda
     version: 4.7.1
   - category: main
     dependencies:
@@ -9908,8 +9628,7 @@ package:
     name: libtiff
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.1-h7dc4979_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.1-h7dc4979_0.conda
     version: 4.7.1
   - category: main
     dependencies:
@@ -9959,8 +9678,7 @@ package:
     name: libuuid
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
     version: 2.41.2
   - category: main
     dependencies:
@@ -9973,8 +9691,7 @@ package:
     name: libuv
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
     version: 1.51.0
   - category: main
     dependencies:
@@ -9986,8 +9703,7 @@ package:
     name: libuv
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libuv-1.51.0-h58003a5_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.51.0-h58003a5_1.conda
     version: 1.51.0
   - category: main
     dependencies:
@@ -9999,8 +9715,7 @@ package:
     name: libuv
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.51.0-h6caf38d_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.51.0-h6caf38d_1.conda
     version: 1.51.0
   - category: main
     dependencies:
@@ -10056,8 +9771,7 @@ package:
     name: libxcb
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
     version: 1.17.0
   - category: main
     dependencies:
@@ -10072,8 +9786,7 @@ package:
     name: libxcb
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
     version: 1.17.0
   - category: main
     dependencies:
@@ -10088,8 +9801,7 @@ package:
     name: libxcb
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
     version: 1.17.0
   - category: main
     dependencies:
@@ -10138,8 +9850,7 @@ package:
     name: libxml2
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.8-h04c0eec_1.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.8-h04c0eec_1.conda
     version: 2.13.8
   - category: main
     dependencies:
@@ -10155,8 +9866,7 @@ package:
     name: libxml2
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.8-he1bc88e_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.8-he1bc88e_1.conda
     version: 2.13.8
   - category: main
     dependencies:
@@ -10172,8 +9882,7 @@ package:
     name: libxml2
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.8-h4a9ca0c_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.8-h4a9ca0c_1.conda
     version: 2.13.8
   - category: main
     dependencies:
@@ -10186,8 +9895,7 @@ package:
     name: libzlib
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
     version: 1.3.1
   - category: main
     dependencies:
@@ -10199,8 +9907,7 @@ package:
     name: libzlib
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
     version: 1.3.1
   - category: main
     dependencies:
@@ -10212,8 +9919,7 @@ package:
     name: libzlib
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
     version: 1.3.1
   - category: main
     dependencies:
@@ -10295,8 +10001,7 @@ package:
     name: llvm-tools
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-20.1.8-hc040464_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-20.1.8-hc040464_0.conda
     version: 20.1.8
   - category: main
     dependencies:
@@ -10357,8 +10062,7 @@ package:
     name: locket
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+    url: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
     version: 1.0.0
   - category: main
     dependencies:
@@ -10370,8 +10074,7 @@ package:
     name: locket
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+    url: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
     version: 1.0.0
   - category: main
     dependencies:
@@ -10383,8 +10086,7 @@ package:
     name: locket
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+    url: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
     version: 1.0.0
   - category: main
     dependencies:
@@ -10396,8 +10098,7 @@ package:
     name: lockfile
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/lockfile-0.12.2-py_1.tar.bz2
+    url: https://conda.anaconda.org/conda-forge/noarch/lockfile-0.12.2-py_1.tar.bz2
     version: 0.12.2
   - category: main
     dependencies:
@@ -10409,8 +10110,7 @@ package:
     name: lockfile
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/lockfile-0.12.2-py_1.tar.bz2
+    url: https://conda.anaconda.org/conda-forge/noarch/lockfile-0.12.2-py_1.tar.bz2
     version: 0.12.2
   - category: main
     dependencies:
@@ -10422,8 +10122,7 @@ package:
     name: lockfile
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/lockfile-0.12.2-py_1.tar.bz2
+    url: https://conda.anaconda.org/conda-forge/noarch/lockfile-0.12.2-py_1.tar.bz2
     version: 0.12.2
   - category: main
     dependencies:
@@ -10437,8 +10136,7 @@ package:
     name: lz4-c
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
     version: 1.10.0
   - category: main
     dependencies:
@@ -10451,8 +10149,7 @@ package:
     name: lz4-c
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.10.0-h240833e_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.10.0-h240833e_1.conda
     version: 1.10.0
   - category: main
     dependencies:
@@ -10465,8 +10162,7 @@ package:
     name: lz4-c
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
     version: 1.10.0
   - category: main
     dependencies:
@@ -10479,8 +10175,7 @@ package:
     name: lzo
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-h280c20c_1002.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-h280c20c_1002.conda
     version: '2.10'
   - category: main
     dependencies:
@@ -10492,8 +10187,7 @@ package:
     name: lzo
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-h4132b18_1002.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-h4132b18_1002.conda
     version: '2.10'
   - category: main
     dependencies:
@@ -10505,8 +10199,7 @@ package:
     name: lzo
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h925e9cb_1002.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h925e9cb_1002.conda
     version: '2.10'
   - category: main
     dependencies:
@@ -10522,8 +10215,7 @@ package:
     name: mamba
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/mamba-2.3.2-h441483a_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/mamba-2.3.2-h441483a_0.conda
     version: 2.3.2
   - category: main
     dependencies:
@@ -10540,8 +10232,7 @@ package:
     name: mamba
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/mamba-2.3.2-hff38754_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/mamba-2.3.2-hff38754_0.conda
     version: 2.3.2
   - category: main
     dependencies:
@@ -10558,8 +10249,7 @@ package:
     name: mamba
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/mamba-2.3.2-he44f4b9_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/mamba-2.3.2-he44f4b9_0.conda
     version: 2.3.2
   - category: main
     dependencies:
@@ -10750,8 +10440,7 @@ package:
     name: mbedtls
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/mbedtls-3.6.3.1-h5888daf_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/mbedtls-3.6.3.1-h5888daf_0.conda
     version: 3.6.3.1
   - category: main
     dependencies:
@@ -10764,8 +10453,7 @@ package:
     name: mbedtls
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/mbedtls-3.6.3.1-h240833e_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/mbedtls-3.6.3.1-h240833e_0.conda
     version: 3.6.3.1
   - category: main
     dependencies:
@@ -10791,8 +10479,7 @@ package:
     name: mdurl
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
     version: 0.1.2
   - category: main
     dependencies:
@@ -10804,8 +10491,7 @@ package:
     name: mdurl
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
     version: 0.1.2
   - category: main
     dependencies:
@@ -10817,8 +10503,7 @@ package:
     name: mdurl
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
     version: 0.1.2
   - category: main
     dependencies:
@@ -11076,8 +10761,7 @@ package:
     name: msrest
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/msrest-0.6.21-pyh44b312d_0.tar.bz2
+    url: https://conda.anaconda.org/conda-forge/noarch/msrest-0.6.21-pyh44b312d_0.tar.bz2
     version: 0.6.21
   - category: main
     dependencies:
@@ -11093,8 +10777,7 @@ package:
     name: msrest
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/msrest-0.6.21-pyh44b312d_0.tar.bz2
+    url: https://conda.anaconda.org/conda-forge/noarch/msrest-0.6.21-pyh44b312d_0.tar.bz2
     version: 0.6.21
   - category: main
     dependencies:
@@ -11110,8 +10793,7 @@ package:
     name: msrest
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/msrest-0.6.21-pyh44b312d_0.tar.bz2
+    url: https://conda.anaconda.org/conda-forge/noarch/msrest-0.6.21-pyh44b312d_0.tar.bz2
     version: 0.6.21
   - category: main
     dependencies:
@@ -11123,8 +10805,7 @@ package:
     name: munkres
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
     version: 1.1.4
   - category: main
     dependencies:
@@ -11136,8 +10817,7 @@ package:
     name: munkres
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
     version: 1.1.4
   - category: main
     dependencies:
@@ -11149,8 +10829,7 @@ package:
     name: munkres
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
     version: 1.1.4
   - category: main
     dependencies:
@@ -11188,8 +10867,7 @@ package:
     name: mypy
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/mypy-1.18.2-py311hf197a57_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.18.2-py311hf197a57_0.conda
     version: 1.18.2
   - category: main
     dependencies:
@@ -11260,8 +10938,7 @@ package:
     name: ncurses
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
     version: '6.5'
   - category: main
     dependencies:
@@ -11273,8 +10950,7 @@ package:
     name: ncurses
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
     version: '6.5'
   - category: main
     dependencies:
@@ -11286,8 +10962,7 @@ package:
     name: ncurses
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
     version: '6.5'
   - category: main
     dependencies:
@@ -11299,8 +10974,7 @@ package:
     name: networkx
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
     version: '3.5'
   - category: main
     dependencies:
@@ -11312,8 +10986,7 @@ package:
     name: networkx
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
     version: '3.5'
   - category: main
     dependencies:
@@ -11325,8 +10998,7 @@ package:
     name: networkx
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
     version: '3.5'
   - category: main
     dependencies:
@@ -11382,8 +11054,7 @@ package:
     name: nodeenv
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
     version: 1.9.1
   - category: main
     dependencies:
@@ -11396,8 +11067,7 @@ package:
     name: nodeenv
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
     version: 1.9.1
   - category: main
     dependencies:
@@ -11410,8 +11080,7 @@ package:
     name: nodeenv
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
     version: 1.9.1
   - category: main
     dependencies:
@@ -11449,8 +11118,7 @@ package:
     name: numpy
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/numpy-2.3.3-py311hf157cb9_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.3.3-py311hf157cb9_0.conda
     version: 2.3.3
   - category: main
     dependencies:
@@ -11484,8 +11152,7 @@ package:
     name: oauthlib
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
     version: 3.3.1
   - category: main
     dependencies:
@@ -11500,8 +11167,7 @@ package:
     name: oauthlib
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
     version: 3.3.1
   - category: main
     dependencies:
@@ -11516,8 +11182,7 @@ package:
     name: oauthlib
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
     version: 3.3.1
   - category: main
     dependencies:
@@ -11534,8 +11199,7 @@ package:
     name: openjpeg
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
     version: 2.5.4
   - category: main
     dependencies:
@@ -11551,8 +11215,7 @@ package:
     name: openjpeg
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.4-h87e8dc5_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.4-h87e8dc5_0.conda
     version: 2.5.4
   - category: main
     dependencies:
@@ -11568,8 +11231,7 @@ package:
     name: openjpeg
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.4-hbfb3c88_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.4-hbfb3c88_0.conda
     version: 2.5.4
   - category: main
     dependencies:
@@ -11583,8 +11245,7 @@ package:
     name: openssl
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.3-h26f9b46_1.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.3-h26f9b46_1.conda
     version: 3.5.3
   - category: main
     dependencies:
@@ -11597,8 +11258,7 @@ package:
     name: openssl
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/openssl-3.5.3-h230baf5_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.5.3-h230baf5_1.conda
     version: 3.5.3
   - category: main
     dependencies:
@@ -11611,8 +11271,7 @@ package:
     name: openssl
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.3-h5503f6c_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.3-h5503f6c_1.conda
     version: 3.5.3
   - category: main
     dependencies:
@@ -11626,8 +11285,7 @@ package:
     name: oras-py
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/oras-py-0.1.14-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/oras-py-0.1.14-pyhd8ed1ab_0.conda
     version: 0.1.14
   - category: main
     dependencies:
@@ -11641,8 +11299,7 @@ package:
     name: oras-py
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/oras-py-0.1.14-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/oras-py-0.1.14-pyhd8ed1ab_0.conda
     version: 0.1.14
   - category: main
     dependencies:
@@ -11656,8 +11313,7 @@ package:
     name: oras-py
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/oras-py-0.1.14-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/oras-py-0.1.14-pyhd8ed1ab_0.conda
     version: 0.1.14
   - category: main
     dependencies:
@@ -11715,8 +11371,7 @@ package:
     name: packaging
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
     version: '25.0'
   - category: main
     dependencies:
@@ -11728,8 +11383,7 @@ package:
     name: packaging
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
     version: '25.0'
   - category: main
     dependencies:
@@ -11741,8 +11395,7 @@ package:
     name: packaging
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
     version: '25.0'
   - category: main
     dependencies:
@@ -11766,8 +11419,7 @@ package:
     name: pango
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
     version: 1.56.4
   - category: main
     dependencies:
@@ -11790,8 +11442,7 @@ package:
     name: pango
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/pango-1.56.4-h6ef8af8_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/pango-1.56.4-h6ef8af8_0.conda
     version: 1.56.4
   - category: main
     dependencies:
@@ -11814,8 +11465,7 @@ package:
     name: pango
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.56.4-h875632e_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.56.4-h875632e_0.conda
     version: 1.56.4
   - category: main
     dependencies:
@@ -11829,8 +11479,7 @@ package:
     name: partd
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
     version: 1.4.2
   - category: main
     dependencies:
@@ -11844,8 +11493,7 @@ package:
     name: partd
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
     version: 1.4.2
   - category: main
     dependencies:
@@ -11859,8 +11507,7 @@ package:
     name: partd
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
     version: 1.4.2
   - category: main
     dependencies:
@@ -11875,8 +11522,7 @@ package:
     name: passlib
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/passlib-1.7.4-pyhd8ed1ab_2.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/passlib-1.7.4-pyhd8ed1ab_2.conda
     version: 1.7.4
   - category: main
     dependencies:
@@ -11891,8 +11537,7 @@ package:
     name: passlib
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/passlib-1.7.4-pyhd8ed1ab_2.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/passlib-1.7.4-pyhd8ed1ab_2.conda
     version: 1.7.4
   - category: main
     dependencies:
@@ -11907,8 +11552,7 @@ package:
     name: passlib
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/passlib-1.7.4-pyhd8ed1ab_2.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/passlib-1.7.4-pyhd8ed1ab_2.conda
     version: 1.7.4
   - category: main
     dependencies:
@@ -11921,8 +11565,7 @@ package:
     name: patch
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/patch-2.8-hb03c661_1002.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/patch-2.8-hb03c661_1002.conda
     version: '2.8'
   - category: main
     dependencies:
@@ -11934,8 +11577,7 @@ package:
     name: patch
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/patch-2.8-h8616949_1002.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/patch-2.8-h8616949_1002.conda
     version: '2.8'
   - category: main
     dependencies:
@@ -11947,8 +11589,7 @@ package:
     name: patch
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/patch-2.8-hc919400_1002.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/patch-2.8-hc919400_1002.conda
     version: '2.8'
   - category: main
     dependencies:
@@ -11961,8 +11602,7 @@ package:
     name: patchelf
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/patchelf-0.17.2-h58526e2_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/patchelf-0.17.2-h58526e2_0.conda
     version: 0.17.2
   - category: main
     dependencies:
@@ -11974,8 +11614,7 @@ package:
     name: pathspec
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
     version: 0.12.1
   - category: main
     dependencies:
@@ -11987,8 +11626,7 @@ package:
     name: pathspec
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
     version: 0.12.1
   - category: main
     dependencies:
@@ -12000,8 +11638,7 @@ package:
     name: pathspec
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
     version: 0.12.1
   - category: main
     dependencies:
@@ -12016,8 +11653,7 @@ package:
     name: pcre2
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.45-hc749103_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.45-hc749103_0.conda
     version: '10.45'
   - category: main
     dependencies:
@@ -12031,8 +11667,7 @@ package:
     name: pcre2
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.45-hf733adb_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.45-hf733adb_0.conda
     version: '10.45'
   - category: main
     dependencies:
@@ -12046,8 +11681,7 @@ package:
     name: pcre2
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.45-ha881caa_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.45-ha881caa_0.conda
     version: '10.45'
   - category: main
     dependencies:
@@ -12072,8 +11706,7 @@ package:
     name: perl
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/perl-5.32.1-7_h10d778d_perl5.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/perl-5.32.1-7_h10d778d_perl5.conda
     version: 5.32.1
   - category: main
     dependencies: {}
@@ -12098,8 +11731,7 @@ package:
     name: pexpect
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
     version: 4.9.0
   - category: main
     dependencies:
@@ -12112,8 +11744,7 @@ package:
     name: pexpect
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
     version: 4.9.0
   - category: main
     dependencies:
@@ -12126,8 +11757,7 @@ package:
     name: pexpect
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
     version: 4.9.0
   - category: main
     dependencies:
@@ -12217,8 +11847,7 @@ package:
     name: pip
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
     version: '25.2'
   - category: main
     dependencies:
@@ -12232,8 +11861,7 @@ package:
     name: pip
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
     version: '25.2'
   - category: main
     dependencies:
@@ -12247,8 +11875,7 @@ package:
     name: pip
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
     version: '25.2'
   - category: main
     dependencies:
@@ -12263,8 +11890,7 @@ package:
     name: pixi
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/pixi-0.55.0-h3760c50_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/pixi-0.55.0-h3760c50_0.conda
     version: 0.55.0
   - category: main
     dependencies:
@@ -12277,8 +11903,7 @@ package:
     name: pixi
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/pixi-0.55.0-h0a75221_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/pixi-0.55.0-h0a75221_0.conda
     version: 0.55.0
   - category: main
     dependencies:
@@ -12291,8 +11916,7 @@ package:
     name: pixi
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/pixi-0.55.0-h42c5e41_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/pixi-0.55.0-h42c5e41_0.conda
     version: 0.55.0
   - category: main
     dependencies:
@@ -12306,8 +11930,7 @@ package:
     name: pixman
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
     version: 0.46.4
   - category: main
     dependencies:
@@ -12320,8 +11943,7 @@ package:
     name: pixman
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/pixman-0.46.4-ha059160_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.46.4-ha059160_1.conda
     version: 0.46.4
   - category: main
     dependencies:
@@ -12334,8 +11956,7 @@ package:
     name: pixman
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.46.4-h81086ad_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.46.4-h81086ad_1.conda
     version: 0.46.4
   - category: main
     dependencies:
@@ -12425,8 +12046,7 @@ package:
     name: pluggy
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
     version: 1.6.0
   - category: main
     dependencies:
@@ -12438,8 +12058,7 @@ package:
     name: pluggy
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
     version: 1.6.0
   - category: main
     dependencies:
@@ -12451,8 +12070,7 @@ package:
     name: pluggy
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
     version: 1.6.0
   - category: main
     dependencies:
@@ -12636,8 +12254,7 @@ package:
     name: psutil
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/psutil-7.1.0-py311hf197a57_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.1.0-py311hf197a57_0.conda
     version: 7.1.0
   - category: main
     dependencies:
@@ -12883,8 +12500,7 @@ package:
     name: pyasn1
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.1-pyhd8ed1ab_2.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.1-pyhd8ed1ab_2.conda
     version: 0.6.1
   - category: main
     dependencies:
@@ -12896,8 +12512,7 @@ package:
     name: pyasn1
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.1-pyhd8ed1ab_2.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.1-pyhd8ed1ab_2.conda
     version: 0.6.1
   - category: main
     dependencies:
@@ -12909,8 +12524,7 @@ package:
     name: pyasn1
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.1-pyhd8ed1ab_2.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.1-pyhd8ed1ab_2.conda
     version: 0.6.1
   - category: main
     dependencies: {}
@@ -12921,8 +12535,7 @@ package:
     name: pybind11-abi
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
+    url: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
     version: '4'
   - category: main
     dependencies: {}
@@ -12933,8 +12546,7 @@ package:
     name: pybind11-abi
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
+    url: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
     version: '4'
   - category: main
     dependencies: {}
@@ -12945,8 +12557,7 @@ package:
     name: pybind11-abi
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
+    url: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
     version: '4'
   - category: main
     dependencies:
@@ -13004,8 +12615,7 @@ package:
     name: pycparser
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
     version: '2.22'
   - category: main
     dependencies:
@@ -13017,8 +12627,7 @@ package:
     name: pycparser
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
     version: '2.22'
   - category: main
     dependencies:
@@ -13030,8 +12639,7 @@ package:
     name: pycparser
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
     version: '2.22'
   - category: main
     dependencies:
@@ -13097,8 +12705,7 @@ package:
     name: pydantic
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.9-pyh3cfb1c2_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.9-pyh3cfb1c2_0.conda
     version: 2.11.9
   - category: main
     dependencies:
@@ -13115,8 +12722,7 @@ package:
     name: pydantic
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.9-pyh3cfb1c2_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.9-pyh3cfb1c2_0.conda
     version: 2.11.9
   - category: main
     dependencies:
@@ -13133,8 +12739,7 @@ package:
     name: pydantic
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.9-pyh3cfb1c2_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.9-pyh3cfb1c2_0.conda
     version: 2.11.9
   - category: main
     dependencies:
@@ -13345,8 +12950,7 @@ package:
     name: pygithub
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pygithub-2.8.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pygithub-2.8.1-pyhd8ed1ab_0.conda
     version: 2.8.1
   - category: main
     dependencies:
@@ -13366,8 +12970,7 @@ package:
     name: pygithub
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pygithub-2.8.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pygithub-2.8.1-pyhd8ed1ab_0.conda
     version: 2.8.1
   - category: main
     dependencies:
@@ -13387,8 +12990,7 @@ package:
     name: pygithub
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pygithub-2.8.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pygithub-2.8.1-pyhd8ed1ab_0.conda
     version: 2.8.1
   - category: main
     dependencies:
@@ -13400,8 +13002,7 @@ package:
     name: pygments
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
     version: 2.19.2
   - category: main
     dependencies:
@@ -13413,8 +13014,7 @@ package:
     name: pygments
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
     version: 2.19.2
   - category: main
     dependencies:
@@ -13426,8 +13026,7 @@ package:
     name: pygments
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
     version: 2.19.2
   - category: main
     dependencies:
@@ -13488,8 +13087,7 @@ package:
     name: pyjwt
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.10.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.10.1-pyhd8ed1ab_0.conda
     version: 2.10.1
   - category: main
     dependencies:
@@ -13501,8 +13099,7 @@ package:
     name: pyjwt
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.10.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.10.1-pyhd8ed1ab_0.conda
     version: 2.10.1
   - category: main
     dependencies:
@@ -13514,8 +13111,7 @@ package:
     name: pyjwt
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.10.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.10.1-pyhd8ed1ab_0.conda
     version: 2.10.1
   - category: main
     dependencies:
@@ -13649,8 +13245,7 @@ package:
     name: pynacl
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/pynacl-1.6.0-py311hf197a57_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/pynacl-1.6.0-py311hf197a57_0.conda
     version: 1.6.0
   - category: main
     dependencies:
@@ -13683,8 +13278,7 @@ package:
     name: pynamodb
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pynamodb-6.1.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pynamodb-6.1.0-pyhd8ed1ab_0.conda
     version: 6.1.0
   - category: main
     dependencies:
@@ -13699,8 +13293,7 @@ package:
     name: pynamodb
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pynamodb-6.1.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pynamodb-6.1.0-pyhd8ed1ab_0.conda
     version: 6.1.0
   - category: main
     dependencies:
@@ -13715,8 +13308,7 @@ package:
     name: pynamodb
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pynamodb-6.1.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pynamodb-6.1.0-pyhd8ed1ab_0.conda
     version: 6.1.0
   - category: main
     dependencies:
@@ -13838,8 +13430,7 @@ package:
     name: pyparsing
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.4-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.4-pyhd8ed1ab_0.conda
     version: 3.1.4
   - category: main
     dependencies:
@@ -13851,8 +13442,7 @@ package:
     name: pyparsing
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.4-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.4-pyhd8ed1ab_0.conda
     version: 3.1.4
   - category: main
     dependencies:
@@ -13864,8 +13454,7 @@ package:
     name: pyparsing
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.4-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.4-pyhd8ed1ab_0.conda
     version: 3.1.4
   - category: main
     dependencies:
@@ -13880,8 +13469,7 @@ package:
     name: pyperclip
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.8.2-pyha804496_3.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.8.2-pyha804496_3.conda
     version: 1.8.2
   - category: main
     dependencies:
@@ -13895,8 +13483,7 @@ package:
     name: pyperclip
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.8.2-pyh534df25_3.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.8.2-pyh534df25_3.conda
     version: 1.8.2
   - category: main
     dependencies:
@@ -13910,8 +13497,7 @@ package:
     name: pyperclip
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.8.2-pyh534df25_3.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.8.2-pyh534df25_3.conda
     version: 1.8.2
   - category: main
     dependencies:
@@ -13966,8 +13552,7 @@ package:
     name: pysocks
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
     version: 1.7.1
   - category: main
     dependencies:
@@ -13980,8 +13565,7 @@ package:
     name: pysocks
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
     version: 1.7.1
   - category: main
     dependencies:
@@ -13994,8 +13578,7 @@ package:
     name: pysocks
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
     version: 1.7.1
   - category: main
     dependencies:
@@ -14013,8 +13596,7 @@ package:
     name: pytest
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pytest-8.0.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.0.2-pyhd8ed1ab_0.conda
     version: 8.0.2
   - category: main
     dependencies:
@@ -14032,8 +13614,7 @@ package:
     name: pytest
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pytest-8.0.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.0.2-pyhd8ed1ab_0.conda
     version: 8.0.2
   - category: main
     dependencies:
@@ -14051,8 +13632,7 @@ package:
     name: pytest
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pytest-8.0.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.0.2-pyhd8ed1ab_0.conda
     version: 8.0.2
   - category: main
     dependencies:
@@ -14337,6 +13917,7 @@ package:
       libzlib: '>=1.3.1,<2.0a0'
       ncurses: '>=6.5,<7.0a0'
       openssl: '>=3.5.0,<4.0a0'
+      pip: ''
       readline: '>=8.2,<9.0a0'
       tk: '>=8.6.13,<8.7.0a0'
       tzdata: ''
@@ -14361,6 +13942,7 @@ package:
       libzlib: '>=1.3.1,<2.0a0'
       ncurses: '>=6.5,<7.0a0'
       openssl: '>=3.5.0,<4.0a0'
+      pip: ''
       readline: '>=8.2,<9.0a0'
       tk: '>=8.6.13,<8.7.0a0'
       tzdata: ''
@@ -14385,6 +13967,7 @@ package:
       libzlib: '>=1.3.1,<2.0a0'
       ncurses: '>=6.5,<7.0a0'
       openssl: '>=3.5.0,<4.0a0'
+      pip: ''
       readline: '>=8.2,<9.0a0'
       tk: '>=8.6.13,<8.7.0a0'
       tzdata: ''
@@ -14862,8 +14445,7 @@ package:
     name: python_abi
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
     version: '3.11'
   - category: main
     dependencies: {}
@@ -14874,8 +14456,7 @@ package:
     name: python_abi
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
     version: '3.11'
   - category: main
     dependencies: {}
@@ -14886,8 +14467,7 @@ package:
     name: python_abi
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
     version: '3.11'
   - category: main
     dependencies:
@@ -14899,8 +14479,7 @@ package:
     name: pytz
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
     version: '2025.2'
   - category: main
     dependencies:
@@ -14912,8 +14491,7 @@ package:
     name: pytz
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
     version: '2025.2'
   - category: main
     dependencies:
@@ -14925,8 +14503,7 @@ package:
     name: pytz
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
     version: '2025.2'
   - category: main
     dependencies:
@@ -14958,8 +14535,7 @@ package:
     name: pyyaml
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.3-py311he13f9b5_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.3-py311he13f9b5_0.conda
     version: 6.0.3
   - category: main
     dependencies:
@@ -14989,8 +14565,7 @@ package:
     name: qhull
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
     version: '2020.2'
   - category: main
     dependencies:
@@ -15003,8 +14578,7 @@ package:
     name: qhull
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
     version: '2020.2'
   - category: main
     dependencies:
@@ -15017,8 +14591,7 @@ package:
     name: qhull
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
     version: '2020.2'
   - category: main
     dependencies:
@@ -15182,8 +14755,7 @@ package:
     name: readline
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
     version: '8.2'
   - category: main
     dependencies:
@@ -15195,8 +14767,7 @@ package:
     name: readline
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h7cca4af_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h7cca4af_2.conda
     version: '8.2'
   - category: main
     dependencies:
@@ -15208,8 +14779,7 @@ package:
     name: readline
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
     version: '8.2'
   - category: main
     dependencies:
@@ -15359,8 +14929,7 @@ package:
     name: requests
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
     version: 2.32.5
   - category: main
     dependencies:
@@ -15376,8 +14945,7 @@ package:
     name: requests
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
     version: 2.32.5
   - category: main
     dependencies:
@@ -15393,8 +14961,7 @@ package:
     name: requests
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
     version: 2.32.5
   - category: main
     dependencies:
@@ -15538,8 +15105,7 @@ package:
     name: rich
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
     version: 14.1.0
   - category: main
     dependencies:
@@ -15554,8 +15120,7 @@ package:
     name: rich
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
     version: 14.1.0
   - category: main
     dependencies:
@@ -15570,8 +15135,7 @@ package:
     name: rich
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
     version: 14.1.0
   - category: main
     dependencies:
@@ -15632,8 +15196,7 @@ package:
     name: ripgrep
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/ripgrep-14.1.1-h8fae777_1.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/ripgrep-14.1.1-h8fae777_1.conda
     version: 14.1.1
   - category: main
     dependencies:
@@ -15645,8 +15208,7 @@ package:
     name: ripgrep
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/ripgrep-14.1.1-h926acf8_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/ripgrep-14.1.1-h926acf8_1.conda
     version: 14.1.1
   - category: main
     dependencies:
@@ -15658,8 +15220,7 @@ package:
     name: ripgrep
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/ripgrep-14.1.1-h0ef69ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/ripgrep-14.1.1-h0ef69ab_1.conda
     version: 14.1.1
   - category: main
     dependencies:
@@ -15886,8 +15447,7 @@ package:
     name: scipy
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/scipy-1.16.2-py311h32c7e5c_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.16.2-py311h32c7e5c_0.conda
     version: 1.16.2
   - category: main
     dependencies:
@@ -15943,8 +15503,7 @@ package:
     name: scrypt
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/scrypt-0.9.4-py311h3a41b9d_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/scrypt-0.9.4-py311h3a41b9d_1.conda
     version: 0.9.4
   - category: main
     dependencies:
@@ -15990,8 +15549,7 @@ package:
     name: semver
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhd8ed1ab_0.conda
     version: 3.0.4
   - category: main
     dependencies:
@@ -16003,8 +15561,7 @@ package:
     name: semver
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhd8ed1ab_0.conda
     version: 3.0.4
   - category: main
     dependencies:
@@ -16016,8 +15573,7 @@ package:
     name: semver
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.4-pyhd8ed1ab_0.conda
     version: 3.0.4
   - category: main
     dependencies:
@@ -16161,8 +15717,7 @@ package:
     name: sgmllib3k
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/sgmllib3k-1.0.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/sgmllib3k-1.0.0-pyhd8ed1ab_1.conda
     version: 1.0.0
   - category: main
     dependencies:
@@ -16174,8 +15729,7 @@ package:
     name: sgmllib3k
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/sgmllib3k-1.0.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/sgmllib3k-1.0.0-pyhd8ed1ab_1.conda
     version: 1.0.0
   - category: main
     dependencies:
@@ -16187,8 +15741,7 @@ package:
     name: sgmllib3k
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/sgmllib3k-1.0.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/sgmllib3k-1.0.0-pyhd8ed1ab_1.conda
     version: 1.0.0
   - category: main
     dependencies:
@@ -16239,8 +15792,7 @@ package:
     name: sigtool
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
+    url: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
     version: 0.1.3
   - category: main
     dependencies:
@@ -16267,8 +15819,7 @@ package:
     name: simdjson
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/simdjson-3.13.0-h84d6215_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/simdjson-3.13.0-h84d6215_0.conda
     version: 3.13.0
   - category: main
     dependencies:
@@ -16281,8 +15832,7 @@ package:
     name: simdjson
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/simdjson-3.13.0-h9275861_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/simdjson-3.13.0-h9275861_0.conda
     version: 3.13.0
   - category: main
     dependencies:
@@ -16308,8 +15858,7 @@ package:
     name: six
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
     version: 1.17.0
   - category: main
     dependencies:
@@ -16321,8 +15870,7 @@ package:
     name: six
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
     version: 1.17.0
   - category: main
     dependencies:
@@ -16334,8 +15882,7 @@ package:
     name: six
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
     version: 1.17.0
   - category: main
     dependencies:
@@ -16347,8 +15894,7 @@ package:
     name: smmap
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
     version: 5.0.2
   - category: main
     dependencies:
@@ -16360,8 +15906,7 @@ package:
     name: smmap
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
     version: 5.0.2
   - category: main
     dependencies:
@@ -16373,8 +15918,7 @@ package:
     name: smmap
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
     version: 5.0.2
   - category: main
     dependencies:
@@ -16386,8 +15930,7 @@ package:
     name: sniffio
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
     version: 1.3.1
   - category: main
     dependencies:
@@ -16399,8 +15942,7 @@ package:
     name: sniffio
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
     version: 1.3.1
   - category: main
     dependencies:
@@ -16412,8 +15954,7 @@ package:
     name: sniffio
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
     version: 1.3.1
   - category: main
     dependencies:
@@ -16464,8 +16005,7 @@ package:
     name: soupsieve
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8-pyhd8ed1ab_0.conda
     version: '2.8'
   - category: main
     dependencies:
@@ -16477,8 +16017,7 @@ package:
     name: soupsieve
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8-pyhd8ed1ab_0.conda
     version: '2.8'
   - category: main
     dependencies:
@@ -16490,8 +16029,7 @@ package:
     name: soupsieve
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8-pyhd8ed1ab_0.conda
     version: '2.8'
   - category: main
     dependencies:
@@ -16588,8 +16126,7 @@ package:
     name: stopit
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/stopit-1.1.2-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/stopit-1.1.2-pyhd8ed1ab_1.conda
     version: 1.1.2
   - category: main
     dependencies:
@@ -16602,8 +16139,7 @@ package:
     name: stopit
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/stopit-1.1.2-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/stopit-1.1.2-pyhd8ed1ab_1.conda
     version: 1.1.2
   - category: main
     dependencies:
@@ -16616,8 +16152,7 @@ package:
     name: stopit
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/stopit-1.1.2-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/stopit-1.1.2-pyhd8ed1ab_1.conda
     version: 1.1.2
   - category: main
     dependencies:
@@ -16634,8 +16169,7 @@ package:
     name: streamz
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/streamz-0.6.4-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/streamz-0.6.4-pyhd8ed1ab_1.conda
     version: 0.6.4
   - category: main
     dependencies:
@@ -16652,8 +16186,7 @@ package:
     name: streamz
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/streamz-0.6.4-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/streamz-0.6.4-pyhd8ed1ab_1.conda
     version: 0.6.4
   - category: main
     dependencies:
@@ -16670,8 +16203,7 @@ package:
     name: streamz
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/streamz-0.6.4-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/streamz-0.6.4-pyhd8ed1ab_1.conda
     version: 0.6.4
   - category: main
     dependencies:
@@ -16685,8 +16217,7 @@ package:
     name: tapi
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
     version: 1300.6.5
   - category: main
     dependencies:
@@ -16700,8 +16231,7 @@ package:
     name: tapi
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
     version: 1300.6.5
   - category: main
     dependencies:
@@ -16715,8 +16245,7 @@ package:
     name: tar
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/tar-1.35-h3b78370_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/tar-1.35-h3b78370_0.conda
     version: '1.35'
   - category: main
     dependencies:
@@ -16744,8 +16273,7 @@ package:
     name: tar
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/tar-1.35-h3bfc444_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/tar-1.35-h3bfc444_0.conda
     version: '1.35'
   - category: main
     dependencies:
@@ -16757,8 +16285,7 @@ package:
     name: tblib
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/tblib-3.1.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/tblib-3.1.0-pyhd8ed1ab_0.conda
     version: 3.1.0
   - category: main
     dependencies:
@@ -16770,8 +16297,7 @@ package:
     name: tblib
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/tblib-3.1.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/tblib-3.1.0-pyhd8ed1ab_0.conda
     version: 3.1.0
   - category: main
     dependencies:
@@ -16783,8 +16309,7 @@ package:
     name: tblib
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/tblib-3.1.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/tblib-3.1.0-pyhd8ed1ab_0.conda
     version: 3.1.0
   - category: main
     dependencies:
@@ -16812,8 +16337,7 @@ package:
     name: tk
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hf689a15_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hf689a15_2.conda
     version: 8.6.13
   - category: main
     dependencies:
@@ -16826,8 +16350,7 @@ package:
     name: tk
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
     version: 8.6.13
   - category: main
     dependencies:
@@ -16839,8 +16362,7 @@ package:
     name: tomli
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhe01879c_2.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhe01879c_2.conda
     version: 2.2.1
   - category: main
     dependencies:
@@ -16852,8 +16374,7 @@ package:
     name: tomli
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhe01879c_2.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhe01879c_2.conda
     version: 2.2.1
   - category: main
     dependencies:
@@ -16865,8 +16386,7 @@ package:
     name: tomli
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhe01879c_2.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhe01879c_2.conda
     version: 2.2.1
   - category: main
     dependencies:
@@ -16878,8 +16398,7 @@ package:
     name: tomli-w
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.2.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.2.0-pyhd8ed1ab_0.conda
     version: 1.2.0
   - category: main
     dependencies:
@@ -16891,8 +16410,7 @@ package:
     name: tomli-w
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.2.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.2.0-pyhd8ed1ab_0.conda
     version: 1.2.0
   - category: main
     dependencies:
@@ -16904,8 +16422,7 @@ package:
     name: tomli-w
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.2.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.2.0-pyhd8ed1ab_0.conda
     version: 1.2.0
   - category: main
     dependencies:
@@ -16917,8 +16434,7 @@ package:
     name: tomlkit
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.13.3-pyha770c72_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.13.3-pyha770c72_0.conda
     version: 0.13.3
   - category: main
     dependencies:
@@ -16930,8 +16446,7 @@ package:
     name: tomlkit
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.13.3-pyha770c72_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.13.3-pyha770c72_0.conda
     version: 0.13.3
   - category: main
     dependencies:
@@ -16943,8 +16458,7 @@ package:
     name: tomlkit
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.13.3-pyha770c72_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.13.3-pyha770c72_0.conda
     version: 0.13.3
   - category: main
     dependencies:
@@ -16956,8 +16470,7 @@ package:
     name: toolz
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_1.conda
     version: 1.0.0
   - category: main
     dependencies:
@@ -16969,8 +16482,7 @@ package:
     name: toolz
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_1.conda
     version: 1.0.0
   - category: main
     dependencies:
@@ -16982,8 +16494,7 @@ package:
     name: toolz
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_1.conda
     version: 1.0.0
   - category: main
     dependencies:
@@ -17042,8 +16553,7 @@ package:
     name: tqdm
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
     version: 4.67.1
   - category: main
     dependencies:
@@ -17056,8 +16566,7 @@ package:
     name: tqdm
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
     version: 4.67.1
   - category: main
     dependencies:
@@ -17070,8 +16579,7 @@ package:
     name: tqdm
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
     version: 4.67.1
   - category: main
     dependencies:
@@ -17162,8 +16670,7 @@ package:
     name: typer
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/typer-0.19.2-pyhef33e25_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/typer-0.19.2-pyhef33e25_0.conda
     version: 0.19.2
   - category: main
     dependencies:
@@ -17176,8 +16683,7 @@ package:
     name: typer
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/typer-0.19.2-pyhef33e25_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/typer-0.19.2-pyhef33e25_0.conda
     version: 0.19.2
   - category: main
     dependencies:
@@ -17190,8 +16696,7 @@ package:
     name: typer
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/typer-0.19.2-pyhef33e25_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/typer-0.19.2-pyhef33e25_0.conda
     version: 0.19.2
   - category: main
     dependencies:
@@ -17412,8 +16917,7 @@ package:
     name: tzdata
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
     version: 2025b
   - category: main
     dependencies: {}
@@ -17424,8 +16928,7 @@ package:
     name: tzdata
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
     version: 2025b
   - category: main
     dependencies: {}
@@ -17436,8 +16939,7 @@ package:
     name: tzdata
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
     version: 2025b
   - category: main
     dependencies:
@@ -17590,8 +17092,7 @@ package:
     name: urllib3
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
     version: 2.5.0
   - category: main
     dependencies:
@@ -17607,8 +17108,7 @@ package:
     name: urllib3
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
     version: 2.5.0
   - category: main
     dependencies:
@@ -17624,8 +17124,7 @@ package:
     name: urllib3
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
     version: 2.5.0
   - category: main
     dependencies:
@@ -17638,8 +17137,7 @@ package:
     name: userpath
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda
     version: 1.9.2
   - category: main
     dependencies:
@@ -17652,8 +17150,7 @@ package:
     name: userpath
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda
     version: 1.9.2
   - category: main
     dependencies:
@@ -17666,8 +17163,7 @@ package:
     name: userpath
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda
     version: 1.9.2
   - category: main
     dependencies:
@@ -17681,8 +17177,7 @@ package:
     name: uv
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/uv-0.8.18-h2f8d451_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.8.18-h2f8d451_0.conda
     version: 0.8.18
   - category: main
     dependencies:
@@ -17695,8 +17190,7 @@ package:
     name: uv
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/uv-0.8.18-h7032f6b_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/uv-0.8.18-h7032f6b_0.conda
     version: 0.8.18
   - category: main
     dependencies:
@@ -17709,8 +17203,7 @@ package:
     name: uv
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.8.18-haaa92d6_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.8.18-haaa92d6_0.conda
     version: 0.8.18
   - category: main
     dependencies:
@@ -17726,8 +17219,7 @@ package:
     name: uvicorn
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.37.0-pyh31011fe_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.37.0-pyh31011fe_0.conda
     version: 0.37.0
   - category: main
     dependencies:
@@ -17743,8 +17235,7 @@ package:
     name: uvicorn
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.37.0-pyh31011fe_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.37.0-pyh31011fe_0.conda
     version: 0.37.0
   - category: main
     dependencies:
@@ -17760,8 +17251,7 @@ package:
     name: uvicorn
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.37.0-pyh31011fe_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.37.0-pyh31011fe_0.conda
     version: 0.37.0
   - category: main
     dependencies:
@@ -18031,8 +17521,7 @@ package:
     name: wayland
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/wayland-1.24.0-h3e06ad9_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.24.0-h3e06ad9_0.conda
     version: 1.24.0
   - category: main
     dependencies:
@@ -18091,8 +17580,7 @@ package:
     name: werkzeug
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.1.3-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.1.3-pyhd8ed1ab_1.conda
     version: 3.1.3
   - category: main
     dependencies:
@@ -18105,8 +17593,7 @@ package:
     name: werkzeug
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.1.3-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.1.3-pyhd8ed1ab_1.conda
     version: 3.1.3
   - category: main
     dependencies:
@@ -18119,8 +17606,7 @@ package:
     name: werkzeug
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.1.3-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.1.3-pyhd8ed1ab_1.conda
     version: 3.1.3
   - category: main
     dependencies:
@@ -18137,8 +17623,7 @@ package:
     name: wget
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/wget-1.21.4-hda4d442_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/wget-1.21.4-hda4d442_0.conda
     version: 1.21.4
   - category: main
     dependencies:
@@ -18154,8 +17639,7 @@ package:
     name: wget
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/wget-1.21.4-hca547e6_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/wget-1.21.4-hca547e6_0.conda
     version: 1.21.4
   - category: main
     dependencies:
@@ -18171,8 +17655,7 @@ package:
     name: wget
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/wget-1.21.4-he2df1f1_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/wget-1.21.4-he2df1f1_0.conda
     version: 1.21.4
   - category: main
     dependencies:
@@ -18184,8 +17667,7 @@ package:
     name: wheel
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
     version: 0.45.1
   - category: main
     dependencies:
@@ -18197,8 +17679,7 @@ package:
     name: wheel
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
     version: 0.45.1
   - category: main
     dependencies:
@@ -18210,8 +17691,7 @@ package:
     name: wheel
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
     version: 0.45.1
   - category: main
     dependencies:
@@ -18241,8 +17721,7 @@ package:
     name: wrapt
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.17.3-py311h13e5629_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.17.3-py311h13e5629_1.conda
     version: 1.17.3
   - category: main
     dependencies:
@@ -18270,8 +17749,7 @@ package:
     name: wsproto
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/wsproto-1.2.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/wsproto-1.2.0-pyhd8ed1ab_1.conda
     version: 1.2.0
   - category: main
     dependencies:
@@ -18284,8 +17762,7 @@ package:
     name: wsproto
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/wsproto-1.2.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/wsproto-1.2.0-pyhd8ed1ab_1.conda
     version: 1.2.0
   - category: main
     dependencies:
@@ -18298,8 +17775,7 @@ package:
     name: wsproto
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/wsproto-1.2.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/wsproto-1.2.0-pyhd8ed1ab_1.conda
     version: 1.2.0
   - category: main
     dependencies:
@@ -18311,8 +17787,7 @@ package:
     name: wurlitzer
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/wurlitzer-3.1.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/wurlitzer-3.1.1-pyhd8ed1ab_1.conda
     version: 3.1.1
   - category: main
     dependencies:
@@ -18324,8 +17799,7 @@ package:
     name: wurlitzer
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/wurlitzer-3.1.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/wurlitzer-3.1.1-pyhd8ed1ab_1.conda
     version: 3.1.1
   - category: main
     dependencies:
@@ -18337,8 +17811,7 @@ package:
     name: wurlitzer
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/wurlitzer-3.1.1-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/wurlitzer-3.1.1-pyhd8ed1ab_1.conda
     version: 3.1.1
   - category: main
     dependencies:
@@ -18353,8 +17826,7 @@ package:
     name: xattr
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/xattr-1.2.0-py311h8e62900_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/xattr-1.2.0-py311h8e62900_1.conda
     version: 1.2.0
   - category: main
     dependencies:
@@ -18385,8 +17857,7 @@ package:
     name: xclip
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/xclip-0.13-hb9d3cd8_4.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/xclip-0.13-hb9d3cd8_4.conda
     version: '0.13'
   - category: main
     dependencies:
@@ -18767,8 +18238,7 @@ package:
     name: xsel
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/xsel-1.2.1-hb9d3cd8_6.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/xsel-1.2.1-hb9d3cd8_6.conda
     version: 1.2.1
   - category: main
     dependencies:
@@ -18781,8 +18251,7 @@ package:
     name: yaml
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
     version: 0.2.5
   - category: main
     dependencies:
@@ -18794,8 +18263,7 @@ package:
     name: yaml
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
     version: 0.2.5
   - category: main
     dependencies:
@@ -18807,8 +18275,7 @@ package:
     name: yaml
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
     version: 0.2.5
   - category: main
     dependencies:
@@ -18822,8 +18289,7 @@ package:
     name: yaml-cpp
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/yaml-cpp-0.8.0-h3f2d84a_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/yaml-cpp-0.8.0-h3f2d84a_0.conda
     version: 0.8.0
   - category: main
     dependencies:
@@ -18836,8 +18302,7 @@ package:
     name: yaml-cpp
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-h92383a6_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-h92383a6_0.conda
     version: 0.8.0
   - category: main
     dependencies:
@@ -18850,8 +18315,7 @@ package:
     name: yaml-cpp
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/yaml-cpp-0.8.0-ha1acc90_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-cpp-0.8.0-ha1acc90_0.conda
     version: 0.8.0
   - category: main
     dependencies:
@@ -18863,8 +18327,7 @@ package:
     name: zict
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
     version: 3.0.0
   - category: main
     dependencies:
@@ -18876,8 +18339,7 @@ package:
     name: zict
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
     version: 3.0.0
   - category: main
     dependencies:
@@ -18889,8 +18351,7 @@ package:
     name: zict
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
     version: 3.0.0
   - category: main
     dependencies:
@@ -18902,8 +18363,7 @@ package:
     name: zipp
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
     version: 3.23.0
   - category: main
     dependencies:
@@ -18915,8 +18375,7 @@ package:
     name: zipp
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
     version: 3.23.0
   - category: main
     dependencies:
@@ -18928,8 +18387,7 @@ package:
     name: zipp
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
     version: 3.23.0
   - category: main
     dependencies:
@@ -18943,8 +18401,7 @@ package:
     name: zlib
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
     version: 1.3.1
   - category: main
     dependencies:
@@ -18957,8 +18414,7 @@ package:
     name: zlib
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
     version: 1.3.1
   - category: main
     dependencies:
@@ -18971,8 +18427,7 @@ package:
     name: zlib
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
     version: 1.3.1
   - category: main
     dependencies:
@@ -19033,8 +18488,7 @@ package:
     name: zstd
     optional: false
     platform: linux-64
-    url:
-      https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
     version: 1.5.7
   - category: main
     dependencies:
@@ -19047,8 +18501,7 @@ package:
     name: zstd
     optional: false
     platform: osx-64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h8210216_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h8210216_2.conda
     version: 1.5.7
   - category: main
     dependencies:
@@ -19061,7 +18514,6 @@ package:
     name: zstd
     optional: false
     platform: osx-arm64
-    url:
-      https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
     version: 1.5.7
 version: 1

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ platforms:
 dependencies:
   - attrs
   - backoff
+  - bcrypt<5  # https://stackoverflow.com/a/79776608
   - cachecontrol
   - cachetools
   - click


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->
Closes #4833. See https://stackoverflow.com/a/79776608

I haven't tried this out locally, but I think it's very likely that it'll fix the broken integration tests. Let's see in the merge queue.

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
