### PR TITLE
feat: make version migrator on-the-fly and use consistent names

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -64,7 +64,7 @@ from conda_forge_tick.utils import (
     fold_log_lines,
     frozen_to_json_friendly,
     get_bot_run_url,
-    get_migrator_name_from_pr_data,
+    get_migrator_report_name_from_pr_data,
     load_existing_graph,
     sanitize_string,
 )
@@ -1255,7 +1255,7 @@ def _update_nodes_with_bot_rerun(gx: nx.DiGraph):
                                 migration["data"],
                             )
 
-                            __name = get_migrator_name_from_pr_data(migration)
+                            __name = get_migrator_report_name_from_pr_data(migration)
                             if __name is not None:
                                 if __pri is pri:
                                     _reset_migrator_pre_pr_migrator_fields(pri, __name)

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -362,7 +362,7 @@ def _is_solvability_check_needed(
     migrator_check_solvable = getattr(migrator, "check_solvable", True)
     pr_attempts = _get_pre_pr_migrator_attempts(
         context.attrs,
-        migrator_name=migrator.unique_name,
+        migrator_name=migrator.report_name,
         is_version=isinstance(migrator, Version),
     )
     max_pr_attempts = getattr(
@@ -424,7 +424,7 @@ def _handle_solvability_error(
 
     _set_pre_pr_migrator_error(
         context.attrs,
-        migrator.unique_name,
+        migrator.report_name,
         _solver_err_str,
         is_version=isinstance(migrator, Version),
     )
@@ -473,7 +473,7 @@ def _check_and_process_solvability(
     if solvable:
         _reset_pre_pr_migrator_fields(
             context.attrs,
-            migrator.unique_name,
+            migrator.report_name,
             is_version=isinstance(migrator, Version),
         )
         return True
@@ -579,7 +579,7 @@ def run(
     ValueError
         If an unexpected response is received from the GitHub API.
     """
-    migrator_name = migrator.unique_name
+    migrator_name = migrator.report_name
     is_version_migration = isinstance(migrator, Version)
     _increment_pre_pr_migrator_attempt(
         context.attrs,
@@ -765,7 +765,7 @@ def _compute_time_per_migrator(migrators, max_attempts_for_share=3):
             with migrator.effective_graph.nodes[node_name]["payload"] as attrs:
                 _attempts = _get_pre_pr_migrator_attempts(
                     attrs,
-                    migrator_name=migrator.unique_name,
+                    migrator_name=migrator.report_name,
                     is_version=isinstance(migrator, Version),
                 )
                 if _attempts < max_attempts_for_share:
@@ -1038,7 +1038,7 @@ def _run_migrator(
     _mg_start = time.time()
     initial_working_dir = os.getcwd()
 
-    migrator_name = migrator.unique_name
+    migrator_name = migrator.report_name
 
     with fold_log_lines(
         f"migrations for {migrator.two_part_name}\n",

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -64,7 +64,6 @@ from conda_forge_tick.utils import (
     fold_log_lines,
     frozen_to_json_friendly,
     get_bot_run_url,
-    get_migrator_name,
     get_migrator_name_from_pr_data,
     load_existing_graph,
     sanitize_string,
@@ -363,7 +362,7 @@ def _is_solvability_check_needed(
     migrator_check_solvable = getattr(migrator, "check_solvable", True)
     pr_attempts = _get_pre_pr_migrator_attempts(
         context.attrs,
-        migrator_name=get_migrator_name(migrator),
+        migrator_name=migrator.unique_name,
         is_version=isinstance(migrator, Version),
     )
     max_pr_attempts = getattr(
@@ -425,7 +424,7 @@ def _handle_solvability_error(
 
     _set_pre_pr_migrator_error(
         context.attrs,
-        get_migrator_name(migrator),
+        migrator.unique_name,
         _solver_err_str,
         is_version=isinstance(migrator, Version),
     )
@@ -474,7 +473,7 @@ def _check_and_process_solvability(
     if solvable:
         _reset_pre_pr_migrator_fields(
             context.attrs,
-            get_migrator_name(migrator),
+            migrator.unique_name,
             is_version=isinstance(migrator, Version),
         )
         return True
@@ -580,7 +579,7 @@ def run(
     ValueError
         If an unexpected response is received from the GitHub API.
     """
-    migrator_name = get_migrator_name(migrator)
+    migrator_name = migrator.unique_name
     is_version_migration = isinstance(migrator, Version)
     _increment_pre_pr_migrator_attempt(
         context.attrs,
@@ -766,7 +765,7 @@ def _compute_time_per_migrator(migrators, max_attempts_for_share=3):
             with migrator.effective_graph.nodes[node_name]["payload"] as attrs:
                 _attempts = _get_pre_pr_migrator_attempts(
                     attrs,
-                    migrator_name=get_migrator_name(migrator),
+                    migrator_name=migrator.unique_name,
                     is_version=isinstance(migrator, Version),
                 )
                 if _attempts < max_attempts_for_share:
@@ -1039,19 +1038,10 @@ def _run_migrator(
     _mg_start = time.time()
     initial_working_dir = os.getcwd()
 
-    migrator_name = get_migrator_name(migrator)
-
-    if hasattr(migrator, "name"):
-        extra_name = "-%s" % migrator.name
-    else:
-        extra_name = ""
+    migrator_name = migrator.unique_name
 
     with fold_log_lines(
-        "migrations for %s%s\n"
-        % (
-            migrator.__class__.__name__,
-            extra_name,
-        ),
+        f"migrations for {migrator.two_part_name}\n",
     ):
         good_prs = 0
         tried_prs = 0
@@ -1095,11 +1085,10 @@ def _run_migrator(
                 )
 
         print(
-            "found %d nodes for migration %s%s"
+            "found %d nodes for migration %s"
             % (
                 len(effective_graph.nodes),
-                migrator.__class__.__name__,
-                extra_name,
+                migrator.two_part_name,
             ),
             flush=True,
         )
@@ -1112,10 +1101,9 @@ def _run_migrator(
     for node_name in possible_nodes:
         with (
             fold_log_lines(
-                "%s%s IS MIGRATING %s"
+                "%s IS MIGRATING %s"
                 % (
-                    migrator.__class__.__name__.upper(),
-                    extra_name,
+                    migrator.two_part_name,
                     node_name,
                 )
             ),
@@ -1164,10 +1152,9 @@ def _run_migrator(
                         continue
 
                     with fold_log_lines(
-                        "%s%s IS MIGRATING %s:%s"
+                        "%s IS MIGRATING %s:%s"
                         % (
-                            migrator.__class__.__name__.upper(),
-                            extra_name,
+                            migrator.two_part_name,
                             fctx.feedstock_name,
                             base_branch,
                         )
@@ -1405,16 +1392,10 @@ def main(ctx: CliContext) -> None:
             migrators,
         )
         for i, migrator in enumerate(migrators):
-            if hasattr(migrator, "name"):
-                extra_name = "-%s" % migrator.name
-            else:
-                extra_name = ""
-
             print(
-                "    %s%s: %d to try (%d total left)- gets %f seconds (%f percent)"
+                "    %s: %d to try (%d total left)- gets %f seconds (%f percent)"
                 % (
-                    migrator.__class__.__name__,
-                    extra_name,
+                    migrator.two_part_name,
                     num_nodes_not_tried[i],
                     num_nodes[i],
                     time_per_migrator[i],

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -183,7 +183,7 @@ def _make_migrator_lazy_json_name(mgr, data):
                 data["kwargs"],
             )
         )
-    ).replace(" ", "_")
+    )
 
 
 def make_from_lazy_json_data(data):

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -171,17 +171,14 @@ def _migrator_hash(klass, args, kwargs):
 
 
 def _make_migrator_lazy_json_name(mgr, data):
-    return (
-        mgr.report_name
-        + (
-            ""
-            if len(mgr._init_args) == 0 and len(mgr._init_kwargs) == 0
-            else "_h"
-            + _migrator_hash(
-                data["class"],
-                data["args"],
-                data["kwargs"],
-            )
+    return mgr.report_name + (
+        ""
+        if len(mgr._init_args) == 0 and len(mgr._init_kwargs) == 0
+        else "_h"
+        + _migrator_hash(
+            data["class"],
+            data["args"],
+            data["kwargs"],
         )
     )
 

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -775,7 +775,7 @@ class Migrator:
         else:
             extra_name = ""
 
-        return self.__class__.name + extra_name
+        return self.__class__.__name__ + extra_name
 
     @property
     def report_name(self):

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -172,7 +172,7 @@ def _migrator_hash(klass, args, kwargs):
 
 def _make_migrator_lazy_json_name(mgr, data):
     return (
-        mgr.unique_name
+        mgr.report_name
         + (
             ""
             if len(mgr._init_args) == 0 and len(mgr._init_kwargs) == 0
@@ -249,6 +249,17 @@ class MiniMigrator:
             The node attributes
         """
         return
+
+    @property
+    def report_name(self):
+        """The name of the migrator used in the status reports and PR attempt tracking data."""
+        if hasattr(self, "name"):
+            assert isinstance(self.name, str)
+            migrator_name = self.name.lower().replace(" ", "")
+        else:
+            migrator_name = self.__class__.__name__.lower()
+
+        return migrator_name
 
     def to_lazy_json_data(self):
         """Serialize the migrator to LazyJson-compatible data."""
@@ -610,7 +621,7 @@ class Migrator:
 
     def commit_message(self, feedstock_ctx: FeedstockContext) -> str:
         """Create a commit message."""
-        return f"migration: {self.unique_name}"
+        return f"migration: {self.report_name}"
 
     def pr_title(self, feedstock_ctx: FeedstockContext) -> str:
         """Get the PR title."""
@@ -666,7 +677,7 @@ class Migrator:
 
         Ties are sorted randomly.
         """
-        migrator_name = self.unique_name
+        migrator_name = self.report_name
 
         seconds_to_days = 1.0 / (60.0 * 60.0 * 24.0)
         now = int(time.time()) * seconds_to_days
@@ -767,8 +778,8 @@ class Migrator:
         return self.__class__.name + extra_name
 
     @property
-    def unique_name(self):
-        """The unique name of the migrator used in PR attempt tracking data."""
+    def report_name(self):
+        """The name of the migrator used in the status reports and PR attempt tracking data."""
         if hasattr(self, "name"):
             assert isinstance(self.name, str)
             migrator_name = self.name.lower().replace(" ", "")

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -171,16 +171,19 @@ def _migrator_hash(klass, args, kwargs):
 
 
 def _make_migrator_lazy_json_name(mgr, data):
-    return mgr.report_name + (
-        ""
-        if len(mgr._init_args) == 0 and len(mgr._init_kwargs) == 0
-        else "_h"
-        + _migrator_hash(
-            data["class"],
-            data["args"],
-            data["kwargs"],
+    if hasattr(mgr, "name"):
+        return mgr.report_name
+    else:
+        return mgr.report_name + (
+            ""
+            if len(mgr._init_args) == 0 and len(mgr._init_kwargs) == 0
+            else "_h"
+            + _migrator_hash(
+                data["class"],
+                data["args"],
+                data["kwargs"],
+            )
         )
-    )
 
 
 def make_from_lazy_json_data(data):

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -459,7 +459,7 @@ class MigrationYaml(GraphMigrator):
 
     def pr_body(self, feedstock_ctx: ClonedFeedstockContext) -> str:
         body = super().pr_body(feedstock_ctx)
-        name = self.unique_name
+        name = self.report_name
         url = f"https://conda-forge.org/status/migration/?name={name}"
         if feedstock_ctx.feedstock_name == "conda-forge-pinning":
             additional_body = (

--- a/conda_forge_tick/migrators/migration_yaml.py
+++ b/conda_forge_tick/migrators/migration_yaml.py
@@ -22,7 +22,6 @@ from conda_forge_tick.os_utils import pushd
 from conda_forge_tick.utils import (
     get_bot_run_url,
     get_keys_default,
-    get_migrator_name,
     yaml_safe_dump,
     yaml_safe_load,
 )
@@ -460,7 +459,7 @@ class MigrationYaml(GraphMigrator):
 
     def pr_body(self, feedstock_ctx: ClonedFeedstockContext) -> str:
         body = super().pr_body(feedstock_ctx)
-        name = get_migrator_name(self)
+        name = self.unique_name
         url = f"https://conda-forge.org/status/migration/?name={name}"
         if feedstock_ctx.feedstock_name == "conda-forge-pinning":
             additional_body = (

--- a/conda_forge_tick/migrators/staticlib.py
+++ b/conda_forge_tick/migrators/staticlib.py
@@ -570,7 +570,7 @@ class StaticLibMigrator(GraphMigrator):
 
     def pr_body(self, feedstock_ctx: ClonedFeedstockContext) -> str:
         body = super().pr_body(feedstock_ctx)
-        name = self.unique_name
+        name = self.report_name
         url = f"https://conda-forge.org/status/migration/?name={name}"
         additional_body = (
             "This PR has been triggered in an effort to update "

--- a/conda_forge_tick/migrators/staticlib.py
+++ b/conda_forge_tick/migrators/staticlib.py
@@ -25,7 +25,6 @@ from conda_forge_tick.os_utils import pushd
 from conda_forge_tick.utils import (
     extract_section_from_yaml_text,
     get_keys_default,
-    get_migrator_name,
     get_recipe_schema_version,
 )
 
@@ -571,7 +570,7 @@ class StaticLibMigrator(GraphMigrator):
 
     def pr_body(self, feedstock_ctx: ClonedFeedstockContext) -> str:
         body = super().pr_body(feedstock_ctx)
-        name = get_migrator_name(self)
+        name = self.unique_name
         url = f"https://conda-forge.org/status/migration/?name={name}"
         additional_body = (
             "This PR has been triggered in an effort to update "

--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -36,7 +36,6 @@ from conda_forge_tick.path_lengths import cyclic_topological_sort
 from conda_forge_tick.utils import (
     fold_log_lines,
     frozen_to_json_friendly,
-    get_migrator_name,
     load_existing_graph,
 )
 from conda_forge_tick.version_filters import filter_version
@@ -169,7 +168,7 @@ def graph_migrator_status(
     gx: nx.DiGraph,
 ) -> Tuple[dict, list, nx.DiGraph]:
     """Get the migrator progress for a given migrator."""
-    migrator_name = get_migrator_name(migrator)
+    migrator_name = migrator.unique_name
 
     num_viz = 0
 
@@ -450,11 +449,7 @@ def main() -> None:
         if isinstance(migrator, MigrationYamlCreator):
             continue
 
-        if hasattr(migrator, "name"):
-            assert isinstance(migrator.name, str)
-            migrator_name = migrator.name.lower().replace(" ", "")
-        else:
-            migrator_name = migrator.__class__.__name__.lower()
+        migrator_name = migrator.unique_name
 
         print(
             "================================================================",

--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -168,7 +168,7 @@ def graph_migrator_status(
     gx: nx.DiGraph,
 ) -> Tuple[dict, list, nx.DiGraph]:
     """Get the migrator progress for a given migrator."""
-    migrator_name = migrator.unique_name
+    migrator_name = migrator.report_name
 
     num_viz = 0
 
@@ -449,7 +449,7 @@ def main() -> None:
         if isinstance(migrator, MigrationYamlCreator):
             continue
 
-        migrator_name = migrator.unique_name
+        migrator_name = migrator.report_name
 
         print(
             "================================================================",

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -1384,17 +1384,6 @@ def get_bot_run_url():
     return os.environ.get("RUN_URL", "")
 
 
-def get_migrator_name(migrator):
-    """Get the canonical name of a migrator."""
-    if hasattr(migrator, "name"):
-        assert isinstance(migrator.name, str)
-        migrator_name = migrator.name.lower().replace(" ", "")
-    else:
-        migrator_name = migrator.__class__.__name__.lower()
-
-    return migrator_name
-
-
 def get_migrator_name_from_pr_data(migration):
     """Get the canonical name of a migration from the PR data."""
     if "version" in migration["data"]:

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -1384,19 +1384,19 @@ def get_bot_run_url():
     return os.environ.get("RUN_URL", "")
 
 
-def get_migrator_name_from_pr_data(migration):
+def get_migrator_report_name_from_pr_data(migration):
     """Get the canonical name of a migration from the PR data."""
     if "version" in migration["data"]:
         return migration["data"]["version"]
     elif "name" in migration["data"]:
-        return migration["data"]["name"]
+        return migration["data"]["name"].lower().replace(" ", "")
     elif "pin_version" in migration["data"]:
         return migration["data"]["pin_version"]
     elif "migrator_name" in migration["data"]:
         return migration["data"]["migrator_name"].lower()
     else:
         logger.warning(
-            "Could not extract migrator name for migration: %s",
+            "Could not extract migrator report name for migration: %s",
             migration["data"],
         )
         return None

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -1390,8 +1390,6 @@ def get_migrator_report_name_from_pr_data(migration):
         return migration["data"]["version"]
     elif "name" in migration["data"]:
         return migration["data"]["name"].lower().replace(" ", "")
-    elif "pin_version" in migration["data"]:
-        return migration["data"]["pin_version"]
     elif "migrator_name" in migration["data"]:
         return migration["data"]["migrator_name"].lower()
     else:

--- a/tests/test_migrator_to_json.py
+++ b/tests/test_migrator_to_json.py
@@ -129,7 +129,7 @@ def test_migrator_to_json_migration_yaml_creator(test_graph):
 
     assert data["__migrator__"] is True
     assert data["class"] == "MigrationYamlCreator"
-    assert data["name"].startswith(pname + "pinning")
+    assert data["name"] == pname + "pinning"
 
     migrator2 = make_from_lazy_json_data(loads(lzj_data))
     assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [
@@ -155,7 +155,7 @@ def test_migrator_to_json_matplotlib_base():
     print("lazy json data:\n", lzj_data)
     assert data["__migrator__"] is True
     assert data["class"] == "MatplotlibBase"
-    assert data["name"].startswith("matplotlib-to-matplotlib-base")
+    assert data["name"] == "matplotlib-to-matplotlib-base"
 
     migrator2 = make_from_lazy_json_data(loads(lzj_data))
     assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [
@@ -181,7 +181,7 @@ def test_migrator_to_json_migration_yaml():
 
     assert data["__migrator__"] is True
     assert data["class"] == "MigrationYaml"
-    assert data["name"].startswith("hi")
+    assert data["name"] == "hi"
 
     migrator2 = make_from_lazy_json_data(loads(lzj_data))
     assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [
@@ -208,7 +208,7 @@ def test_migrator_to_json_replacement():
     print("lazy json data:\n", lzj_data)
     assert data["__migrator__"] is True
     assert data["class"] == "Replacement"
-    assert data["name"].startswith("matplotlib-to-matplotlib-base")
+    assert data["name"] == "matplotlib-to-matplotlib-base"
 
     migrator2 = make_from_lazy_json_data(loads(lzj_data))
     assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [
@@ -235,7 +235,7 @@ def test_migrator_to_json_arch():
     print("lazy json data:\n", lzj_data)
     assert data["__migrator__"] is True
     assert data["class"] == "ArchRebuild"
-    assert data["name"].startswith("aarch64andppc64leaddition")
+    assert data["name"] == "aarch64andppc64leaddition"
 
     migrator2 = make_from_lazy_json_data(loads(lzj_data))
     assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [
@@ -262,7 +262,7 @@ def test_migrator_to_json_osx_arm():
     print("lazy json data:\n", lzj_data)
     assert data["__migrator__"] is True
     assert data["class"] == "OSXArm"
-    assert data["name"].startswith("armosxaddition")
+    assert data["name"] == "armosxaddition"
 
     migrator2 = make_from_lazy_json_data(loads(lzj_data))
     assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [
@@ -289,7 +289,7 @@ def test_migrator_to_json_win_arm64():
     print("lazy json data:\n", lzj_data)
     assert data["__migrator__"] is True
     assert data["class"] == "WinArm64"
-    assert data["name"].startswith("supportwindowsarm64platform")
+    assert data["name"] == "supportwindowsarm64platform"
 
     migrator2 = make_from_lazy_json_data(loads(lzj_data))
     assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [
@@ -315,7 +315,7 @@ def test_migrator_to_json_others(klass):
     print("lazy json data:\n", lzj_data)
     assert data["__migrator__"] is True
     assert data["class"] == klass.__name__
-    assert data["name"].startswith(migrator.name.lower().replace(" ", ""))
+    assert data["name"] == migrator.name.lower().replace(" ", "")
 
     migrator2 = make_from_lazy_json_data(loads(lzj_data))
     assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [

--- a/tests/test_migrator_to_json.py
+++ b/tests/test_migrator_to_json.py
@@ -35,7 +35,7 @@ def test_migrator_to_json_dep_update_minimigrator():
         "__mini_migrator__": True,
         "args": [python_nodes],
         "kwargs": {},
-        "name": f"DependencyUpdateMigrator_h{hsh}",
+        "name": f"dependencyupdatemigrator_h{hsh}",
         "class": "DependencyUpdateMigrator",
     }
 
@@ -65,7 +65,7 @@ def test_migrator_to_json_minimigrators_nodeps():
                 "__mini_migrator__": True,
                 "args": [],
                 "kwargs": {},
-                "name": migrator_name,
+                "name": migrator_name.lower(),
                 "class": migrator_name,
             }
 
@@ -129,7 +129,7 @@ def test_migrator_to_json_migration_yaml_creator(test_graph):
 
     assert data["__migrator__"] is True
     assert data["class"] == "MigrationYamlCreator"
-    assert data["name"] == pname + "_pinning"
+    assert data["name"].startswith(pname + "pinning")
 
     migrator2 = make_from_lazy_json_data(loads(lzj_data))
     assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [
@@ -155,7 +155,7 @@ def test_migrator_to_json_matplotlib_base():
     print("lazy json data:\n", lzj_data)
     assert data["__migrator__"] is True
     assert data["class"] == "MatplotlibBase"
-    assert data["name"] == "matplotlib-to-matplotlib-base"
+    assert data["name"].startswith("matplotlib-to-matplotlib-base")
 
     migrator2 = make_from_lazy_json_data(loads(lzj_data))
     assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [
@@ -181,7 +181,7 @@ def test_migrator_to_json_migration_yaml():
 
     assert data["__migrator__"] is True
     assert data["class"] == "MigrationYaml"
-    assert data["name"] == "hi"
+    assert data["name"].startswith("hi")
 
     migrator2 = make_from_lazy_json_data(loads(lzj_data))
     assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [
@@ -208,7 +208,7 @@ def test_migrator_to_json_replacement():
     print("lazy json data:\n", lzj_data)
     assert data["__migrator__"] is True
     assert data["class"] == "Replacement"
-    assert data["name"] == "matplotlib-to-matplotlib-base"
+    assert data["name"].startswith("matplotlib-to-matplotlib-base")
 
     migrator2 = make_from_lazy_json_data(loads(lzj_data))
     assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [
@@ -235,7 +235,7 @@ def test_migrator_to_json_arch():
     print("lazy json data:\n", lzj_data)
     assert data["__migrator__"] is True
     assert data["class"] == "ArchRebuild"
-    assert data["name"] == "aarch64_and_ppc64le_addition"
+    assert data["name"].startswith("aarch64andppc64leaddition")
 
     migrator2 = make_from_lazy_json_data(loads(lzj_data))
     assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [
@@ -262,7 +262,7 @@ def test_migrator_to_json_osx_arm():
     print("lazy json data:\n", lzj_data)
     assert data["__migrator__"] is True
     assert data["class"] == "OSXArm"
-    assert data["name"] == "arm_osx_addition"
+    assert data["name"].startswith("armosxaddition")
 
     migrator2 = make_from_lazy_json_data(loads(lzj_data))
     assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [
@@ -289,7 +289,7 @@ def test_migrator_to_json_win_arm64():
     print("lazy json data:\n", lzj_data)
     assert data["__migrator__"] is True
     assert data["class"] == "WinArm64"
-    assert data["name"] == "support_windows_arm64_platform"
+    assert data["name"].startswith("supportwindowsarm64platform")
 
     migrator2 = make_from_lazy_json_data(loads(lzj_data))
     assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [
@@ -315,7 +315,7 @@ def test_migrator_to_json_others(klass):
     print("lazy json data:\n", lzj_data)
     assert data["__migrator__"] is True
     assert data["class"] == klass.__name__
-    assert data["name"] == migrator.name.replace(" ", "_")
+    assert data["name"].startswith(migrator.name.lower().replace(" ", ""))
 
     migrator2 = make_from_lazy_json_data(loads(lzj_data))
     assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR 

- centralizes the migrator naming code
- makes the Version migrator on-the-fly so it is more up to date

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
