### PR TITLE
fix: do not write LazyJson files outside of context manager

### DIFF
--- a/.github/workflows/bot-events.yml
+++ b/.github/workflows/bot-events.yml
@@ -96,7 +96,7 @@ jobs:
             react-to-event \
             --event='${{ inputs.event }}' \
             --uid='${{ inputs.uid }}'
-            
+
         env:
           BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -1969,3 +1969,20 @@ def reset_and_restore_file(pth: str):
     subprocess.run(["git", "reset", "--", pth], capture_output=True, text=True)
     subprocess.run(["git", "restore", "--", pth], capture_output=True, text=True)
     subprocess.run(["git", "clean", "-f", "--", pth], capture_output=True, text=True)
+
+
+@lock_git_operation()
+def is_tracked_by_git(pth: str):
+    """Return True if the current working directory is a git repo and the `pth` is
+    tracked by git.
+    """
+    # command suggested by AI and then tested by hand
+    ret = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", pth],
+        capture_output=True,
+        text=True,
+    )
+    if ret.returncode == 0:
+        return True
+    else:
+        return False

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -1969,20 +1969,3 @@ def reset_and_restore_file(pth: str):
     subprocess.run(["git", "reset", "--", pth], capture_output=True, text=True)
     subprocess.run(["git", "restore", "--", pth], capture_output=True, text=True)
     subprocess.run(["git", "clean", "-f", "--", pth], capture_output=True, text=True)
-
-
-@lock_git_operation()
-def is_tracked_by_git(pth: str):
-    """Return True if the current working directory is a git repo and the `pth` is
-    tracked by git.
-    """
-    # command suggested by AI and then tested by hand
-    ret = subprocess.run(
-        ["git", "ls-files", "--error-unmatch", pth],
-        capture_output=True,
-        text=True,
-    )
-    if ret.returncode == 0:
-        return True
-    else:
-        return False

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -1025,27 +1025,10 @@ class LazyJson(MutableMapping):
 
         # make this backwards compatible with old behavior
         if CF_TICK_GRAPH_DATA_PRIMARY_BACKEND == "file" and not self._no_sync:
