### PR TITLE
fix: handle split keys in lists for recipe parsing

### DIFF
--- a/conda_forge_tick/recipe_parser/_parser.py
+++ b/conda_forge_tick/recipe_parser/_parser.py
@@ -230,7 +230,12 @@ def _unmunge_split_key_value_pairs_with_selectors(lines):
     for line in lines:
         if (
             len(line.lstrip()) > 0
-            and line.lstrip()[0] == "?"
+            and (
+                (len(line.split()) > 1 and line.split()[0:2] == ["-", "?"])
+                or (
+                    len(line.split()) > 0 and line.split()[0] == "?"
+                )
+            )
             and ":" not in line
             and CONDA_SELECTOR in line
         ):


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

This PR should fix #4846. It needs a test.

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
