### PR TITLE
fix: ensure we add last_fetched timestamp to Pull Request data when made

### DIFF
--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -1302,6 +1302,7 @@ class GitHubBackend(GitPlatformBackend):
             k: self._github3_session.last_response_headers.get(k, None)
             for k in PullRequestDataValid.HEADER_FIELDS
         }
+        header_fields["last_fetched"] = datetime.now()
 
         # note: this ignores extra fields in the response
         return PullRequestDataValid.model_validate(response.as_dict() | header_fields)
@@ -1470,6 +1471,7 @@ class DryRunBackend(GitPlatformBackend):
             {
                 "ETag": "GITHUB_PR_ETAG",
                 "Last-Modified": utils.format_datetime(now),
+                "last_fetched": datetime.now(),
                 "id": 13371337,
                 "html_url": f"https://github.com/{target_owner}/{target_repo}/pulls/1337",
                 "created_at": now,


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

We did not have this and it was forcing extra refreshes of brand new PRs.

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
