### PR TITLE
Add ruamel_yaml mapping to pypi_name_mapping_static

### DIFF
--- a/conda_forge_tick/pypi_name_mapping_static.yaml
+++ b/conda_forge_tick/pypi_name_mapping_static.yaml
@@ -100,6 +100,10 @@
   import_name: ruamel.yaml
   conda_name: ruamel.yaml
 
+- pypi_name: ruamel_yaml
+  import_name: ruamel.yaml
+  conda_name: ruamel.yaml
+
 - pypi_name: fastjsonschema
   import_name: fastjsonschema
   conda_name: python-fastjsonschema


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

Quick fix for problem described in https://github.com/regro/cf-scripts/issues/5745 where when the bot updates a feedstock with `ruamel.yaml` as a run dependency, it rewrites it as `ruamel_yaml` in `meta.yaml`, which does not exist on conda-forge and breaks the build. 

The static mapping at `conda_forge_tick/pypi_name_mapping_static.yaml` already has the correct entry:

```yaml
- pypi_name: ruamel-yaml
  import_name: ruamel.yaml
  conda_name: ruamel.yaml
```

The problem is that the mapping is keyed on the dash-normalized PyPI name (`ruamel-yaml`), but when the bot encounters `ruamel.yaml` in wheel metadata it normalizes dots to underscores (`ruamel_yaml`) before the lookup, so the mapping is never hit and the bad name passes through.

**This PR adds a second entry to the static mapping with the underscore form so the lookup hits regardless.**

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

https://github.com/regro/cf-scripts/issues/5745
