### PR TITLE
feat: Add `whitelist_file` option to yaml migrators

### DIFF
--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -4,6 +4,7 @@ import contextlib
 import copy
 import logging
 import math
+import os
 import re
 import secrets
 import time
@@ -29,10 +30,50 @@ from ..migrators_types import AttrsTypedDict, MigrationUidTypedDict, PackageName
 if typing.TYPE_CHECKING:
     from conda_forge_tick.utils import JsonFriendly
 
+MIGRATION_SUPPORT_DIRS = [
+    Path(os.environ["CONDA_PREFIX"]) / "share" / "conda-forge" / "migration_support",
+    # Deprecated
+    Path(os.environ["CONDA_PREFIX"]) / "share" / "conda-forge" / "migrations",
+]
+
 
 logger = logging.getLogger(__name__)
 
 RNG = secrets.SystemRandom()
+
+
+def load_target_packages(package_list_file: str) -> Set[str]:
+    # We are constraining the scope of this migrator
+    fname = None
+    for d in MIGRATION_SUPPORT_DIRS:
+        fname = d / package_list_file
+        if fname.exists():
+            break
+
+    assert fname is not None, (
+        f"Could not find {package_list_file} in migration support dirs"
+    )
+
+    with fname.open() as f:
+        target_packages = set(f.read().split())
+
+    return target_packages
+
+
+def cut_graph_to_target_packages(graph, target_packages):
+    """Cut the graph to only the target packages.
+
+    **operates in place**
+    """
+    packages = target_packages.copy()
+    for target in target_packages:
+        if target in graph.nodes:
+            packages.update(nx.ancestors(graph, target))
+    for node in list(graph.nodes.keys()):
+        if node not in packages:
+            pluck(graph, node)
+    # post-plucking cleanup
+    graph.remove_edges_from(nx.selfloop_edges(graph))
 
 
 def skip_migrator_due_to_schema(

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -16,7 +16,9 @@ from conda_forge_tick.migrators.core import (
     GraphMigrator,
     Migrator,
     MiniMigrator,
+    cut_graph_to_target_packages,
     get_outputs_lut,
+    load_target_packages,
 )
 from conda_forge_tick.os_utils import pushd
 from conda_forge_tick.utils import (
@@ -188,8 +190,13 @@ class MigrationYaml(GraphMigrator):
         force_pr_after_solver_attempts=10,
         longterm=False,
         paused=False,
+        whitelist_file: Optional[str] = None,
         **kwargs: Any,
     ):
+        if whitelist_file is not None:
+            target_packages = load_target_packages(whitelist_file)
+            cut_graph_to_target_packages(total_graph, target_packages)
+
         if not hasattr(self, "_init_args"):
             self._init_args = [yaml_contents, name]
 


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR adds a new `whitelist_file` option to the yaml specification for migrators. This can be used to limit the packages affected by a migrator with a text file listing desired packages much like we already use for arch migrations.

This came out of discussions around the currently paused Python free-threaded migrator to give us the option of approaching that migration carefully, but may find applications beyond that.


#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
