### PR TITLE
fix: xorg-x11-proto-devel mapping to xorg-xorgproto

### DIFF
--- a/conda_forge_tick/migrators/cdt.py
+++ b/conda_forge_tick/migrators/cdt.py
@@ -79,7 +79,7 @@ cdt_mapping = {
     "xcb-util-keysyms-devel": "xcb-util-keysyms",
     "xcb-util-renderutil-devel": "xcb-util-renderutil",
     "xcb-util-wm-devel": "xcb-util-wm",
-    "xorg-x11-proto-devel": "xorg-xorgproto"
+    "xorg-x11-proto-devel": "xorg-xorgproto",
 }
 
 


### PR DESCRIPTION
cc @isuruf

<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
