### PR TITLE
fix: set a timeout for git command execution in deploy

### DIFF
--- a/conda_forge_tick/deploy.py
+++ b/conda_forge_tick/deploy.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 RNG = secrets.SystemRandom()
 GIT_CMD_TIMEOUT = 300
 
+
 def _flush_io():
     sys.stdout.flush()
     sys.stderr.flush()


### PR DESCRIPTION
Added a timeout for git commands to prevent hanging.

<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
