### PR TITLE
fix: properly extract tags that include forward slashes

### DIFF
--- a/conda_forge_tick/update_sources.py
+++ b/conda_forge_tick/update_sources.py
@@ -211,10 +211,15 @@ class VersionFromFeed(AbstractSource, abc.ABC):
         vers = []
 
         for entry in data["entries"]:
-            ver = urllib.parse.unquote(entry["link"]).split("/")[-1]
+            ver = urllib.parse.unquote(entry["link"].split("/")[-1])
 
             if is_tag_ignored(node_attrs, ver):
                 continue
+
+            # Strip scope prefix (e.g. "sass_api/" from "sass_api/17.5.0") so
+            # subsequent dev-version checks only operate on the version part.
+            if "/" in ver:
+                ver = ver.rsplit("/", 1)[1]
 
             for prefix in self.ver_prefix_remove:
                 if ver.startswith(prefix):

--- a/tests/test_upstream_versions.py
+++ b/tests/test_upstream_versions.py
@@ -2013,6 +2013,39 @@ def test_github_version_prefix(url, version, version_prefix, tmpdir):
         assert gh.version_prefix == version_prefix
 
 
+@mock.patch("conda_forge_tick.update_sources.feedparser.parse")
+def test_github_release_tag_with_slash_respects_allowed_tag_globs(
+    feedparser_parse_mock: MagicMock,
+):
+    feedparser_parse_mock.return_value = {
+        "bozo": 0,
+        "entries": [
+            {
+                "link": "https://github.com/sass/dart-sass/releases/tag/sass_api%2F17.5.0",
+            },
+            {
+                "link": "https://github.com/sass/dart-sass/releases/tag/sass_api%2F17.4.0",
+            },
+        ],
+    }
+
+    node_attrs = {
+        "conda-forge.yml": {
+            "bot": {
+                "version_updates": {
+                    "allowed_tag_globs": "sass_api/*",
+                },
+            },
+        },
+    }
+
+    gh = Github()
+    assert (
+        gh.get_version("https://github.com/sass/dart-sass/releases.atom", node_attrs)
+        == "17.5.0"
+    )
+
+
 @pytest.mark.parametrize(
     "url, feedstock_version",
     [


### PR DESCRIPTION
Fixes extracting tags from the `github` source (atom feed containing URLs of the form `https://github.com/<owner>/<repo>/releases/tag/<tag>` for all releases of a repository incl. side-packages).

Before, when a tag contained a forward slash like e.g. `sass_api/17.5.0`, everything up to and including the last slash was stripped, wrongly extracting `17.5.0` as the tag instead of the full `sass_api/17.5.0` tag name. As a consequence, the [`bot.version_updates.allowed_tag_globs`](https://conda-forge.org/docs/maintainer/conda_forge_yml/#bot) config setting wouldn't work as intended.

<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