-            if not LAZY_JSON_BACKENDS[CF_TICK_GRAPH_DATA_PRIMARY_BACKEND]().hexists(
-                self.hashmap, self.node
-            ):
-                self._never_synced = True
-            else:
-                self._never_synced = False
-
-    def __del__(self):
-        if (
-            hasattr(self, "_never_synced")
-            and self._never_synced
-            and hasattr(self, "_no_sync")
-            and not self._no_sync
-        ):
-            hashmap = self.hashmap if hasattr(self, "hashmap") else "unknown"
-            node = self.node if hasattr(self, "node") else "unknown"
-            logger.warning(
-                "LazyJson object '%s/%s.json' has never been synced and is being garbage collected!",
-                hashmap,
-                node,
-                stacklevel=2,
+            LAZY_JSON_BACKENDS[CF_TICK_GRAPH_DATA_PRIMARY_BACKEND]().hsetnx(
+                self.hashmap,
+                self.node,
+                dumps({}),
             )
 
     @property
@@ -1094,6 +1077,10 @@ class LazyJson(MutableMapping):
                 else:
                     data_str = dumps({})
                     lzj_is_new = True
+                    if not self._in_context and not self._no_sync:
+                        # need to push file to backend since will not get
+                        # done at end of context manager
+                        backend.hset(self.hashmap, self.node, data_str)
 
                 if isinstance(data_str, bytes):  # type: ignore[unreachable]
                     data_str = data_str.decode("utf-8")  # type: ignore[unreachable]
@@ -1127,7 +1114,6 @@ class LazyJson(MutableMapping):
                 if CF_TICK_GRAPH_DATA_USE_FILE_CACHE:
                     file_backend = LAZY_JSON_BACKENDS["file"]()
                     file_backend.hset(self.hashmap, self.node, data_str)
-                    self._never_synced = False
 
                 # sync changes to all backends
                 for backend_name in CF_TICK_GRAPH_DATA_BACKENDS:
@@ -1135,7 +1121,6 @@ class LazyJson(MutableMapping):
                         continue
                     backend = LAZY_JSON_BACKENDS[backend_name]()
                     backend.hset(self.hashmap, self.node, data_str)
-                    self._never_synced = False
 
         if purge and not self._no_sync:
             # this evicts the json from memory and trades i/o for mem

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -1025,10 +1025,27 @@ class LazyJson(MutableMapping):
 
         # make this backwards compatible with old behavior
         if CF_TICK_GRAPH_DATA_PRIMARY_BACKEND == "file" and not self._no_sync:
-            LAZY_JSON_BACKENDS[CF_TICK_GRAPH_DATA_PRIMARY_BACKEND]().hsetnx(
-                self.hashmap,
-                self.node,
-                dumps({}),
+            if not LAZY_JSON_BACKENDS[CF_TICK_GRAPH_DATA_PRIMARY_BACKEND]().hexists(
+                self.hashmap, self.node
+            ):
+                self._never_synced = True
+            else:
+                self._never_synced = False
+
+    def __del__(self):
+        if (
+            hasattr(self, "_never_synced")
+            and self._never_synced
+            and hasattr(self, "_no_sync")
+            and not self._no_sync
+        ):
+            hashmap = self.hashmap if hasattr(self, "hashmap") else "unknown"
+            node = self.node if hasattr(self, "node") else "unknown"
+            logger.warning(
+                "LazyJson object '%s/%s.json' has never been synced and is being garbage collected!",
+                hashmap,
+                node,
+                stacklevel=2,
             )
 
     @property
@@ -1077,10 +1094,6 @@ class LazyJson(MutableMapping):
                 else:
                     data_str = dumps({})
                     lzj_is_new = True
-                    if not self._in_context and not self._no_sync:
-                        # need to push file to backend since will not get
-                        # done at end of context manager
-                        backend.hset(self.hashmap, self.node, data_str)
 
                 if isinstance(data_str, bytes):  # type: ignore[unreachable]
                     data_str = data_str.decode("utf-8")  # type: ignore[unreachable]
@@ -1114,6 +1127,7 @@ class LazyJson(MutableMapping):
                 if CF_TICK_GRAPH_DATA_USE_FILE_CACHE:
                     file_backend = LAZY_JSON_BACKENDS["file"]()
                     file_backend.hset(self.hashmap, self.node, data_str)
+                    self._never_synced = False
 
                 # sync changes to all backends
                 for backend_name in CF_TICK_GRAPH_DATA_BACKENDS:
@@ -1121,6 +1135,7 @@ class LazyJson(MutableMapping):
                         continue
                     backend = LAZY_JSON_BACKENDS[backend_name]()
                     backend.hset(self.hashmap, self.node, data_str)
+                    self._never_synced = False
 
         if purge and not self._no_sync:
             # this evicts the json from memory and trades i/o for mem

--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -13,6 +13,7 @@ import psutil
 import tqdm
 
 from conda_forge_tick.feedstock_parser import load_feedstock
+from conda_forge_tick.git_utils import is_tracked_by_git
 from conda_forge_tick.lazy_json_backends import (
     LAZY_JSON_BACKENDS,
     LazyJson,
@@ -402,6 +403,25 @@ def _migrate_schemas(nodes):
             _migrate_schema(node, sub_graph)
 
 
+def _should_be_stub_node(name):
+    # a node is a stub if its json data does not exist or
+    # the json data is an empty dict and the file is not tracked by git
+    pth = get_sharded_path(f"node_attrs/{name}.json")
+
+    if not os.path.exists(pth):
+        return True
+
+    # is empty JSON blob and not tracked by git
+    with open(pth) as fp:
+        data = fp.read()
+    if data.strip() == "{}" and not is_tracked_by_git(pth):
+        # remove the file here so it is not pushed later
+        os.remove(pth)
+        return True
+
+    return False
+
+
 def main(
     ctx: CliContext,
     job: int = 1,
@@ -431,7 +451,7 @@ def main(
 
         new_names = {name for name in names if name not in gx.nodes}
         for name in names:
-            if not os.path.exists(get_sharded_path(f"node_attrs/{name}.json")):
+            if _should_be_stub_node(name):
                 # we use the stub here to ensure we do not create an empty node
                 # by leaving a file on disk or syncing the json
                 sub_graph = {

--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -13,7 +13,6 @@ import psutil
 import tqdm
 
 from conda_forge_tick.feedstock_parser import load_feedstock
-from conda_forge_tick.git_utils import is_tracked_by_git
 from conda_forge_tick.lazy_json_backends import (
     LAZY_JSON_BACKENDS,
     LazyJson,
@@ -403,25 +402,6 @@ def _migrate_schemas(nodes):
             _migrate_schema(node, sub_graph)
 
 
-def _should_be_stub_node(name):
-    # a node is a stub if its json data does not exist or
-    # the json data is an empty dict and the file is not tracked by git
-    pth = get_sharded_path(f"node_attrs/{name}.json")
-
-    if not os.path.exists(pth):
-        return True
-
-    # is empty JSON blob and not tracked by git
-    with open(pth) as fp:
-        data = fp.read()
-    if data.strip() == "{}" and not is_tracked_by_git(pth):
-        # remove the file here so it is not pushed later
-        os.remove(pth)
-        return True
-
-    return False
-
-
 def main(
     ctx: CliContext,
     job: int = 1,
@@ -451,7 +431,7 @@ def main(
 
         new_names = {name for name in names if name not in gx.nodes}
         for name in names:
-            if _should_be_stub_node(name):
+            if not os.path.exists(get_sharded_path(f"node_attrs/{name}.json")):
                 # we use the stub here to ensure we do not create an empty node
                 # by leaving a file on disk or syncing the json
                 sub_graph = {

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -1312,7 +1312,9 @@ def load_graph(filename: str = DEFAULT_GRAPH_FILENAME) -> nx.DiGraph | None:
     nx.DiGraph or None
         The graph, or None if the file is empty JSON
     """
-    dta = copy.deepcopy(LazyJson(filename).data)
+    lzj = LazyJson(filename)
+    with lzj:
+        dta = copy.deepcopy(lzj.data)
     if dta:
         return nx.node_link_graph(dta, edges="links")
     else:

--- a/tests/test_lazy_json_backends.py
+++ b/tests/test_lazy_json_backends.py
@@ -450,23 +450,17 @@ def test_lazy_json(tmpdir, backend):
             assert not os.path.exists(f)
             lj = LazyJson(f)
 
-            if backend == "file":
-                assert os.path.exists(lj.file_name)
-                assert os.path.exists(sharded_path)
-                with open(sharded_path) as ff:
-                    assert ff.read() == json.dumps({})
-            else:
-                assert not os.path.exists(sharded_path)
-                assert not os.path.exists(lj.file_name)
+            assert not os.path.exists(sharded_path)
+            assert not os.path.exists(lj.file_name)
 
             with pytest.raises(AssertionError):
                 lj.update({"hi": "globe"})
-            if backend == "file":
-                with open(sharded_path) as ff:
-                    assert ff.read() == dumps({})
             p = pickle.dumps(lj)
             lj2 = pickle.loads(p)
             assert not getattr(lj2, "_data", None)
+
+            assert not os.path.exists(sharded_path)
+            assert not os.path.exists(lj.file_name)
 
             with lj as attrs:
                 attrs["hi"] = "world"
@@ -538,13 +532,10 @@ def test_lazy_json_default(tmpdir):
         assert fpth == f
         assert not os.path.exists(fpth)
         lj = LazyJson(f)
-        assert os.path.exists(lj.file_name)
-        assert os.path.exists(fpth)
+        assert not os.path.exists(lj.file_name)
+        assert not os.path.exists(fpth)
         assert lj.json_ref == {"__lazy_json__": lj.file_name}
         assert lj.sharded_path == get_sharded_path(f"{lj.hashmap}/{lj.node}.json")
-
-        with open(fpth) as ff:
-            assert ff.read() == json.dumps({})
 
         with pytest.raises(AssertionError):
             lj.update({"hi": "globe"})
@@ -684,9 +675,12 @@ def test_lazy_json_stub_default(tmpdir):
 
 def test_lazy_json_backends_hashmap(tmpdir):
     with pushd(tmpdir):
-        LazyJson("blah.json")
-        LazyJson("node_attrs/blah.json")
-        LazyJson("node_attrs/blah_blah.json")
+        with LazyJson("blah.json"):
+            pass
+        with LazyJson("node_attrs/blah.json"):
+            pass
+        with LazyJson("node_attrs/blah_blah.json"):
+            pass
 
         assert get_all_keys_for_hashmap("lazy_json") == ["blah"]
         assert sorted(get_all_keys_for_hashmap("node_attrs")) == sorted(
@@ -1027,10 +1021,7 @@ def test_lazy_json_backends_contexts_double_write():
     with tempfile.TemporaryDirectory() as tmpdir, pushd(tmpdir):
         with lazy_json_override_backends(["file"], use_file_cache=False):
             lzj = LazyJson("test.json")
-            # old behavior always makes a file on init
-            # we remove it here so that we can test
-            assert os.path.exists(lzj.sharded_path)
-            os.remove(lzj.sharded_path)
+            assert not os.path.exists(lzj.sharded_path)
 
             with lzj:
                 # file should not yet exist

--- a/tests/test_make_graph.py
+++ b/tests/test_make_graph.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 
 import networkx as nx
 import pytest
@@ -68,6 +69,8 @@ def test_try_load_feedstock(
 )
 def test_make_graph_nowrite(tmp_path, kwargs):
     with pushd(str(tmp_path)):
+        subprocess.run(["git", "init", "."], check=True, capture_output=True)
+
         (tmp_path / "all_feedstocks.json").write_text(
             json.dumps(
                 {
@@ -112,9 +115,27 @@ def test_make_graph_nowrite(tmp_path, kwargs):
             fname.relative_to(tmp_path) for fname in fnames
         )
 
+        # run again to ensure no empty files are made
+        if "update_nodes_and_edges" in kwargs:
+            make_graph_main(
+                None,
+                **kwargs,
+            )
+
+            fnames = sorted(list(tmp_path.glob("**/*.json")))
+            assert not any(fname.name == "bar.json" for fname in fnames), sorted(
+                fname.relative_to(tmp_path) for fname in fnames
+            )
+
         gx = load_existing_graph()
         all_nodes = set(gx.nodes.keys())
         if "update_nodes_and_edges" in kwargs:
             assert "bar" in all_nodes, all_nodes
+
+            # this load should not make a file
+            fnames = sorted(list(tmp_path.glob("**/*.json")))
+            assert not any(fname.name == "bar.json" for fname in fnames), sorted(
+                fname.relative_to(tmp_path) for fname in fnames
+            )
         else:
             assert "bar" not in all_nodes, all_nodes

--- a/tests/test_make_graph.py
+++ b/tests/test_make_graph.py
@@ -1,5 +1,4 @@
 import json
-import subprocess
 
 import networkx as nx
 import pytest
@@ -69,8 +68,6 @@ def test_try_load_feedstock(
 )
 def test_make_graph_nowrite(tmp_path, kwargs):
     with pushd(str(tmp_path)):
-        subprocess.run(["git", "init", "."], check=True, capture_output=True)
-
         (tmp_path / "all_feedstocks.json").write_text(
             json.dumps(
                 {
@@ -115,27 +112,9 @@ def test_make_graph_nowrite(tmp_path, kwargs):
             fname.relative_to(tmp_path) for fname in fnames
         )
 
-        # run again to ensure no empty files are made
-        if "update_nodes_and_edges" in kwargs:
-            make_graph_main(
-                None,
-                **kwargs,
-            )
-
-            fnames = sorted(list(tmp_path.glob("**/*.json")))
-            assert not any(fname.name == "bar.json" for fname in fnames), sorted(
-                fname.relative_to(tmp_path) for fname in fnames
-            )
-
         gx = load_existing_graph()
         all_nodes = set(gx.nodes.keys())
         if "update_nodes_and_edges" in kwargs:
             assert "bar" in all_nodes, all_nodes
-
-            # this load should not make a file
-            fnames = sorted(list(tmp_path.glob("**/*.json")))
-            assert not any(fname.name == "bar.json" for fname in fnames), sorted(
-                fname.relative_to(tmp_path) for fname in fnames
-            )
         else:
             assert "bar" not in all_nodes, all_nodes


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR removes the behavior that LazyJson files are written outside of the context manager.

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

closes #5894
