### PR TITLE
fix: remove extra keys section from pr_info

### DIFF
--- a/.github/workflows/tests-reusable.yml
+++ b/.github/workflows/tests-reusable.yml
@@ -128,7 +128,7 @@ jobs:
             test-durations-${{ github.ref }}-
             test-durations-
 
-      - name: run pytest
+      - name: post-process test durations
         if: ${{ ! env.CI_SKIP }}
         run: |
           if [[ -f .test_durations ]]; then

--- a/.github/workflows/tests-reusable.yml
+++ b/.github/workflows/tests-reusable.yml
@@ -142,9 +142,6 @@ jobs:
         if: ${{ ! env.CI_SKIP }}
         run: |
           export TEST_BOT_TOKEN_VAL=unpassword
-          if [[ -f .test_durations ]]; then
-            cp .test_durations .test_durations.${{ matrix.group }}
-          fi
           pytest \
             -v \
             -n 3 \

--- a/.github/workflows/tests-reusable.yml
+++ b/.github/workflows/tests-reusable.yml
@@ -131,6 +131,16 @@ jobs:
       - name: run pytest
         if: ${{ ! env.CI_SKIP }}
         run: |
+          if [[ -f .test_durations ]]; then
+            cp .test_durations .test_durations.${{ matrix.group }}
+          fi
+          ls -lah .test_durations*
+          echo " "
+          cat .test_durations*
+
+      - name: run pytest
+        if: ${{ ! env.CI_SKIP }}
+        run: |
           export TEST_BOT_TOKEN_VAL=unpassword
           if [[ -f .test_durations ]]; then
             cp .test_durations .test_durations.${{ matrix.group }}

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -124,7 +124,7 @@ def _make_migrator_graph(graph, migrator, effective=False, pluck_nodes=True):
 def _sanitized_muids(pred: List[dict]) -> List["JsonFriendly"]:
     lst = []
     for pr in pred:
-        d: "JsonFriendly" = {"data": pr["data"], "keys": pr["keys"]}
+        d: "JsonFriendly" = {"data": pr["data"]}
         lst.append(d)
     return lst
 

--- a/conda_forge_tick/models/pr_info.py
+++ b/conda_forge_tick/models/pr_info.py
@@ -9,7 +9,6 @@ from conda_forge_tick.models.common import (
     NoneIsEmptyDict,
     PrJsonLazyJsonReference,
     StrictBaseModel,
-    before_validator_ensure_dict,
 )
 from conda_forge_tick.models.pr_json import PullRequestDataValid, PullRequestInfoSpecial
 
@@ -195,45 +194,6 @@ class MigrationPullRequest(StrictBaseModel):
     """
 
     data: MigrationPullRequestData
-
-    # noinspection PyNestedDecorators
-    @model_validator(mode="before")
-    @classmethod
-    def validate_keys(cls, input_data: Any) -> Any:
-        """
-        Validate the keys field against the data field.
-
-        The current implementation uses a field "keys" which is a list of all keys present in the
-        MigrationPullRequestData object, duplicating them. This list is redundant and should be removed.
-        The consistency of this field is validated here, after which it is removed.
-
-        Raises
-        ------
-        ValueError
-            If the keys field or the data field is missing, has the wrong type
-            or the keys field does not exactly match the keys of the data field.
-        """
-        input_data = before_validator_ensure_dict(input_data)
-
-        if "keys" not in input_data:
-            raise ValueError("The keys field is missing.")
-        if "data" not in input_data:
-            raise ValueError("The data field is missing.")
-
-        keys = input_data.pop("keys")
-        if not isinstance(keys, list):
-            raise ValueError("The keys field must be a list.")
-
-        data = input_data["data"]
-        if not isinstance(data, dict):
-            raise ValueError("The data field must be a dictionary.")
-
-        if set(keys) != set(data.keys()):
-            raise ValueError(
-                "The keys field must exactly contain all keys of the data field."
-            )
-
-        return input_data
 
 
 class ExceptionInfo(StrictBaseModel):

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -1295,8 +1295,7 @@ def frozen_to_json_friendly(fz: Any, pr: Optional[LazyJson] = None) -> "JsonFrie
 def frozen_to_json_friendly(fz, pr: Optional[LazyJson] = None):
     if fz is None:
         return None
-    keys = sorted(list(fz.keys()))
-    d = {"keys": keys, "data": dict(fz)}
+    d = {"data": dict(fz)}
     if pr:
         d["PR"] = pr
     return d

--- a/tests/test_yaml/depfinder.json
+++ b/tests/test_yaml/depfinder.json
@@ -8,12 +8,7 @@
                 "bot_rerun": false,
                 "migrator_name": "Noarch",
                 "migrator_version": 0
-            },
-            "keys": [
-                "bot_rerun",
-                "migrator_name",
-                "migrator_version"
-            ]
+            }
         },
         {
             "PR": {
@@ -24,13 +19,7 @@
                 "migrator_name": "Version",
                 "migrator_version": 0,
                 "version": "2.1.1"
-            },
-            "keys": [
-                "bot_rerun",
-                "migrator_name",
-                "migrator_version",
-                "version"
-            ]
+            }
         },
         {
             "PR": {
@@ -41,13 +30,7 @@
                 "migrator_name": "Version",
                 "migrator_version": 0,
                 "version": "2.2.1"
-            },
-            "keys": [
-                "bot_rerun",
-                "migrator_name",
-                "migrator_version",
-                "version"
-            ]
+            }
         }
     ],
     "bad": false,


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR removes the keys section from the pr_info json blob. 

These steps need to be done in the order below in order to merge this PR:

- [x] ensure tests pass
- [ ] stop bot
- [ ] merge PR
- [ ] migrate schema in cf-graph-countyfair
- [ ] restart bot

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
