### PR TITLE
fix: ensure integration tests do a dummy run on forks

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Check if we should run rest of tests
         id: should-run
-        run:
+        run: |
           if [[ ${SHOULD_RUN} == "true" ]]; then
             echo "should-run=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This will fix automerge for forks. The integration tests always get run in the merge queue if needed anyways.

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
