### PR TITLE
fix: avoid dependency comparison crashes

### DIFF
--- a/conda_forge_tick/update_deps.py
+++ b/conda_forge_tick/update_deps.py
@@ -804,9 +804,10 @@ def _apply_env_dep_comparison(
         # Remove old package.
         if patch.after is None:
             new_deps.pop(dep_index)
+            continue
+
         # Update existing package.
-        else:
-            new_deps[dep_index] = patch.after
+        new_deps[dep_index] = patch.after
     return new_deps
 
 

--- a/conda_forge_tick/update_deps.py
+++ b/conda_forge_tick/update_deps.py
@@ -763,6 +763,22 @@ def is_expression_requirement(dep: str) -> bool:
     return dep.startswith(r"${{")
 
 
+def _dep_package_name(dep: str) -> str:
+    """Return the package-token part of a conda dependency string."""
+    return dep.split()[0]
+
+
+def _find_dep_index(deps: list[str], dep: str) -> int | None:
+    """Find a dependency by exact text first, then by package token."""
+    if dep in deps:
+        return deps.index(dep)
+    package = _dep_package_name(dep)
+    for i, existing_dep in enumerate(deps):
+        if _dep_package_name(existing_dep) == package:
+            return i
+    return None
+
+
 def _apply_env_dep_comparison(
     deps: list[str], env_dep_comparison: EnvDepComparison
 ) -> list[str]:
@@ -779,12 +795,18 @@ def _apply_env_dep_comparison(
         # Add new package.
         if patch.before is None:
             new_deps.append(patch.after)  # type: ignore[arg-type]
+            continue
+
+        dep_index = _find_dep_index(new_deps, patch.before)
+        if dep_index is None:
+            continue
+
         # Remove old package.
-        elif patch.after is None:
-            new_deps.remove(patch.before)
+        if patch.after is None:
+            new_deps.pop(dep_index)
         # Update existing package.
         else:
-            new_deps[new_deps.index(patch.before)] = patch.after
+            new_deps[dep_index] = patch.after
     return new_deps
 
 

--- a/tests/test_update_deps.py
+++ b/tests/test_update_deps.py
@@ -13,6 +13,7 @@ from conda_forge_tick.migrators import DependencyUpdateMigrator, Version
 from conda_forge_tick.recipe_parser import CondaMetaYAML
 from conda_forge_tick.update_deps import (
     DepComparison,
+    _apply_env_dep_comparison,
     _merge_dep_comparisons_sec,
     _modify_package_name_from_github,
     _update_sec_deps,
@@ -178,6 +179,30 @@ def test_get_depfinder_comparison():
         print(d)
     assert d["run"] == {"df_minus_cf": {"pyyaml"}}
     assert "host" not in d
+
+
+def test_apply_env_dep_comparison_matches_dependency_by_package_name():
+    deps = [
+        "cuda-version >=12,<13",
+        "cuda-nvcc-impl >=12.0",
+        "python >=3.11",
+    ]
+    env_dep_comparison = {
+        "cf_minus_df": {"cuda-version", "cuda-nvcc-impl"},
+        "df_minus_cf": set(),
+    }
+
+    assert _apply_env_dep_comparison(deps, env_dep_comparison) == ["python >=3.11"]
+
+
+def test_apply_env_dep_comparison_ignores_missing_dependency_text():
+    deps = ["cuda-version >=12,<13", "python >=3.11"]
+    env_dep_comparison = {
+        "cf_minus_df": {"cuda-cudart-dev"},
+        "df_minus_cf": set(),
+    }
+
+    assert _apply_env_dep_comparison(deps, env_dep_comparison) == deps
 
 
 praw_recipe = """\


### PR DESCRIPTION
## Summary
- make `_apply_env_dep_comparison()` match dependency removals/updates by exact text first, then package token
- skip missing dependency entries instead of raising `ValueError`
- add focused regression coverage for bare CUDA package tokens and missing dependency text

## Verification
- `python3 -m py_compile conda_forge_tick/update_deps.py tests/test_update_deps.py` ✅
- `git diff --check` ✅
- focused pytest not run locally: this runner lacks repo test dependencies/pytest

Fixes #5996