### PR TITLE
Fix dependency update token mismatch

### DIFF
--- a/conda_forge_tick/update_deps.py
+++ b/conda_forge_tick/update_deps.py
@@ -763,6 +763,26 @@ def is_expression_requirement(dep: str) -> bool:
     return dep.startswith(r"${{")
 
 
+def _find_env_dep_index(deps: list[str], dep: str) -> int | None:
+    """Find a dependency by exact text, falling back to package token.
+
+    Dependency comparisons are keyed by package token, but the comparison entry
+    can be less specific than the recipe line (for example ``cuda-version`` vs
+    ``cuda-version >=12,<13``). Prefer exact matches so formatting is preserved
+    where possible, then fall back to the same package-token match used when the
+    patches are created.
+    """
+    if dep in deps:
+        return deps.index(dep)
+
+    package = dep.split(" ", 1)[0]
+    for i, recipe_dep in enumerate(deps):
+        if recipe_dep.split(" ", 1)[0] == package:
+            return i
+
+    return None
+
+
 def _apply_env_dep_comparison(
     deps: list[str], env_dep_comparison: EnvDepComparison
 ) -> list[str]:
@@ -781,10 +801,14 @@ def _apply_env_dep_comparison(
             new_deps.append(patch.after)  # type: ignore[arg-type]
         # Remove old package.
         elif patch.after is None:
-            new_deps.remove(patch.before)
+            loc = _find_env_dep_index(new_deps, patch.before)
+            if loc is not None:
+                new_deps.pop(loc)
         # Update existing package.
         else:
-            new_deps[new_deps.index(patch.before)] = patch.after
+            loc = _find_env_dep_index(new_deps, patch.before)
+            if loc is not None:
+                new_deps[loc] = patch.after
     return new_deps
 
 

--- a/tests/test_update_deps.py
+++ b/tests/test_update_deps.py
@@ -13,6 +13,7 @@ from conda_forge_tick.migrators import DependencyUpdateMigrator, Version
 from conda_forge_tick.recipe_parser import CondaMetaYAML
 from conda_forge_tick.update_deps import (
     DepComparison,
+    _apply_env_dep_comparison,
     _merge_dep_comparisons_sec,
     _modify_package_name_from_github,
     _update_sec_deps,
@@ -161,6 +162,27 @@ def test_update_run_deps():
     print("\n" + recipe.dumps())
     assert updated_deps
     assert "python >={{ python_min }}" in recipe.dumps()
+
+
+def test_apply_env_dep_comparison_matches_package_token_for_update():
+    deps = ["python", "cuda-version >=12,<13", "numpy"]
+    comparison = {
+        "cf_minus_df": {"cuda-version"},
+        "df_minus_cf": {"cuda-version >=12"},
+    }
+
+    assert _apply_env_dep_comparison(deps, comparison) == [
+        "python",
+        "cuda-version >=12",
+        "numpy",
+    ]
+
+
+def test_apply_env_dep_comparison_skips_missing_package_remove():
+    deps = ["python", "numpy"]
+    comparison = {"cf_minus_df": {"cuda-version"}, "df_minus_cf": set()}
+
+    assert _apply_env_dep_comparison(deps, comparison) == deps
 
 
 def test_get_depfinder_comparison():


### PR DESCRIPTION
Fixes #5996.

This makes `_apply_env_dep_comparison()` robust when the dependency comparison uses a package token such as `cuda-version`, but the recipe contains a constrained dependency line such as `cuda-version >=12,<13`.

Changes:
- prefer exact dependency text matches when applying comparison patches;
- fall back to matching the package token before removing/updating;
- skip missing remove/update targets instead of raising a bare `ValueError`;
- add focused regression coverage for token-match update and missing-remove skip.

Local verification:
- `python -m py_compile conda_forge_tick/update_deps.py tests/test_update_deps.py`
- `git diff --check`

I could not run the targeted pytest locally because this runner is missing the test dependency `networkx`, so I left the PR narrow for CI/review iteration.