### PR TITLE
BUG: Expand NVIDIA version updates to variable version numbers

### DIFF
--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -954,10 +954,9 @@ class NVIDIA(AbstractSource):
         response = requests.get(actual_url)
         html_content = response.text
         # Search for links to redistrib_*.json in the response and strip the versions from there
-        # re doesn't support repeating patterns, so we assume there are three version numbers
-        redistrib_pattern = re.compile(
-            pattern=r"redistrib_[0-9]+\.[0-9]+\.[0-9]+\.json<"
-        )
+        # re doesn't support repeating patterns, so we cannot use r"redistrib_([0-9]+\.)+json<"
+        # Some packages use X.Y versioning; others use X.Y.Z versioning.
+        redistrib_pattern = re.compile(pattern=r"redistrib_[0-9]+\.(.*)\.json<")
         result = re.findall(redistrib_pattern, html_content)
         stripped_results = [x.removesuffix(".json<").split("_")[1] for x in result]
         stripped_results.sort(key=Version, reverse=True)

--- a/tests/test_upstream_versions.py
+++ b/tests/test_upstream_versions.py
@@ -1189,6 +1189,121 @@ extra:
     - conda-forge/cuda
 """  # noqa
 
+sample_nvpl = """
+{% set version = "0.4.1.1" %}
+{% set soversion = ".".join(version.split(".")[:3]) %}
+{% set somajor = version.split(".")[0] %}
+{% set arm_variant_type = arm_variant_type|default("sbsa") %}
+
+package:
+  name: libnvpl-blas-split
+  version: {{ version }}
+
+source:
+  url: https://developer.download.nvidia.com/compute/nvpl/redist/nvpl_blas/linux-sbsa/nvpl_blas-linux-sbsa-{{ version }}-archive.tar.xz
+  sha256: 57704e2e211999c899bca26346b946b881b609554914245131b390410f7b93e8
+
+build:
+  number: 1
+  # nvpl is only for ARM architecture
+  skip: true  # [not aarch64]
+  script:
+    - cp -rv include $PREFIX
+    - cp -rv lib $PREFIX
+    - check-glibc "$PREFIX"/lib*/*.so.* "$PREFIX"/bin/* "$PREFIX"/targets/*/lib*/*.so.* "$PREFIX"/targets/*/bin/*  # [linux]
+
+requirements:
+  build:
+    - cf-nvidia-tools 1.*  # [linux]
+
+outputs:
+
+  - name: libnvpl-blas-dev
+    build:
+      run_exports:
+        - {{ pin_subpackage("libnvpl-blas" ~ somajor) }}
+    files:
+      - include/nvpl_blas*
+      - include/nvpl_blas*/**
+      - lib/cmake/nvpl_blas*/**
+      - lib/libnvpl_blas*.so
+    requirements:
+      host:
+        - {{ pin_subpackage("libnvpl-blas" ~ somajor, exact=True) }}
+        - _nvpl_dev_mutex
+        - libnvpl-common-dev
+      run:
+        - _nvpl_dev_mutex
+        - {{ pin_compatible("libnvpl-common-dev", max_pin="x.x.x") }}
+        - {{ pin_subpackage("libnvpl-blas" ~ somajor, exact=True) }}
+      run_constrained:
+        - arm-variant * {{ arm_variant_type }}
+    test:
+      files:
+        - test
+      requires:   # [build_platform == target_platform]
+        - {{ compiler("c") }}  # [build_platform == target_platform]
+        - {{ compiler("cxx") }}  # [build_platform == target_platform]
+        - {{ stdlib("c") }}  # [build_platform == target_platform]
+        - cmake   # [build_platform == target_platform]
+        - ninja  # [build_platform == target_platform]
+      commands:
+        - cmake ${CMAKE_ARGS} -GNinja test  # [build_platform == target_platform]
+        - cmake --build .  # [build_platform == target_platform]
+        - test -f $PREFIX/include/nvpl_blas.h
+        - test -f $PREFIX/lib/cmake/nvpl_blas/nvpl_blas-config.cmake
+        - test -f $PREFIX/lib/libnvpl_blas_core.so
+        - test -f $PREFIX/lib/libnvpl_blas_ilp64_gomp.so
+        - test -f $PREFIX/lib/libnvpl_blas_ilp64_seq.so
+        - test -f $PREFIX/lib/libnvpl_blas_lp64_gomp.so
+        - test -f $PREFIX/lib/libnvpl_blas_lp64_seq.so
+
+  - name: libnvpl-blas{{ somajor }}
+    build:
+      run_exports:
+        - {{ pin_subpackage("libnvpl-blas" ~ somajor) }}
+    files:
+      - lib/libnvpl_blas*.so.*
+    requirements:
+      build:
+        - {{ compiler("c") }}
+        - {{ stdlib("c") }}
+        - arm-variant * {{ arm_variant_type }}
+      run_constrained:
+        - arm-variant * {{ arm_variant_type }}
+    test:
+      commands:
+        - test -f $PREFIX/lib/libnvpl_blas_core.so.{{ somajor }}
+        - test -f $PREFIX/lib/libnvpl_blas_core.so.{{ soversion }}
+        - test -f $PREFIX/lib/libnvpl_blas_ilp64_gomp.so.{{ somajor }}
+        - test -f $PREFIX/lib/libnvpl_blas_ilp64_gomp.so.{{ soversion }}
+        - test -f $PREFIX/lib/libnvpl_blas_ilp64_seq.so.{{ somajor }}
+        - test -f $PREFIX/lib/libnvpl_blas_ilp64_seq.so.{{ soversion }}
+        - test -f $PREFIX/lib/libnvpl_blas_lp64_gomp.so.{{ somajor }}
+        - test -f $PREFIX/lib/libnvpl_blas_lp64_gomp.so.{{ soversion }}
+        - test -f $PREFIX/lib/libnvpl_blas_lp64_seq.so.{{ somajor }}
+        - test -f $PREFIX/lib/libnvpl_blas_lp64_seq.so.{{ soversion }}
+
+about:
+  home: https://developer.nvidia.com/nvpl
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  license_file: LICENSE
+  license_url: https://docs.nvidia.com/nvpl/license.html
+  summary: >-
+    The NVIDIA Performance Libraries (NVPL) are a collection of high performance mathematical libraries optimized for the NVIDIA Grace Armv9.0 architecture.
+  description: >-
+    The NVIDIA Performance Libraries (NVPL) are a collection of high performance mathematical libraries optimized for the NVIDIA Grace Armv9.0 architecture.
+
+    These CPU-only libraries have no dependencies on CUDA or CTK, and are drop in replacements for standard C and Fortran mathematical APIs allowing HPC applications to achieve maximum performance on the Grace platform.
+  doc_url: https://docs.nvidia.com/nvpl/
+
+extra:
+  feedstock-name: libnvpl-blas
+  recipe-maintainers:
+    - conda-forge/cuda
+"""  # noqa
+
+
 latest_url_nvidia_test_list = [
     (
         "libnvjpeg2k-split",
@@ -1220,6 +1335,24 @@ latest_url_nvidia_test_list = [
                 "version_updates": {
                     "nvidia": {
                         "json_name": "libcutensor",
+                    }
+                }
+            }
+        },
+    ),
+    (
+        "libnvpl-blas",
+        sample_nvpl,
+        "0.4.1.1",
+        None,
+        NVIDIA(),
+        {},
+        {
+            "bot": {
+                "version_updates": {
+                    "nvidia": {
+                        "compute_subdir": "nvpl",
+                        "json_name": "nvpl_blas",
                     }
                 }
             }


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

Some NVIDIA products inconsistently use version numbers. i.e. The same package will only use 2,3,or 4 version numbers! Therefore, we must also check version strings with other than 3 version numbers.

The `re` module from the python standard library does not support the full regex specification. Specifically, I believe it does not support capture groups, so I cannot match against a repeating subpatterns such as `([0-9]\.)*` without adding a dependency on a third-party regex library.
Therefore I use the overly general expression `redistrib_[0-9]+\.(.*)\.json` which is quite broad because it allows any chars after the initial version number, but it will match both `redistrib_1.2.json` and `redistrib_1.2.3.json` and `redistrib_1.2.3.1.json`. 

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
