### PR TITLE
add excluded_dependencies for win-arm64 migrator

### DIFF
--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -39,7 +39,8 @@ def _filter_excluded_deps(graph, excluded_dependencies):
     """
     nodes_to_remove = set(excluded_dependencies)
     for excluded_dep in excluded_dependencies:
-        nodes_to_remove |= set(nx.descendants(graph, excluded_dep))
+        if excluded_dep in graph.nodes:
+            nodes_to_remove |= set(nx.descendants(graph, excluded_dep))
     for node in nodes_to_remove:
         pluck(graph, node)
     # post-plucking cleanup

--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -437,6 +437,7 @@ class WinArm64(_CrossCompileRebuild):
     build_platform = {"win_arm64": "win_64"}
     pkg_list_filename = "win_arm64.txt"
     arches = {"win_arm64": "win_64"}
+    excluded_dependencies = {"r-languageserver"}
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("name", "support windows arm64 platform")


### PR DESCRIPTION
For the win-arm64 [migrator](https://conda-forge.org/status/migration/?name=supportwindowsarm64platform), a lot of R packages are included, because the bot sees that `ci-setup` depends on `r-languageserver`. Filter out that package so we can get rid of a bunch of dependencies in the graph that we don't need to bootstrap the build tools.

