### PR TITLE
Create fake-migrator nodes to debug inter-migration issues.

### DIFF
--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -1004,11 +1004,6 @@ def load_migrators(skip_paused: bool = True) -> MutableSequence[Migrator]:
     pinning_migrators = []
     longterm_migrators = []
     all_names = get_all_keys_for_hashmap("migrators")
-    # Only load python314 and python314t migrators - filter BEFORE submitting to pool
-    allowed_migrators = {"python314", "python314t"}
-    all_names = [name for name in all_names if name in allowed_migrators]
-    print(f"Loading only: {all_names}", flush=True)
-
     with executor("process", 2) as pool:
         futs = [pool.submit(_load, name) for name in all_names]
 
@@ -1032,13 +1027,11 @@ def load_migrators(skip_paused: bool = True) -> MutableSequence[Migrator]:
             else:
                 migrators.append(migrator)
 
-    # Commented out - version migrator is slow
-    # version_migrator = _make_version_migrator(load_existing_graph())
+    version_migrator = _make_version_migrator(load_existing_graph())
 
     RNG.shuffle(pinning_migrators)
     RNG.shuffle(longterm_migrators)
-    # migrators = [version_migrator] + migrators + pinning_migrators + longterm_migrators
-    migrators = migrators + pinning_migrators + longterm_migrators
+    migrators = [version_migrator] + migrators + pinning_migrators + longterm_migrators
 
     return migrators
 


### PR DESCRIPTION
This is draft code to debug some migrations issues to 314t migration.

A few packages are marked as "waiting for parent" (parent in another migration), but those parents have been merged for a while. 

This adds in the migration status data "fake-parents" nodes from other migration, so you can get things like

```
migrator_python314_matplotlib | https://github.com/conda-forge/matplotlib-feedstock/pull/429
| Done | 34(children) |	matplotlib
```

Click on the link, and found that `https://github.com/conda-forge/matplotlib-feedstock/pull/429` is merged


like https://github.com/conda-forge/breezy-feedstock/pull/4, https://github.com/conda-forge/numba-feedstock/pull/162, https://github.com/conda-forge/llvmlite-feedstock/pull/102, https://github.com/conda-forge/matplotlib-feedstock/pull/429 and https://github.com/conda-forge/pyside2-feedstock/pull/261 as the respective parent we are "waiting for", and obviously they have been merged a while.


The error in cf-script is that (I think), the format has changed at some point, and some stuff have a pr "number" instead of a 'html_url' maybe ?

<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
