### PR TITLE
fix: only use local pinnings when running integration tests

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -12,6 +12,9 @@ concurrency:
   group: cf-scripts-integration-tests
   cancel-in-progress: false
 
+env:
+  CF_TICK_USE_LOCAL_PINNINGS: "true"
+
 defaults:
   run:
     shell: bash -leo pipefail {0}

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ If your migrator needs special configuration, you should write a new factory fun
 - `BOT_TOKEN`: a GitHub token for the bot user
 - `CF_FEEDSTOCK_OPS_CONTAINER_NAME`: the name of the container to use in the bot, otherwise defaults to `ghcr.io/regro/conda-forge-tick`
 - `CF_FEEDSTOCK_OPS_CONTAINER_TAG`: set this to override the default container tag used in production runs, otherwise the value of `__version__` is used
+- `CF_TICK_USE_LOCAL_PINNINGS`: set to `true` to force the bot to always use the local copy of the pinnings file for rerenders, set during integration testing
 
 Additional environment variables are described in [the settings module](conda_forge_tick/settings.py).
 

--- a/conda_forge_tick/rerender_feedstock.py
+++ b/conda_forge_tick/rerender_feedstock.py
@@ -23,9 +23,13 @@ def rerender_feedstock(feedstock_dir, timeout=900, use_container=None):
     str
         The commit message for the rerender. If None, the rerender didn't change anything.
     """
-    local_pinnings = os.path.join(
-        os.path.expandvars("${CONDA_PREFIX}"), "conda_build_config.yaml"
-    )
+    if str(os.environ.get("CF_TICK_USE_LOCAL_PINNINGS", "false")).lower() == "true":
+        local_pinnings = os.path.join(
+            os.path.expandvars("${CONDA_PREFIX}"), "conda_build_config.yaml"
+        )
+    else:
+        local_pinnings = None
+
     return _rerender(
         feedstock_dir,
         exclusive_config_file=local_pinnings,


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This will fix missing metadata from commit messages when smithy rerenders.

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

closes #5440 
