### PR TITLE
cdt: fix adding `host:` section, improve deduplication and handling empty lines

### DIFF
--- a/conda_forge_tick/migrators/cdt.py
+++ b/conda_forge_tick/migrators/cdt.py
@@ -180,7 +180,7 @@ class CDTMigrator(Migrator):
                 for key, subsection in subsections.items()
             }
 
-            for key, subsection in subsections.items():
+            for key, subsection in list(subsections.items()):
                 new = []
                 # Perform CDT replacement.
                 for line in subsection:

--- a/tests/test_cdt.py
+++ b/tests/test_cdt.py
@@ -1179,6 +1179,43 @@ extra:
     - martin-g
 """  # noqa
 
+no_host_recipe = """\
+package:
+  name: test
+  version: 1.0.0
+
+requirements:
+  build:
+    - make
+    - pkg-config
+    - {{ stdlib('c') }}
+    - gnuconfig  # [unix]
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ cdt('xorg-x11-proto-devel') }}
+    - {{ cdt('libx11-devel') }}
+    - {{ cdt('libxext-devel') }}
+"""
+
+no_host_recipe_correct = """\
+package:
+  name: test
+  version: 1.0.0
+
+requirements:
+  build:
+    - make
+    - pkg-config
+    - {{ stdlib('c') }}
+    - gnuconfig  # [unix]
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - xorg-xorgproto
+    - xorg-libx11
+    - xorg-libxext
+"""
+
 
 def test_cdt(tmp_path):
     run_test_migration(
@@ -1249,6 +1286,22 @@ def test_cdt_openmotif(tmp_path):
         m=cdt_migrator,
         inp=openmotif_recipe,
         output=openmotif_recipe_correct,
+        prb="This migrator will attempt to replace the CDT dependencies with regular conda-forge packages",
+        kwargs={"new_version": "1.0.0"},
+        mr_out={
+            "migrator_name": "CDTMigrator",
+            "migrator_version": 1,
+            "name": "CDT Migrator",
+        },
+        tmp_path=tmp_path,
+    )
+
+
+def test_cdt_no_host(tmp_path):
+    run_test_migration(
+        m=cdt_migrator,
+        inp=no_host_recipe,
+        output=no_host_recipe_correct,
         prb="This migrator will attempt to replace the CDT dependencies with regular conda-forge packages",
         kwargs={"new_version": "1.0.0"},
         mr_out={


### PR DESCRIPTION
#### Description:

Three fixes for the CDT migrator:
- Fix "dictionary size changed" error when adding `host:` section to a recipe without one. Add a minimal test case (there is no real recipe like that).
- Improve deduplication to account for packages already in requirements (previously it only deduplicated against the same CDT replacements).
- Append new packages to `host:` section prior to any trailing empty lines.

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
