### PR TITLE
prod: move data repo to conda-forge and rename default branch

### DIFF
--- a/.github/workflows/test-model.yml
+++ b/.github/workflows/test-model.yml
@@ -41,7 +41,7 @@ jobs:
         if: ${{ ! env.CI_SKIP }}
         run: |
           pip install --no-deps --no-build-isolation -e .
-          git clone --depth=1 https://github.com/regro/cf-graph-countyfair.git cf-graph
+          git clone --depth=1 https://github.com/conda-forge/autotick-bot-graph.git cf-graph
 
       - name: conda info and env
         if: ${{ ! env.CI_SKIP }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ Base class: `Migration` in `core.py`. Migrators handle automated changes:
 
 ### Data Model
 
-The bot uses `cf-graph-countyfair` repository as its database. Key structures:
+The bot uses `autotick-bot-graph repository as its database. Key structures:
 - `graph.json`: NetworkX dependency graph
 - `node_attrs/`: Package metadata (one JSON per package, sharded paths)
 - `versions/`: Upstream version information
@@ -97,7 +97,7 @@ Pydantic models in `conda_forge_tick/models/` document the schema.
 ### LazyJson System
 
 Data is loaded lazily via `LazyJson` class. Backends configured via `CF_TICK_GRAPH_DATA_BACKENDS`:
-- `file`: Local filesystem (default, requires cf-graph-countyfair clone)
+- `file`: Local filesystem (default, requires autotick-bot-graph clone)
 - `github`: Read-only from GitHub raw URLs (good for debugging)
 - `mongodb`: MongoDB database
 
@@ -137,7 +137,7 @@ Located in `tests_integration/`. Tests the full bot pipeline against real GitHub
 The integration tests require three GitHub entities that mimic production:
 - **Conda-forge org** (`GITHUB_ACCOUNT_CONDA_FORGE_ORG`): Contains test feedstocks
 - **Bot user** (`GITHUB_ACCOUNT_BOT_USER`): Creates forks and PRs
-- **Regro org** (`GITHUB_ACCOUNT_REGRO_ORG`): Contains a test `cf-graph-countyfair` repository
+- **Regro org** (`GITHUB_ACCOUNT_REGRO_ORG`): Contains a test `autotick-bot-graph` repository
 
 Default staging accounts are `conda-forge-bot-staging`, `regro-cf-autotick-bot-staging`, and `regro-staging`. You can use your own accounts by setting environment variables.
 
@@ -217,4 +217,4 @@ Tests run the full bot pipeline in sequence:
 6. `auto-tick`
 7. (repeat migrators and auto-tick for state propagation)
 
-Each step deploys to the staging `cf-graph-countyfair` repo.
+Each step deploys to the staging `autotick-bot-graph` repo.

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ conda-forge-tick --help
 
 For debugging, use the `--debug` flag. This enables debug logging and disables multiprocessing.
 
-Note that the bot expects the [conda-forge dependency graph](https://github.com/regro/cf-graph-countyfair) to be
+Note that the bot expects the [conda-forge dependency graph](https://github.com/conda-forge/autotick-bot-graph) to be
 present in the current working directory by default, unless the `--online` flag is used.
 
 > [!TIP]
@@ -323,23 +323,23 @@ As `conda-forge` grew, the "single job + global data access" model became increa
 
 In this section, we list the collection of jobs that comprise the bot. Each job touches a distinct part of the bot's data structure and is run in parallel with the other jobs. We have also specified the GitHub Actions workflow that runs each job. See those files for further details on which commands are run.
 
-**bot** / `bot-bot.yml`: The main job that runs the bot, making PRs to feedstocks, etc. This job writes data on the PRs it makes to `cf-graph-countyfair/pr_info` and `cf-graph-countyfair/version_pr_info`. It also writes new PR JSON blobs to `cf-graph-countyfair/pr_json` for each PR to track their statuses on GitHub.
+**bot** / `bot-bot.yml`: The main job that runs the bot, making PRs to feedstocks, etc. This job writes data on the PRs it makes to `autotick-bot-graph/pr_info` and `autotick-bot-graph/version_pr_info`. It also writes new PR JSON blobs to `autotick-bot-graph/pr_json` for each PR to track their statuses on GitHub.
 
-**feedstocks** / `bot-feedstocks.yml`: Updates the list of valid and archived feedstocks in `conda-forge` located at `cf-graph-countyfair/all_feedstocks.json`.
+**feedstocks** / `bot-feedstocks.yml`: Updates the list of valid and archived feedstocks in `conda-forge` located at `autotick-bot-graph/all_feedstocks.json`.
 
-**versions** / `bot-versions.yml`: Fetches the latest version for each feedstock in `conda-forge`, writing the data to `cf-graph-countyfair/versions/`.
+**versions** / `bot-versions.yml`: Fetches the latest version for each feedstock in `conda-forge`, writing the data to `autotick-bot-graph/versions/`.
 
-**prs** / `bot-prs.yml`: Fetches the latest PR statuses from GitHub for all of the PRs that bot has made, writing the data to`cf-graph-countyfair/pr_json`.
+**prs** / `bot-prs.yml`: Fetches the latest PR statuses from GitHub for all of the PRs that bot has made, writing the data to`autotick-bot-graph/pr_json`.
 
-**pypi-mapping** / `bot-pypi-mapping.yml`: Builds a mapping of packages between PyPI and `conda-forge`, and a mapping of python imports to packages using the bot's metadata. The PyPI mapping is written to `cf-graph-countyfair/mappings` and the import mapping is written to `cf-graph-countyfair/import_to_pkg_maps`. This job also generates some internal data stored at `cf-graph-countyfair/ranked_hubs_authorities.json`.
+**pypi-mapping** / `bot-pypi-mapping.yml`: Builds a mapping of packages between PyPI and `conda-forge`, and a mapping of python imports to packages using the bot's metadata. The PyPI mapping is written to `autotick-bot-graph/mappings` and the import mapping is written to `autotick-bot-graph/import_to_pkg_maps`. This job also generates some internal data stored at `autotick-bot-graph/ranked_hubs_authorities.json`.
 
-**make-graph** / `bot-make-graph.yml`: Builds the `conda-forge` dependency graph from the feedstocks in `cf-graph-countyfair/all_feedstocks.json`. The graph is written to `cf-graph-countyfair/graph.json` and specific attributes for each node are written to `cf-graph-countyfair/node_attrs`. This job also performs some schema migrations and might add new files to `cf-graph-countyfair/pr_info` and `cf-graph-countyfair/version_pr_info`.
+**make-graph** / `bot-make-graph.yml`: Builds the `conda-forge` dependency graph from the feedstocks in `autotick-bot-graph/all_feedstocks.json`. The graph is written to `autotick-bot-graph/graph.json` and specific attributes for each node are written to `autotick-bot-graph/node_attrs`. This job also performs some schema migrations and might add new files to `autotick-bot-graph/pr_info` and `autotick-bot-graph/version_pr_info`.
 
-**make-migrators** / `bot-make-migrators.yml`: Builds the migrations the bot will run, writing them as JSON to `cf-graph-countyfair/migrators`.
+**make-migrators** / `bot-make-migrators.yml`: Builds the migrations the bot will run, writing them as JSON to `autotick-bot-graph/migrators`.
 
-**update-status-page** / `bot-update-status-page.yml`: Updates the status page at `conda-forge.org/status` with the latest migration information. The status data is written to `cf-graph-countyfair/status`.
+**update-status-page** / `bot-update-status-page.yml`: Updates the status page at `conda-forge.org/status` with the latest migration information. The status data is written to `autotick-bot-graph/status`.
 
-**[NOT CURRENTLY USED] cache** / `bot-cache.yml`: Caches the data in `cf-graph-countyfair` to GitHub Actions.
+**[NOT CURRENTLY USED] cache** / `bot-cache.yml`: Caches the data in `autotick-bot-graph` to GitHub Actions.
 
 **keepalive** / `bot-keepalive.yml`: This job runs every 15 minutes and ensures that the bot is still running. If the bot is not running, it will restart it.
 
@@ -348,16 +348,16 @@ Many of these jobs could be converted to a more event-driven model, especially t
 ### Using the `conda_forge_tick` Module to Interact with the Bot Data
 
 The next few sections provide information about how to use the `conda_forge_tick` package to
-interact with the `cf-graph-countyfair` repo.
+interact with the `autotick-bot-graph` repo.
 
-You will need a copy of `regro/cf-graph-countyfair` and need to be at the root level of the `cf-graph-countyfair` repo
+You will need a copy of `conda-forge/autotick-bot-graph` and need to be at the root level of the `autotick-bot-graph` repo
 for these code snippets to work properly. You can clone the repo with the following command:
 
 ```bash
-git clone --depth=1 https://github.com/regro/cf-graph-countyfair.git
+git clone --depth=1 https://github.com/conda-forge/autotick-bot-graph.git
 ```
 
-The `cf-graph-countyfair` repo also has a [notebook](https://github.com/regro/cf-graph-countyfair/blob/master/example.ipynb) with some code examples.
+The `autotick-bot-graph` repo also has a [notebook](https://github.com/conda-forge/autotick-bot-graph/blob/main/example.ipynb) with some code examples.
 
 #### Loading the graph
 
@@ -405,7 +405,7 @@ See the [run_bot_task.py](docker/run_bot_task.py) script for more information.
 
 ### Data Model
 
-The bot uses the [conda-forge dependency graph](https://github.com/regro/cf-graph-countyfair) to remember metadata
+The bot uses the [conda-forge dependency graph](https://github.com/conda-forge/autotick-bot-graph) to remember metadata
 about feedstocks, their versions, and their dependencies. Some of the information
 (e.g. the contents of `recipe/meta.yaml` file of the corresponding feedstock) is redundant but stored in the
 graph for performance reasons. In an attempt to document the data model, we have created a
@@ -423,9 +423,9 @@ ideal.
 
 The backend(s) can be set by using the `CF_TICK_GRAPH_DATA_BACKENDS` environment variable to a colon-separated list of backends (e.g., `export CF_TICK_GRAPH_DATA_BACKENDS=file:mongodb`). The possible backends are:
 
-- `file` (default): Use the local file system to store data. In order to properly use this backend, you must clone the `regro/cf-graph-countyfair` repository and run the bot from `regro/cf-graph-countyfair`'s root directory. You can use the `deploy` command from the bot CLI to commit any changes and push them to the remote repository.
+- `file` (default): Use the local file system to store data. In order to properly use this backend, you must clone the `conda-forge/autotick-bot-graph` repository and run the bot from `conda-forge/autotick-bot-graph`'s root directory. You can use the `deploy` command from the bot CLI to commit any changes and push them to the remote repository.
 - `mongodb`: Use a MongoDB database to store data. In order to use this backend, you need to set the `MONGODB_CONNECTION_STRING` environment variable to the connection string of the MongoDB database you want to use. **WARNING: The bot will typically read almost all of its data in the backend during its runs, so be careful when using this backend without a pre-cached local copy of the data.**
-- `github`: Read-only backend that uses the `regro/cf-graph-countyfair` repository as a data source. This backend reads data on-the-fly using GitHub's "raw" URLs (e.g, `https://raw.githubusercontent.com/regro/cf-graph-countyfair/master/all_feedstocks.json`). This backend is ideal for debugging when you only want to touch a fraction of the data.
+- `github`: Read-only backend that uses the `conda-forge/autotick-bot-graph` repository as a data source. This backend reads data on-the-fly using GitHub's "raw" URLs (e.g, `https://raw.githubusercontent.com/conda-forge/autotick-bot-graph/main/all_feedstocks.json`). This backend is ideal for debugging when you only want to touch a fraction of the data.
 
 The bot uses the first backend in the list as the primary backend and syncs any changed data to the other backends as needed. The bot will also cache data to disk upon first use to speed up subsequent reads. To turn off this caching, set the `CF_TICK_GRAPH_DATA_USE_FILE_CACHE` environment variable to `false`.
 

--- a/autotick-bot/install_bot_code.sh
+++ b/autotick-bot/install_bot_code.sh
@@ -3,7 +3,7 @@
 # Environment Variables:
 # - CF_FEEDSTOCK_OPS_CONTAINER_NAME: The name of the container image to use for the bot (optional, not used but left intact)
 # - CF_FEEDSTOCK_OPS_CONTAINER_TAG: The tag of the container image to use for the bot (optional).
-# - CF_TICK_GRAPH_GITHUB_BACKEND_REPO: The GitHub repository to clone cf-graph from. Default: regro/cf-graph-countyfair
+# - CF_TICK_GRAPH_GITHUB_BACKEND_REPO: The GitHub repository to clone cf-graph from. Default: conda-forge/autotick-bot-graph
 
 # Sets the following environment variables via GITHUB_ENV:
 # - CF_FEEDSTOCK_OPS_CONTAINER_NAME (see above)
@@ -41,7 +41,7 @@ for arg in "$@"; do
   fi
 done
 if [[ "${clone_graph}" == "true" ]]; then
-  cf_graph_repo=${CF_TICK_GRAPH_GITHUB_BACKEND_REPO:-"regro/cf-graph-countyfair"}
+  cf_graph_repo=${CF_TICK_GRAPH_GITHUB_BACKEND_REPO:-"conda-forge/autotick-bot-graph"}
   cf_graph_remote="https://github.com/${cf_graph_repo}.git"
   # please make sure the cloning depth is always identical to the one used in the integration tests (test_integration.py)
   git clone --depth=5 "${cf_graph_remote}" cf-graph

--- a/conda_forge_tick/models/README.md
+++ b/conda_forge_tick/models/README.md
@@ -6,7 +6,7 @@ Refer to the [main README](../../README.md) for an explanation of what this is a
 
 The most important parts of the graph repository looks like this:
 ```
-cf-graph-countyfair
+autotick-bot-graph
 ├── import_to_pkg_maps
 │   └── ...
 ├── mappings/pypi

--- a/conda_forge_tick/settings.py
+++ b/conda_forge_tick/settings.py
@@ -47,14 +47,14 @@ class BotSettings(BaseSettings):
     """
 
     graph_github_backend_repo: str = Field(
-        "regro/cf-graph-countyfair", pattern=r"^[\w\.-]+/[\w\.-]+$"
+        "conda-forge/autotick-bot-graph", pattern=r"^[\w\.-]+/[\w\.-]+$"
     )
     """
-    The GitHub repository to deploy to. Default: "regro/cf-graph-countyfair".
+    The GitHub repository to deploy to. Default: "conda-forge/autotick-bot-graph".
     If you change the field name, you must also update the `ENV_GRAPH_GITHUB_BACKEND_REPO` constant.
     """
 
-    graph_repo_default_branch: str = "master"
+    graph_repo_default_branch: str = "main"
     """
     The default branch of the graph_github_backend_repo repository.
     """
@@ -63,7 +63,7 @@ class BotSettings(BaseSettings):
     def graph_github_backend_raw_base_url(self) -> str:
         """
         The base URL for the GitHub raw view of the graph_github_backend_repo repository.
-        Example: https://github.com/regro/cf-graph-countyfair/raw/master.
+        Example: https://github.com/conda-forge/autotick-bot-graph/raw/main.
         """
         return f"https://github.com/{self.graph_github_backend_repo}/raw/{self.graph_repo_default_branch}/"
 

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -1808,7 +1808,7 @@ def test_git_utils_push_and_delete_file_via_gh_api():
     node = f"test_file_h{uid}"
     fname = node + ".json"
 
-    repo_name = "regro/cf-graph-countyfair"
+    repo_name = "conda-forge/autotick-bot-graph"
     gh = github_client()
     repo = gh.get_repo(repo_name)
 

--- a/tests/test_lazy_json_backends.py
+++ b/tests/test_lazy_json_backends.py
@@ -942,7 +942,7 @@ def test_lazy_json_backends_github_api():
             assert not backend.hexists("lazy_json", node)
     finally:
         gh = github_client()
-        repo = gh.get_repo("regro/cf-graph-countyfair")
+        repo = gh.get_repo("conda-forge/autotick-bot-graph")
         message = f"remove files {fname} from testing"
         for tr in range(10):
             try:
@@ -972,7 +972,7 @@ def test_lazy_json_backends_github_api_nopush():
     try:
         with lazy_json_override_backends(["github_api"], use_file_cache=False):
             gh = github_client()
-            repo = gh.get_repo("regro/cf-graph-countyfair")
+            repo = gh.get_repo("conda-forge/autotick-bot-graph")
 
             lzj = LazyJson(fname)
             with lzj:

--- a/tests/test_make_migrators.py
+++ b/tests/test_make_migrators.py
@@ -138,13 +138,13 @@ def test_make_migrators_initialize_migrators():
                 "git",
                 "clone",
                 "--depth=1",
-                "https://github.com/regro/cf-graph-countyfair.git",
+                "https://github.com/conda-forge/autotick-bot-graph.git",
             ],
             cwd=tmpdir,
             check=True,
         )
         with (
-            pushd(os.path.join(tmpdir, "cf-graph-countyfair")),
+            pushd(os.path.join(tmpdir, "autotick-bot-graph")),
             lazy_json_override_backends(["file"], use_file_cache=True),
         ):
             gx = load_graph()

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -65,7 +65,7 @@ def test_env_is_protected_against_malicious_recipes(tmpdir, caplog, env_setup):
 
     pmy = populate_feedstock_attributes("blah", {}, in_yaml, None, "{}")
 
-    # This url gets saved in https://github.com/regro/cf-graph-countyfair
+    # This url gets saved in https://github.com/conda-forge/autotick-bot-graph
     pswd = os.environ.get("TEST_BOT_TOKEN_VAL", "unpassword")
     tst_url = f"https://{pswd[0]}/{pswd[1:]}"
     assert pmy["url"][0] != tst_url

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -39,8 +39,8 @@ class TestBotSettings:
         bot_settings = BotSettings()
 
         assert bot_settings.conda_forge_org == "conda-forge"
-        assert bot_settings.graph_github_backend_repo == "regro/cf-graph-countyfair"
-        assert bot_settings.graph_repo_default_branch == "master"
+        assert bot_settings.graph_github_backend_repo == "conda-forge/autotick-bot-graph"
+        assert bot_settings.graph_repo_default_branch == "main"
         assert bot_settings.github_runner_debug is False
         assert 0 <= bot_settings.frac_update_upstream_versions <= 1
         assert 0 <= bot_settings.frac_make_graph <= 1

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -39,7 +39,9 @@ class TestBotSettings:
         bot_settings = BotSettings()
 
         assert bot_settings.conda_forge_org == "conda-forge"
-        assert bot_settings.graph_github_backend_repo == "conda-forge/autotick-bot-graph"
+        assert (
+            bot_settings.graph_github_backend_repo == "conda-forge/autotick-bot-graph"
+        )
         assert bot_settings.graph_repo_default_branch == "main"
         assert bot_settings.github_runner_debug is False
         assert 0 <= bot_settings.frac_update_upstream_versions <= 1

--- a/tests_integration/README.md
+++ b/tests_integration/README.md
@@ -14,7 +14,7 @@ The integration tests operate in a testing environment consisting of three real 
 [regro-cf-autotick-bot](https://github.com/regro-cf-autotick-bot) account and is a test environment in which the bot
 will create forks of the conda-forge-bot-staging repositories
 - [regro-staging](https://github.com/regro-staging) (organization) (named after the [regro](https://github.com/regro)
-account) contains a special version of the [cf-graph-countyfair](https://github.com/regro/cf-graph-countyfair) which
+account) contains a special version of the [autotick-bot-graph](https://github.com/conda-forge/autotick-bot-graph) which
 the bot uses during testing.
 
 ## Test Cases Definition

--- a/tests_integration/lib/_run_test_cases.py
+++ b/tests_integration/lib/_run_test_cases.py
@@ -31,7 +31,7 @@ def reset_cf_graph():
     with resources.as_file(EMPTY_GRAPH_DIR) as empty_graph_dir:
         IntegrationTestHelper().overwrite_github_repository(
             GitHubAccount.REGRO_ORG,
-            "cf-graph-countyfair",
+            "autotick-bot-graph",
             empty_graph_dir,
             branch=settings().graph_repo_default_branch,
         )

--- a/tests_integration/lib/_shared.py
+++ b/tests_integration/lib/_shared.py
@@ -19,7 +19,7 @@ IS_USER_ACCOUNT: dict[GitHubAccount, bool] = {
     GitHubAccount.REGRO_ORG: False,
 }
 
-REGRO_ACCOUNT_REPOS = {"cf-graph-countyfair"}
+REGRO_ACCOUNT_REPOS = {"autotick-bot-graph"}
 
 ENV_GITHUB_RUN_ID = "GITHUB_RUN_ID"
 """
@@ -61,8 +61,8 @@ def get_transparent_urls() -> set[str]:
     # this is not a constant because the graph_repo_default_branch setting is dynamic
     graph_repo_default_branch = settings().graph_repo_default_branch
     transparent_urls = {
-        f"https://raw.githubusercontent.com/regro/cf-graph-countyfair/{graph_repo_default_branch}/mappings/pypi/name_mapping.yaml",
-        f"https://raw.githubusercontent.com/regro/cf-graph-countyfair/{graph_repo_default_branch}/mappings/pypi/grayskull_pypi_mapping.json",
+        f"https://raw.githubusercontent.com/conda-forge/autotick-bot-graph/{graph_repo_default_branch}/mappings/pypi/name_mapping.yaml",
+        f"https://raw.githubusercontent.com/conda-forge/autotick-bot-graph/{graph_repo_default_branch}/mappings/pypi/grayskull_pypi_mapping.json",
         "https://raw.githubusercontent.com/regro/cf-scripts/refs/heads/main/conda_forge_tick/cf_tick_schema.json",
         "https://raw.githubusercontent.com/conda-forge/conda-smithy/refs/heads/main/conda_smithy/data/conda-forge.json",
         "https://api.github.com/*",

--- a/tests_integration/resources/empty-graph/README.md
+++ b/tests_integration/resources/empty-graph/README.md
@@ -1,4 +1,4 @@
-# cf-graph-countyfair (For Integration Tests)
+# autotick-bot-graph (For Integration Tests)
 
 This repository is used in integration tests of [cf-scripts](https://github.com/regro/cf-scripts) to set up a clean initial state for the
-`cf-graph-countyfair` repository.
+`autotick-bot-graph` repository.

--- a/tests_integration/test_integration.py
+++ b/tests_integration/test_integration.py
@@ -65,7 +65,7 @@ def global_environment_setup():
     new_settings.frac_make_graph = 1.0  # do not skip nodes due to randomness
     new_settings.frac_update_upstream_versions = 1.0
     new_settings.graph_github_backend_repo = (
-        f"{GitHubAccount.REGRO_ORG}/cf-graph-countyfair"
+        f"{GitHubAccount.REGRO_ORG}/autotick-bot-graph"
     )
     new_settings.conda_forge_org = GitHubAccount.CONDA_FORGE_ORG
 

--- a/tests_model/test_validate.py
+++ b/tests_model/test_validate.py
@@ -115,7 +115,7 @@ def pytest_generate_tests(metafunc):
     if not packages:
         warnings.warn(
             "No packages found. Make sure these tests are run "
-            "from within the cf-graph-countyfair repository in order to do full "
+            "from within the autotick-bot-graph repository in order to do full "
             "schema validation."
         )
 


### PR DESCRIPTION
<!--
Thanks for contributing to cf-scripts!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

Moving the data repo refs to conda-forge org.

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
