### PR TITLE
Convert preformatted error strings into structured payloads for status report

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gc
 import glob
 import logging
@@ -6,7 +8,7 @@ import textwrap
 import time
 import traceback
 import typing
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Any, Literal, cast
 from urllib.error import URLError
 from uuid import uuid4
@@ -79,22 +81,35 @@ logger = logging.getLogger(__name__)
 TIMEOUT = int(os.environ.get("TIMEOUT", 600))
 
 
-def _set_pre_pr_migrator_error(attrs, migrator_name, error_str, *, is_version):
+def _set_pre_pr_migrator_error(
+    attrs,
+    migrator_name,
+    error_str,
+    *,
+    is_version,
+    error_payload: _BotJobError | None = None,
+):
     if is_version:
         with attrs["version_pr_info"] as vpri:
             version = vpri["new_version"]
-            if "new_version_errors" not in vpri:
-                vpri["new_version_errors"] = {}
-            vpri["new_version_errors"][version] = sanitize_string(error_str)
+            if error_str:
+                vpri.setdefault("new_version_errors", {})[version] = sanitize_string(
+                    error_str
+                )
+            if error_payload:
+                vpri.setdefault("new_version_error_payloads", {})[version] = asdict(
+                    error_payload
+                )
     else:
-        pre_key = "pre_pr_migrator_status"
-
         with attrs["pr_info"] as pri:
-            if pre_key not in pri:
-                pri[pre_key] = {}
-            pri[pre_key][migrator_name] = sanitize_string(
-                error_str,
-            )
+            if error_str:
+                pri.setdefault("pre_pr_migrator_status", {})[migrator_name] = (
+                    sanitize_string(error_str)
+                )
+            if error_payload:
+                pri.setdefault("pre_pr_migrator_status_payload", {})[migrator_name] = (
+                    asdict(error_payload)
+                )
 
 
 def _increment_pre_pr_migrator_attempt(attrs, migrator_name, *, is_version):
@@ -131,6 +146,7 @@ def _reset_version_pre_pr_migrator_fields(vpri, version=None):
         version = vpri["new_version"]
     for _key in [
         "new_version_errors",
+        "new_version_error_payloads",
         "new_version_attempts",
         "new_version_attempt_ts",
     ]:
@@ -141,6 +157,7 @@ def _reset_version_pre_pr_migrator_fields(vpri, version=None):
 def _reset_migrator_pre_pr_migrator_fields(pri, migrator_name):
     for _key in [
         "pre_pr_migrator_status",
+        "pre_pr_migrator_status_payload",
         "pre_pr_migrator_attempts",
         "pre_pr_migrator_attempt_ts",
     ]:
@@ -285,6 +302,27 @@ class _RerenderInfo:
     """
 
 
+@dataclass(frozen=True)
+class _BotJobError:
+    """
+    Details about errors handled by the job and reported to status JSON.
+
+    Messages are sanitized on instantiation
+    """
+
+    kind: Literal["not-solvable", "bot-error"]
+    "Type of error"
+    messages: list[str]
+    "List of error messages, plain text"
+    url: str | None = None
+    "URL pointing to the job that resulted in this error, if any"
+    base_branch: str | None = None
+    "Feedstock branch where the bot is running on, if applicable"
+
+    def __post_init__(self):
+        self.messages[:] = [sanitize_string(msg) for msg in self.messages]
+
+
 def _run_rerender(
     git_cli: GitCli, context: ClonedFeedstockContext, suppress_errors: bool = False
 ) -> _RerenderInfo:
@@ -421,12 +459,17 @@ def _handle_solvability_error(
         </details>
         """,
     ).strip()
-
     _set_pre_pr_migrator_error(
         context.attrs,
         migrator.report_name,
         _solver_err_str,
         is_version=isinstance(migrator, Version),
+        error_payload=_BotJobError(
+            kind="not-solvable",
+            url=ci_url,
+            base_branch=base_branch,
+            messages=sorted(set(errors)),
+        ),
     )
 
     # remove part of a try for solver errors to make those slightly
