### PR TITLE
fix: ensure we have a separate log-level bit in commands

### DIFF
--- a/.github/workflows/bot-make-graph.yml
+++ b/.github/workflows/bot-make-graph.yml
@@ -66,7 +66,7 @@ jobs:
           pushd cf-graph
 
           export RUN_URL="https://github.com/regro/cf-scripts/actions/runs/${RUN_ID}"
-          conda-forge-tick make-graph --update-nodes-and-edges --debug
+          conda-forge-tick make-graph --update-nodes-and-edges --log-level=debug
         env:
           CF_TICK_GRAPH_DATA_BACKENDS: "${{ vars.CF_TICK_GRAPH_DATA_BACKENDS }}"
           MONGODB_CONNECTION_STRING: ${{ secrets.MONGODB_CONNECTION_STRING }}

--- a/conda_forge_tick/cli.py
+++ b/conda_forge_tick/cli.py
@@ -66,6 +66,9 @@ click.Group.command_class = TimedCommand
         "Turning off containers is a potential security issue."
     ),
 )
+@click.option(
+    "--log-level", default="info", type=str, help="The logging level as a string."
+)
 @pass_context
 @click.pass_context
 def main(
@@ -75,8 +78,9 @@ def main(
     dry_run: bool,
     online: bool,
     no_containers: bool,
+    log_level,
 ) -> None:
-    log_level = "debug" if debug else "info"
+    log_level = "debug" if debug else log_level
     setup_logging(log_level)
 
     ctx.debug = debug
@@ -114,7 +118,6 @@ def gather_all_feedstocks() -> None:
     is_flag=True,
     help="If given, only migrate the schema of the node attrs.",
 )
-@click.option("--debug/--no-debug", default=False)
 @pass_context
 def make_graph(
     ctx: CliContext,
@@ -122,12 +125,8 @@ def make_graph(
     n_jobs: int,
     update_nodes_and_edges: bool,
     schema_migration_only: bool,
-    debug: bool,
 ) -> None:
     from . import make_graph
-
-    log_level = "debug" if debug else "info"
-    setup_logging(log_level)
 
     check_job_param_relative(job, n_jobs)
 
@@ -332,20 +331,14 @@ def make_migrators(
     ),
     type=str,
 )
-@click.option("--debug/--no-debug", default=False)
 @pass_context
 def react_to_event(
     ctx: CliContext,
     event: str,
     uid: str,
-    debug: bool,
 ) -> None:
     """React to an event."""
     from .events import react_to_event
-
-    log_level = "debug" if debug else "info"
-    setup_logging(log_level)
-    ctx.debug = debug
 
     react_to_event(ctx, event, uid)
 

--- a/conda_forge_tick/cli.py
+++ b/conda_forge_tick/cli.py
@@ -78,7 +78,7 @@ def main(
     dry_run: bool,
     online: bool,
     no_containers: bool,
-    log_level,
+    log_level: str,
 ) -> None:
     log_level = "debug" if debug else log_level
     setup_logging(log_level)


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

The CLI had an override of `--debug` in a subcommand. This PR cleans that up by adding a `--log-level` option.

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
