### PR TITLE
fix compiler stub replacement

### DIFF
--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -472,22 +472,14 @@ def replace_compiler_with_stub(text: str) -> str:
     -------
     str
     """
-    # replaces ${{ compiler('c') }} with ${{ 'c_compiler_stub' }}
+    # replaces ${{ compiler('c') | any | other filters }} with 'c_compiler_stub'
     # should work even with jinja filters like ${{ compiler('c') | replace('==', '>=') }}
-    # where _only_ `compiler('c')` is replaced with the stub string
-    pattern = r"""(?<=\$\{\{)(.*)compiler\((["'])([^["']+)\2\)(?=.*\}\})"""
-    text = re.sub(
-        pattern,
-        lambda m: f"{m.group(1)}{m.group(2)}{m.group(3)}_compiler_stub{m.group(2)}",
-        text,
-    )
+    # the whole template string is replaced with the stub
+    pattern = r"""\$\{\{.*compiler\(\s*(["'])([^["']+)\1\s*\).*\}\}"""
+    text = re.sub(pattern, lambda m: f"{m.group(2)}_compiler_stub", text)
 
-    pattern = r"""(?<=\$\{\{)(.*)stdlib\((["'])([^["']+)\2\)(?=.*\}\})"""
-    text = re.sub(
-        pattern,
-        lambda m: f"{m.group(1)}{m.group(2)}{m.group(3)}_stdlib_stub{m.group(2)}",
-        text,
-    )
+    pattern = r"""\$\{\{.*stdlib\(\s*(["'])([^["']+)\1\s*\).*\}\}"""
+    text = re.sub(pattern, lambda m: f"{m.group(2)}_stdlib_stub", text)
 
     return text
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -451,16 +451,16 @@ def test_extract_section_from_yaml_text(
 @pytest.mark.parametrize(
     "text, expected",
     [
-        ("${{ compiler('c') }}", "${{ 'c_compiler_stub' }}"),
-        ('${{   compiler("fortran")  }}', '${{   "fortran_compiler_stub"  }}'),
-        ('${{stdlib("cxx")}}', '${{"cxx_stdlib_stub"}}'),
+        ("${{ compiler('c') }}", "c_compiler_stub"),
+        ('${{   compiler( "fortran" )  }}', "fortran_compiler_stub"),
+        ('${{stdlib("cxx")}}', "cxx_stdlib_stub"),
         (
             '${{ variable | default(compiler("c")) }}',
-            '${{ variable | default("c_compiler_stub") }}',
+            "c_compiler_stub",
         ),
         (
             '${{ compiler("fortran") | replace("x", "y") }}',
-            '${{ "fortran_compiler_stub" | replace("x", "y") }}',
+            "fortran_compiler_stub",
         ),
         ('# compiler("fortran")', '# compiler("fortran")'),
     ],


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

fixes regex to substitute only the `compiler("x")` part instead of the whole template string, so that it remains valid if there's other stuff going on like jinja filters.

So instead of turning

```
${{ compiler('x') }}
```

into 

```
x_compiler_stub
```

it is turned into

```
${{ 'x_compiler_stub' }}
```


#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

this may fix #5382 (I can at least do a local call of:

```
text = read_recipe_yaml()

_render_recipe_yaml(text, platform_arch="linux-64", cbc_path="/path/to/openmpi-feedstock/.ci_support/linux_64_channel_targetsconda-forge_maincuda_compiler_version12.9mpi_typeconda.yam
      ⋮ l")
```

(note: it still fails if I don't give it a variant config due to the empty `libfabric` variable)