### PR TITLE
fix: ensure if cond is string for v1 migrator

### DIFF
--- a/conda_forge_tick/migrators/recipe_v1.py
+++ b/conda_forge_tick/migrators/recipe_v1.py
@@ -33,7 +33,9 @@ def _munge_if_value_to_string(value: Any) -> str:
 def get_condition(node: Any) -> Node | None:
     if isinstance(node, dict) and "if" in node:
         return Parser(
-            Environment(), _munge_if_value_to_string(node["if"]).strip(), state="variable"
+            Environment(),
+            _munge_if_value_to_string(node["if"]).strip(),
+            state="variable",
         ).parse_expression()
     return None
 


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR fixes the string error for v1 migrators.

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

closes #5476
