### PR TITLE
chore: exclude 1.4.7 for rattler-build-conda-compat

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -52,7 +52,7 @@ dependencies:
   - python-dateutil
   - python-graphviz
   - rattler-build >=0.35.4
-  - rattler-build-conda-compat >=1.3.0,<2
+  - rattler-build-conda-compat >=1.4.6,<2,!=1.4.7
   - requests
   - ruamel.yaml
   - ruamel.yaml.jinja2


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

We need 1.4.8 or later, but this is not yet released.

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