@@ -890,36 +933,43 @@ def _run_migrator_on_feedstock_branch(
         _set_pre_pr_migrator_error(
             attrs,
             migrator_name,
-            str(
-                e
-            ),  # we do not use any HTML formats here since at one point status page had them
+            # we do not use any HTML formats here since at one point status page had them
+            str(e),
             is_version=is_version,
+            error_payload=_BotJobError(kind="bot-error", messages=[str(e)]),
         )
 
     except URLError as e:
         logger.exception("URLError ERROR", exc_info=e)
+        formatted_traceback = str(traceback.format_exc())
         with attrs["pr_info"] as pri:
             pri["bad"] = {
                 "exception": str(e),
-                "traceback": str(traceback.format_exc()).split(
+                "traceback": formatted_traceback.split(
                     "\n",
                 ),
                 "code": getattr(e, "code"),
                 "url": getattr(e, "url"),
             }
-
+        _job_url = get_bot_run_url()
         _set_pre_pr_migrator_error(
             attrs,
             migrator_name,
             sanitize_string(
                 "bot error (%s): %s: %s"
                 % (
-                    '<a href="' + get_bot_run_url() + '">bot CI job</a>',
+                    '<a href="' + _job_url + '">bot CI job</a>',
                     base_branch,
-                    str(traceback.format_exc()),
+                    formatted_traceback,
                 ),
             ),
             is_version=is_version,
+            error_payload=_BotJobError(
+                kind="bot-error",
+                url=_job_url,
+                base_branch=base_branch,
+                messages=[formatted_traceback],
+            ),
         )
 
     except Exception as e:
@@ -947,19 +997,25 @@ def _run_migrator_on_feedstock_branch(
                         "\n",
                     ),
                 }
-
+        _bot_run_url = get_bot_run_url()
         _set_pre_pr_migrator_error(
             attrs,
             migrator_name,
             sanitize_string(
                 "bot error (%s): %s:\n%s"
                 % (
-                    '<a href="' + get_bot_run_url() + '">bot CI job</a>',
+                    '<a href="' + _bot_run_url + '">bot CI job</a>',
                     base_branch,
                     _err_tb,
                 ),
             ),
             is_version=is_version,
+            error_payload=_BotJobError(
+                kind="bot-error",
+                url=_bot_run_url,
+                base_branch=base_branch,
+                messages=[_err_tb],
+            ),
         )
 
     else:

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import gc
 import glob
-import html
 import logging
 import os
 import textwrap
@@ -85,32 +84,19 @@ TIMEOUT = int(os.environ.get("TIMEOUT", 600))
 def _set_pre_pr_migrator_error(
     attrs,
     migrator_name,
-    error_str,
+    error_payload: _BotJobError,
     *,
     is_version,
-    error_payload: _BotJobError | None = None,
 ):
     if is_version:
         with attrs["version_pr_info"] as vpri:
             version = vpri["new_version"]
-            if error_str:
-                vpri.setdefault("new_version_errors", {})[version] = sanitize_string(
-                    error_str
-                )
-            if error_payload:
-                vpri.setdefault("new_version_error_payloads", {})[version] = asdict(
-                    error_payload
-                )
+            vpri.setdefault("new_version_errors", {})[version] = asdict(error_payload)
     else:
         with attrs["pr_info"] as pri:
-            if error_str:
-                pri.setdefault("pre_pr_migrator_status", {})[migrator_name] = (
-                    sanitize_string(error_str)
-                )
-            if error_payload:
-                pri.setdefault("pre_pr_migrator_status_payload", {})[migrator_name] = (
-                    asdict(error_payload)
-                )
+            pri.setdefault("pre_pr_migrator_status", {})[migrator_name] = asdict(
+                error_payload
+            )
 
 
 def _increment_pre_pr_migrator_attempt(attrs, migrator_name, *, is_version):
@@ -147,7 +133,6 @@ def _reset_version_pre_pr_migrator_fields(vpri, version=None):
         version = vpri["new_version"]
     for _key in [
         "new_version_errors",
-        "new_version_error_payloads",
         "new_version_attempts",
         "new_version_attempt_ts",
     ]:
@@ -158,7 +143,6 @@ def _reset_version_pre_pr_migrator_fields(vpri, version=None):
 def _reset_migrator_pre_pr_migrator_fields(pri, migrator_name):
     for _key in [
         "pre_pr_migrator_status",
-        "pre_pr_migrator_status_payload",
         "pre_pr_migrator_attempts",
         "pre_pr_migrator_attempt_ts",
     ]:
@@ -303,7 +287,7 @@ class _RerenderInfo:
     """
 
 
-@dataclass
+@dataclass(kw_only=True)
 class _BotJobError:
     """
     Details about errors handled by the job and reported to status JSON.
@@ -321,9 +305,9 @@ class _BotJobError:
     "Feedstock branch where the bot is running on, if applicable"
 
     def __post_init__(self):
-        self.messages = [html.escape(sanitize_string(msg)) for msg in self.messages]
+        self.messages = [sanitize_string(msg) for msg in self.messages]
         if self.base_branch:
-            self.base_branch = html.escape(self.base_branch)
+            self.base_branch = sanitize_string(self.base_branch)
 
 
 def _run_rerender(
@@ -450,29 +434,17 @@ def _handle_solvability_error(
 ) -> None:
     ci_url = get_bot_run_url()
     ci_url = f"(<a href='{ci_url}'>bot CI job</a>)" if ci_url else ""
-    _solver_err_str = textwrap.dedent(
-        f"""
-        not solvable {ci_url} @ {base_branch}
-        <details>
-        <div align="left">
-        <pre>
-        {"</pre><pre>".join(sorted(set(errors)))}
-        </pre>
-        </div>
-        </details>
-        """,
-    ).strip()
+
     _set_pre_pr_migrator_error(
         context.attrs,
         migrator.report_name,
-        _solver_err_str,
-        is_version=isinstance(migrator, Version),
-        error_payload=_BotJobError(
+        _BotJobError(
             kind="not-solvable",
             url=ci_url,
             base_branch=base_branch,
             messages=sorted(set(errors)),
         ),
+        is_version=isinstance(migrator, Version),
     )
 
     # remove part of a try for solver errors to make those slightly
@@ -936,10 +908,8 @@ def _run_migrator_on_feedstock_branch(
         _set_pre_pr_migrator_error(
             attrs,
             migrator_name,
-            # we do not use any HTML formats here since at one point status page had them
-            str(e),
+            _BotJobError(kind="bot-error", messages=[str(e)]),
             is_version=is_version,
-            error_payload=_BotJobError(kind="bot-error", messages=[str(e)]),
         )
 
     except URLError as e:
@@ -958,21 +928,13 @@ def _run_migrator_on_feedstock_branch(
         _set_pre_pr_migrator_error(
             attrs,
             migrator_name,
-            sanitize_string(
-                "bot error (%s): %s: %s"
-                % (
-                    '<a href="' + _job_url + '">bot CI job</a>',
-                    base_branch,
-                    formatted_traceback,
-                ),
-            ),
-            is_version=is_version,
-            error_payload=_BotJobError(
+            _BotJobError(
                 kind="bot-error",
                 url=_job_url,
                 base_branch=base_branch,
                 messages=[formatted_traceback],
             ),
+            is_version=is_version,
         )
 
     except Exception as e:
@@ -1004,21 +966,13 @@ def _run_migrator_on_feedstock_branch(
         _set_pre_pr_migrator_error(
             attrs,
             migrator_name,
-            sanitize_string(
-                "bot error (%s): %s:\n%s"
-                % (
-                    '<a href="' + _bot_run_url + '">bot CI job</a>',
-                    base_branch,
-                    _err_tb,
-                ),
-            ),
-            is_version=is_version,
-            error_payload=_BotJobError(
+            _BotJobError(
                 kind="bot-error",
                 url=_bot_run_url,
                 base_branch=base_branch,
                 messages=[_err_tb],
             ),
+            is_version=is_version,
         )
 
     else:

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import gc
 import glob
+import html
 import logging
 import os
 import textwrap
@@ -302,7 +303,7 @@ class _RerenderInfo:
     """
 
 
-@dataclass(frozen=True)
+@dataclass
 class _BotJobError:
     """
     Details about errors handled by the job and reported to status JSON.
@@ -320,7 +321,9 @@ class _BotJobError:
     "Feedstock branch where the bot is running on, if applicable"
 
     def __post_init__(self):
-        self.messages[:] = [sanitize_string(msg) for msg in self.messages]
+        self.messages = [html.escape(sanitize_string(msg)) for msg in self.messages]
+        if self.base_branch:
+            self.base_branch = html.escape(self.base_branch)
 
 
 def _run_rerender(

--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -96,6 +96,7 @@ def make_feedstock_required_lazy_json_refs(name, _in_vpri=None, _in_pri=None):
         for key in [
             "new_version_attempts",
             "new_version_errors",
+            "new_version_error_payloads",
             "new_version_attempt_ts",
         ]:
             if key not in vpri:
@@ -105,6 +106,7 @@ def make_feedstock_required_lazy_json_refs(name, _in_vpri=None, _in_pri=None):
     with lzj_pri as pri:
         for key in [
             "pre_pr_migrator_status",
+            "pre_pr_migrator_status_payload",
             "pre_pr_migrator_attempts",
             "pre_pr_migrator_attempt_ts",
         ]:
@@ -199,7 +201,7 @@ def _migrate_schema(name, sub_graph):
                     )
 
         with sub_graph["version_pr_info"] as vpri:
-            for mn in vpri["new_version_errors"].keys():
+            for mn in vpri["new_version_error_payloads"].keys():
                 if mn not in vpri["new_version_attempts"]:
                     vpri["new_version_attempts"][mn] = 1
                 if mn not in vpri["new_version_attempt_ts"]:

--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -96,7 +96,6 @@ def make_feedstock_required_lazy_json_refs(name, _in_vpri=None, _in_pri=None):
         for key in [
             "new_version_attempts",
             "new_version_errors",
-            "new_version_error_payloads",
             "new_version_attempt_ts",
         ]:
             if key not in vpri:
@@ -106,7 +105,6 @@ def make_feedstock_required_lazy_json_refs(name, _in_vpri=None, _in_pri=None):
     with lzj_pri as pri:
         for key in [
             "pre_pr_migrator_status",
-            "pre_pr_migrator_status_payload",
             "pre_pr_migrator_attempts",
             "pre_pr_migrator_attempt_ts",
         ]:
@@ -201,7 +199,7 @@ def _migrate_schema(name, sub_graph):
                     )
 
         with sub_graph["version_pr_info"] as vpri:
-            for mn in vpri["new_version_error_payloads"].keys():
+            for mn in vpri["new_version_errors"].keys():
                 if mn not in vpri["new_version_attempts"]:
                     vpri["new_version_attempts"][mn] = 1
                 if mn not in vpri["new_version_attempt_ts"]:

--- a/conda_forge_tick/models/pr_info.py
+++ b/conda_forge_tick/models/pr_info.py
@@ -263,6 +263,26 @@ class PrInfoValid(StrictBaseModel):
 
     If a migration is eventually successful, the corresponding key is removed from the dictionary.
     """
+    pre_pr_migrator_status_payload: NoneIsEmptyDict[
+        str, dict[str, str | list[str]]
+    ] = {}
+    """
+    A dictionary (migration name -> error payload) of the error status of the migrations.
+    Errors are added here if a non-version migration fails before a migration PR is created.
+
+    This field contains structured data as the value, precisely to avoid having to send HTML strings.
+    These are meant to be handled by the frontend to target whatever style they see fit. The
+    dataclass backing these values can be found at `conda_forge_tick.auto_tick._BotJobError`.
+
+    The same thing for version migrations is part of the `version_pr_info` object.
+
+    There are implicit assumptions about the contents of this field, but they are not documented.
+    Refer to status_report.graph_migrator_status, for example.
+
+    Note: The names of migrators appear here without spaces and in lowercase. This is not always the case.
+
+    If a migration is eventually successful, the corresponding key is removed from the dictionary.
+    """
 
     pre_pr_migrator_attempts: NoneIsEmptyDict[str, int] = {}
     """
@@ -286,13 +306,23 @@ class PrInfoValid(StrictBaseModel):
 
     @model_validator(mode="after")
     def check_pre_pr_migrations(self) -> Self:
-        if self.pre_pr_migrator_status.keys() != self.pre_pr_migrator_attempts.keys():
+        if (
+            self.pre_pr_migrator_status.keys()
+            != self.pre_pr_migrator_attempts.keys()
+            != self.pre_pr_migrator_status_payload.keys()
+        ):
             raise ValueError(
-                "The keys (migration names) of pre_pr_migrator_status and pre_pr_migrator_attempts must match."
+                "The keys (migration names) of pre_pr_migrator_status, "
+                "pre_pr_migrator_status_payloads and pre_pr_migrator_attempts must match."
             )
-        if self.pre_pr_migrator_status.keys() != self.pre_pr_migrator_attempt_ts.keys():
+        if (
+            self.pre_pr_migrator_status.keys()
+            != self.pre_pr_migrator_attempt_ts.keys()
+            != self.pre_pr_migrator_status_payload.keys()
+        ):
             raise ValueError(
-                "The keys (migration names) of pre_pr_migrator_status and pre_pr_migrator_attempt_ts must match."
+                "The keys (migration names) of pre_pr_migrator_status, "
+                "pre_pr_migrator_status_payloads and pre_pr_migrator_attempt_ts must match."
             )
         return self
 

--- a/conda_forge_tick/models/pr_info.py
+++ b/conda_forge_tick/models/pr_info.py
@@ -248,24 +248,7 @@ class PrInfoValid(StrictBaseModel):
     The Azure token errors should be removed from the graph, e.g. by parsing the model and re-serializing it.
     """
 
-    pre_pr_migrator_status: NoneIsEmptyDict[str, str] = {}
-    """
-    A dictionary (migration name -> error message) of the error status of the migrations.
-    Errors are added here if a non-version migration fails before a migration PR is created.
-    This field can contain HTML tags, which are probably intended for the status page.
-
-    The same thing for version migrations is part of the `version_pr_info` object.
-
-    There are implicit assumptions about the contents of this field, but they are not documented.
-    Refer to status_report.graph_migrator_status, for example.
-
-    Note: The names of migrators appear here without spaces and in lowercase. This is not always the case.
-
-    If a migration is eventually successful, the corresponding key is removed from the dictionary.
-    """
-    pre_pr_migrator_status_payload: NoneIsEmptyDict[
-        str, dict[str, str | list[str]]
-    ] = {}
+    pre_pr_migrator_status: NoneIsEmptyDict[str, dict[str, str | list[str]]] = {}
     """
     A dictionary (migration name -> error payload) of the error status of the migrations.
     Errors are added here if a non-version migration fails before a migration PR is created.
@@ -273,6 +256,7 @@ class PrInfoValid(StrictBaseModel):
     This field contains structured data as the value, precisely to avoid having to send HTML strings.
     These are meant to be handled by the frontend to target whatever style they see fit. The
     dataclass backing these values can be found at `conda_forge_tick.auto_tick._BotJobError`.
+    Previous iterations of the schema only included a preformatted string.
 
     The same thing for version migrations is part of the `version_pr_info` object.
 
@@ -306,23 +290,13 @@ class PrInfoValid(StrictBaseModel):
 
     @model_validator(mode="after")
     def check_pre_pr_migrations(self) -> Self:
-        if (
-            self.pre_pr_migrator_status.keys()
-            != self.pre_pr_migrator_attempts.keys()
-            != self.pre_pr_migrator_status_payload.keys()
-        ):
+        if self.pre_pr_migrator_status.keys() != self.pre_pr_migrator_attempts.keys():
             raise ValueError(
-                "The keys (migration names) of pre_pr_migrator_status, "
-                "pre_pr_migrator_status_payloads and pre_pr_migrator_attempts must match."
+                "The keys (migration names) of pre_pr_migrator_status and pre_pr_migrator_attempts must match."
             )
-        if (
-            self.pre_pr_migrator_status.keys()
-            != self.pre_pr_migrator_attempt_ts.keys()
-            != self.pre_pr_migrator_status_payload.keys()
-        ):
+        if self.pre_pr_migrator_status.keys() != self.pre_pr_migrator_attempt_ts.keys():
             raise ValueError(
-                "The keys (migration names) of pre_pr_migrator_status, "
-                "pre_pr_migrator_status_payloads and pre_pr_migrator_attempt_ts must match."
+                "The keys (migration names) of pre_pr_migrator_status and pre_pr_migrator_attempt_ts must match."
             )
         return self
 

--- a/conda_forge_tick/models/version_pr_info.py
+++ b/conda_forge_tick/models/version_pr_info.py
@@ -36,26 +36,40 @@ class VersionPrInfo(StrictBaseModel):
     PR.
     """
 
+    new_version_error_payloads: NoneIsEmptyDict[str, dict[str, str | list[str]]] = {}
+    """
+    Mapping (version -> error payload) to describe the errors that occurred when trying to update the versions in the
+    PR. The error payload is backed up by the `conda_forge_tick.auto_tick._BotJobError` dataclass.
+    """
+
     @model_validator(mode="after")
     def check_new_version_error_keys(self):
         wrong_versions = [
             version
-            for version in self.new_version_errors
+            for version in (
+                *self.new_version_errors,
+                *self.self.new_version_error_payloads,
+            )
             if version not in self.new_version_attempts
         ]
 
         if wrong_versions:
             raise ValueError(
-                f"new_version_errors contains at least one version not in new_version_attempts: {wrong_versions}"
+                "new_version_errors or new_version_error_payloads contains "
+                f"at least one version not in new_version_attempts: {wrong_versions}"
             )
 
         wrong_versions = [
             version
-            for version in self.new_version_errors
+            for version in (
+                *self.new_version_errors,
+                *self.self.new_version_error_payloads,
+            )
             if version not in self.new_version_attempt_ts
         ]
 
         if wrong_versions:
             raise ValueError(
-                f"new_version_errors contains at least one version not in new_version_attempt_ts: {wrong_versions}"
+                "new_version_errors or new_version_error_payloads contains "
+                f"at least one version not in new_version_attempt_ts: {wrong_versions}"
             )

--- a/conda_forge_tick/models/version_pr_info.py
+++ b/conda_forge_tick/models/version_pr_info.py
@@ -30,46 +30,34 @@ class VersionPrInfo(StrictBaseModel):
     attempt to make the version PR.
     """
 
-    new_version_errors: NoneIsEmptyDict[str, str] = {}
-    """
-    Mapping (version -> error message) to describe the errors that occurred when trying to update the versions in the
-    PR.
-    """
-
-    new_version_error_payloads: NoneIsEmptyDict[str, dict[str, str | list[str]]] = {}
+    new_version_errors: NoneIsEmptyDict[str, dict[str, str | list[str]]] = {}
     """
     Mapping (version -> error payload) to describe the errors that occurred when trying to update the versions in the
     PR. The error payload is backed up by the `conda_forge_tick.auto_tick._BotJobError` dataclass.
+
+    Previous iterations of the model only included a preformatted string with the error details.
     """
 
     @model_validator(mode="after")
     def check_new_version_error_keys(self):
         wrong_versions = [
             version
-            for version in (
-                *self.new_version_errors,
-                *self.self.new_version_error_payloads,
-            )
+            for version in self.new_version_errors
             if version not in self.new_version_attempts
         ]
 
         if wrong_versions:
             raise ValueError(
-                "new_version_errors or new_version_error_payloads contains "
-                f"at least one version not in new_version_attempts: {wrong_versions}"
+                f"new_version_errors contains at least one version not in new_version_attempts: {wrong_versions}"
             )
 
         wrong_versions = [
             version
-            for version in (
-                *self.new_version_errors,
-                *self.self.new_version_error_payloads,
-            )
+            for version in self.new_version_errors
             if version not in self.new_version_attempt_ts
         ]
 
         if wrong_versions:
             raise ValueError(
-                "new_version_errors or new_version_error_payloads contains "
-                f"at least one version not in new_version_attempt_ts: {wrong_versions}"
+                f"new_version_errors contains at least one version not in new_version_attempt_ts: {wrong_versions}"
             )

--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -141,19 +141,26 @@ def write_version_migrator_status(migrator, mctx):
                     if attempts == 0:
                         out["queued"][node] = new_version  # type: ignore[assignment]
                     else:
+                        previous_payload = vpri.get("new_version_errors", {}).get(
+                            new_version,
+                            {
+                                # Follows schema in .autotick._BotJobError
+                                "kind": "bot-error",
+                                "messages": [
+                                    f"No error information available for version '{new_version}'"
+                                ],
+                            },
+                        )
+                        # FUTURE: Remove once all JSON documents have migrated from str to dict
+                        if isinstance(previous_payload, str):
+                            previous_payload = {
+                                "kind": "plain",
+                                "messages": [previous_payload],
+                            }
                         out["errors"][node] = {
-                            "attempts": attempts,
                             # type: ignore
-                            **vpri.get("new_version_errors", {}).get(
-                                new_version,
-                                {
-                                    # Follows schema in .autotick._BotJobError
-                                    "kind": "bot-error",
-                                    "messages": [
-                                        f"No error information available for version '{new_version}'"
-                                    ],
-                                },
-                            ),
+                            **previous_payload,
+                            "attempts": attempts,
                         }
 
     with open("./status/version_status.v2.json", "wb") as f:

--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -83,9 +83,10 @@ def _ok_version(ver):
 
 def write_version_migrator_status(migrator, mctx):
     """Write the status of the version migrator."""
-    out: dict[str, dict[str, str]] = {
+    out: dict[str, dict[str, str | list[str]]] = {
         "queued": {},  # name -> pending version
         "errors": {},  # name -> error
+        "error_payloads": {},  # name -> structured data about errors
     }
 
     gx = mctx.graph
@@ -149,10 +150,24 @@ def write_version_migrator_status(migrator, mctx):
                             "No error information available for version '%s'."
                             % new_version,
                         )
+                        out["error_payloads"][node] = {
+                            "attempts": attempts,
+                            # type: ignore
+                            **vpri.get("new_version_error_payloads", {}).get(
+                                new_version,
+                                {
+                                    # Follows schema in .autotick._BotJobError
+                                    "kind": "bot-error",
+                                    "messages": [
+                                        f"No error information available for version '{new_version}'"
+                                    ],
+                                },
+                            ),
+                        }
 
     with open("./status/version_status.json", "wb") as f:
-        old_out: dict[str, dict[str, str] | set[str]] = {}
-        old_out.update(out)
+        old_out: dict[str, dict[str, str | list[str]] | set[str]] = {}
+        old_out.update({k: v for k, v in out.items() if k != "error_payloads"})
         old_out["queued"] = set(out["queued"].keys())
         old_out["errored"] = set(out["errors"].keys())
         f.write(
@@ -166,7 +181,16 @@ def write_version_migrator_status(migrator, mctx):
     with open("./status/version_status.v2.json", "wb") as f:
         f.write(
             orjson.dumps(
-                out,
+                {k: v for k, v in out.items() if k != "error_payloads"},
+                option=orjson.OPT_SORT_KEYS | orjson.OPT_INDENT_2,
+                default=_sorted_set_json,
+            )
+        )
+
+    with open("./status/version_status.v3.json", "wb") as f:
+        f.write(
+            orjson.dumps(
+                {k: v for k, v in out.items() if k != "errors"},
                 option=orjson.OPT_SORT_KEYS | orjson.OPT_INDENT_2,
                 default=_sorted_set_json,
             )
@@ -262,19 +286,17 @@ def graph_migrator_status(
             fc = "#440154"
             fntc = "white"
         elif pr_json is None:
+            kind = (
+                attrs.get("pr_info", {})
+                .get("pre_pr_migrator_status_payload", {})
+                .get(migrator_name, {})
+                .get("kind")
+            )
             if buildable:
-                if "not solvable" in (
-                    attrs.get("pr_info", {})
-                    .get("pre_pr_migrator_status", {})
-                    .get(migrator_name, "")
-                ):
+                if kind == "not-solvable":
                     out["not-solvable"].add(node)
                     fc = "#ff8c00"
-                elif "bot error" in (
-                    attrs.get("pr_info", {})
-                    .get("pre_pr_migrator_status", {})
-                    .get(migrator_name, "")
-                ) or attrs.get("parsing_error", ""):
+                elif kind == "bot-error" or attrs.get("parsing_error", ""):
                     out["bot-error"].add(node)
                     fc = "#000000"
                     fntc = "white"
@@ -282,11 +304,7 @@ def graph_migrator_status(
                     out["awaiting-pr"].add(node)
                     fc = "#35b779"
             else:
-                if "bot error" in (
-                    attrs.get("pr_info", {})
-                    .get("pre_pr_migrator_status", {})
-                    .get(migrator_name, "")
-                ) or attrs.get("parsing_error", ""):
+                if kind == "bot-error" or attrs.get("parsing_error", ""):
                     out["bot-error"].add(node)
                     fc = "#000000"
                     fntc = "white"
@@ -342,8 +360,17 @@ def graph_migrator_status(
                 )
                 .get(migrator_name, "")
             ) or attrs.get("parsing_error", "")
+            node_metadata["pre_pr_migrator_status_payload"] = (
+                attrs.get("pr_info", {})
+                .get(
+                    "pre_pr_migrator_status_payload",
+                    {},
+                )
+                .get(migrator_name, {})
+            ) or {"kind": "bot-error", "messages": [attrs.get("parsing_error", "")]}
         else:
             node_metadata["pre_pr_migrator_status"] = ""
+            node_metadata["pre_pr_migrator_status_payload"] = {}
 
         if pr_json and "PR" in pr_json:
             # I needed to fake some PRs they don't have html_urls though

--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -334,7 +334,7 @@ def graph_migrator_status(
             if not gx2[k].get("payload", {}).get("archived", False)
         ]
         if node in out["not-solvable"] or node in out["bot-error"]:
-            node_metadata["pre_pr_migrator_status"] = (
+            previous_status = (
                 attrs.get("pr_info", {})
                 .get(
                     "pre_pr_migrator_status",
@@ -342,6 +342,10 @@ def graph_migrator_status(
                 )
                 .get(migrator_name, {})
             ) or {"kind": "bot-error", "messages": [attrs.get("parsing_error", "")]}
+            # FUTURE: Remove once all JSON documents have migrated from str to dict
+            if isinstance(previous_status, str):
+                previous_status = {"kind": "plain", "messages": [previous_status]}
+            node_metadata["pre_pr_migrator_status"] = previous_status
         else:
             node_metadata["pre_pr_migrator_status"] = {}
 

--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -85,8 +85,7 @@ def write_version_migrator_status(migrator, mctx):
     """Write the status of the version migrator."""
     out: dict[str, dict[str, str | list[str]]] = {
         "queued": {},  # name -> pending version
-        "errors": {},  # name -> error
-        "error_payloads": {},  # name -> structured data about errors
+        "errors": {},  # name -> structured data about errors
     }
 
     gx = mctx.graph
@@ -142,18 +141,10 @@ def write_version_migrator_status(migrator, mctx):
                     if attempts == 0:
                         out["queued"][node] = new_version  # type: ignore[assignment]
                     else:
-                        out["errors"][node] = f"{attempts:.2f} attempts - " + vpri.get(
-                            "new_version_errors",
-                            {},
-                        ).get(
-                            new_version,
-                            "No error information available for version '%s'."
-                            % new_version,
-                        )
-                        out["error_payloads"][node] = {
+                        out["errors"][node] = {
                             "attempts": attempts,
                             # type: ignore
-                            **vpri.get("new_version_error_payloads", {}).get(
+                            **vpri.get("new_version_errors", {}).get(
                                 new_version,
                                 {
                                     # Follows schema in .autotick._BotJobError
@@ -165,32 +156,10 @@ def write_version_migrator_status(migrator, mctx):
                             ),
                         }
 
-    with open("./status/version_status.json", "wb") as f:
-        old_out: dict[str, dict[str, str | list[str]] | set[str]] = {}
-        old_out.update({k: v for k, v in out.items() if k != "error_payloads"})
-        old_out["queued"] = set(out["queued"].keys())
-        old_out["errored"] = set(out["errors"].keys())
-        f.write(
-            orjson.dumps(
-                old_out,
-                option=orjson.OPT_SORT_KEYS | orjson.OPT_INDENT_2,
-                default=_sorted_set_json,
-            )
-        )
-
     with open("./status/version_status.v2.json", "wb") as f:
         f.write(
             orjson.dumps(
-                {k: v for k, v in out.items() if k != "error_payloads"},
-                option=orjson.OPT_SORT_KEYS | orjson.OPT_INDENT_2,
-                default=_sorted_set_json,
-            )
-        )
-
-    with open("./status/version_status.v3.json", "wb") as f:
-        f.write(
-            orjson.dumps(
-                {k: v for k, v in out.items() if k != "errors"},
+                out,
                 option=orjson.OPT_SORT_KEYS | orjson.OPT_INDENT_2,
                 default=_sorted_set_json,
             )
@@ -286,12 +255,18 @@ def graph_migrator_status(
             fc = "#440154"
             fntc = "white"
         elif pr_json is None:
-            kind = (
-                attrs.get("pr_info", {})
-                .get("pre_pr_migrator_status_payload", {})
-                .get(migrator_name, {})
-                .get("kind")
-            )
+            pre_pr_migrator_status = (
+                attrs.get("pr_info", {}).get("pre_pr_migrator_status", {})
+            ).get(migrator_name, {})
+            if isinstance(pre_pr_migrator_status, str):
+                if "not solvable" in pre_pr_migrator_status:
+                    kind = "not-solvable"
+                elif "bot error" in pre_pr_migrator_status:
+                    kind = "bot-error"
+                else:
+                    kind = None
+            else:
+                kind = pre_pr_migrator_status.get("kind")
             if buildable:
                 if kind == "not-solvable":
                     out["not-solvable"].add(node)
@@ -358,19 +333,10 @@ def graph_migrator_status(
                     "pre_pr_migrator_status",
                     {},
                 )
-                .get(migrator_name, "")
-            ) or attrs.get("parsing_error", "")
-            node_metadata["pre_pr_migrator_status_payload"] = (
-                attrs.get("pr_info", {})
-                .get(
-                    "pre_pr_migrator_status_payload",
-                    {},
-                )
                 .get(migrator_name, {})
             ) or {"kind": "bot-error", "messages": [attrs.get("parsing_error", "")]}
         else:
-            node_metadata["pre_pr_migrator_status"] = ""
-            node_metadata["pre_pr_migrator_status_payload"] = {}
+            node_metadata["pre_pr_migrator_status"] = {}
 
         if pr_json and "PR" in pr_json:
             # I needed to fake some PRs they don't have html_urls though

--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -38,6 +38,7 @@ from conda_forge_tick.utils import (
     frozen_to_json_friendly,
     load_existing_graph,
     pr_can_be_archived,
+    sanitize_string,
 )
 from conda_forge_tick.version_filters import filter_version
 
@@ -155,7 +156,7 @@ def write_version_migrator_status(migrator, mctx):
                         if isinstance(previous_payload, str):
                             previous_payload = {
                                 "kind": "plain",
-                                "messages": [previous_payload],
+                                "messages": [sanitize_string(previous_payload)],
                             }
                         out["errors"][node] = {
                             # type: ignore
@@ -344,7 +345,10 @@ def graph_migrator_status(
             ) or {"kind": "bot-error", "messages": [attrs.get("parsing_error", "")]}
             # FUTURE: Remove once all JSON documents have migrated from str to dict
             if isinstance(previous_status, str):
-                previous_status = {"kind": "plain", "messages": [previous_status]}
+                previous_status = {
+                    "kind": "plain",
+                    "messages": [sanitize_string(previous_status)],
+                }
             node_metadata["pre_pr_migrator_status"] = previous_status
         else:
             node_metadata["pre_pr_migrator_status"] = {}

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -1,6 +1,7 @@
 import contextlib
 import copy
 import datetime
+import html
 import io
 import itertools
 import logging
@@ -1416,6 +1417,7 @@ def as_iterable(iterable_or_scalar: Any) -> Iterable:
 
 
 def sanitize_string(instr: str) -> str:
+    """Masks secrets/tokens and escapes HTML."""
     from conda_forge_tick.env_management import SensitiveEnv
 
     with sensitive_env() as env:
@@ -1425,7 +1427,7 @@ def sanitize_string(instr: str) -> str:
         if token is not None:
             instr = instr.replace(token, "~" * len(token))
 
-    return instr
+    return html.escape(instr)
 
 
 def get_keys_default(


### PR DESCRIPTION

<!--
Thanks for contributing to conda-forge-bot!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR introduces new fields that supersede their value-is-a-string counterparts with structured payloads. This way we can avoid pre-formatting the error strings and let the frontend handle it. Namely:

- In `conda-forge-bot-data/status/version_status.v2.json`, `errors` points now to dictionaries containing details like `kind`, `url`, `base_branch` and `messages` (one or more plain strings).
- In `conda-forge-bot-data/status/migration_json/*.json`, `_feedstock_status.[].pre_pr_migrator_status` is now the same type of dictionary, plus an optional `attempts` float.

#### Checklist:

- [X] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
- https://github.com/conda-forge/conda-forge-bot/issues/6218
