### PR TITLE
feat: flatten v1 staging outputs before rendering

### DIFF
--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -35,6 +35,7 @@ from conda_forge_feedstock_ops.container_utils import (
     run_container_operation,
     should_use_container,
 )
+from rattler_build_conda_compat.outputs import flatten_staging_inheritance
 
 from . import sensitive_env
 from .lazy_json_backends import LazyJson
@@ -521,7 +522,12 @@ def _render_recipe_yaml(
             else ["--target-platform", platform_arch]
         )
 
-        prepared_text = replace_compiler_with_stub(text)
+        stubbed_text = replace_compiler_with_stub(text)
+        # rattler-build --render-only drops staging outputs and does not
+        # propagate their build/host requirements into inheriting outputs,
+        # so flatten them first to keep the dep graph complete for pinning
+        # and arch migrations.
+        prepared_text = flatten_staging_inheritance(stubbed_text)
 
         res = subprocess.run(
             ["rattler-build", "build", "--render-only"]

--- a/environment.yml
+++ b/environment.yml
@@ -52,7 +52,7 @@ dependencies:
   - python-dateutil
   - python-graphviz
   - rattler-build >=0.58.3,<0.60
-  - rattler-build-conda-compat >=1.4.6,<2,!=1.4.7,!=1.4.8
+  - rattler-build-conda-compat >=1.4.13,<2
   - requests
   - ruamel.yaml
   - ruamel.yaml.jinja2

--- a/tests/test_recipe_yaml_parsing.py
+++ b/tests/test_recipe_yaml_parsing.py
@@ -200,3 +200,66 @@ def test_populate_feedstock_attributes(recipe_name):
         assert isinstance(value, set)
         for el in value:
             assert isinstance(el, str)
+
+
+def test_populate_feedstock_attributes_staging_outputs():
+    """Build/host deps declared in a staging output must appear in the
+    parsed feedstock attributes, otherwise pinning migrations won't
+    know that this feedstock needs to be rebuilt.
+    """
+    recipe_text = """\
+outputs:
+  - staging:
+      name: shared-build
+    source:
+      url: https://example.com/foo-1.0.tar.gz
+      sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+    requirements:
+      build:
+        - cxx_compiler_stub
+      host:
+        - cudnn 9.*
+        - python
+  - package:
+      name: foo
+      version: "1.0"
+    inherit: shared-build
+    requirements:
+      host:
+        - numpy
+      run:
+        - python
+        - numpy
+about:
+  license: MIT
+  summary: test
+"""
+
+    with TemporaryDirectory() as tmpdir:
+        os.makedirs(Path(tmpdir) / "recipe", exist_ok=True)
+        os.makedirs(Path(tmpdir) / ".ci_support", exist_ok=True)
+        (Path(tmpdir) / "recipe" / "recipe.yaml").write_text(recipe_text)
+        (Path(tmpdir) / ".ci_support" / "linux_64_.yaml").write_text("""\
+target_platform:
+  - linux-64
+""")
+        node_attrs = populate_feedstock_attributes(
+            "foo",
+            {},
+            recipe_yaml=recipe_text,
+            feedstock_dir=tmpdir,
+        )
+
+    build_reqs = node_attrs["total_requirements"]["build"]
+    assert "cxx_compiler_stub" in build_reqs
+
+    host_reqs = node_attrs["total_requirements"]["host"]
+    # from staging
+    assert "cudnn 9.*" in host_reqs
+    assert "python" in host_reqs
+    # from the package output itself
+    assert "numpy" in host_reqs
+
+    run_reqs = node_attrs["total_requirements"]["run"]
+    assert "python" in run_reqs
+    assert "numpy" in run_reqs


### PR DESCRIPTION
This prepares for the soon-to-be-stabilized staging output of recipe v1: https://github.com/conda/ceps/pull/102

With this update, we require a newer rattler-build-conda-compat and make use of the new API that flattens staging output requirement into the package requirements. That way migrations will trigger even though the relevant requirements are only in staging outputs.