### PR TITLE
Add an XFAIL-ing test case for `pyobjc-framework-quartz`

### DIFF
--- a/tests/test_v1_yaml/version_pyobjc.yaml
+++ b/tests/test_v1_yaml/version_pyobjc.yaml
@@ -1,0 +1,70 @@
+schema_version: 1
+
+context:
+  name: pyobjc-framework-Quartz
+  version: "12.2"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/source/${{ name[0] }}/${{ name }}/pyobjc_framework_quartz-${{ version }}.tar.gz
+  sha256: b343395d4790323b0376fe20c83ac468510ba19f65429323ca211708c939d107
+
+build:
+  number: 0
+  script:
+    # force pyobjc to use conda-forge's chosen SDK
+    - export CFLAGS="${CFLAGS} -isysroot ${SDKROOT:-$CONDA_BUILD_SYSROOT}"
+    # force ignoring invalid compiler flag (-Wl,-export-dynamic)
+    - export CFLAGS="${CFLAGS} -Wno-unused-command-line-argument"
+    - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: (not osx) or match(python, ">=2,<3") or python_impl == 'pypy' or (arm64 and match(python, "<3.9"))
+
+requirements:
+  build:
+    - ${{ compiler("c") }}
+    - ${{ stdlib("c") }}
+    - if: build_platform != target_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+  host:
+    - pip
+    - python
+    - setuptools
+    - wheel
+  run:
+    - python
+    - pyobjc-core >=${{ version }}
+    - pyobjc-framework-cocoa >=${{ version }}
+
+tests:
+  - python:
+      pip_check: true
+      imports:
+        - Quartz
+        - Quartz.CoreGraphics
+        - Quartz.CoreVideo
+        - Quartz.ImageIO
+        - Quartz.ImageKit
+        - Quartz.PDFKit
+        - Quartz.QuartzComposer
+        - Quartz.QuartzCore
+        - Quartz.QuartzFilters
+        - Quartz.QuickLookUI
+
+about:
+  license: MIT
+  license_file: LICENSE.txt
+  summary: Wrappers for the Quartz frameworks on Mac OS X
+  homepage: https://github.com/ronaldoussoren/pyobjc
+  repository: https://github.com/ronaldoussoren/pyobjc/tree/master/pyobjc-framework-Quartz
+  documentation: https://pyobjc.readthedocs.io/en/latest/
+
+extra:
+  recipe-maintainers:
+    - jschueller
+    - hhslepicka
+    - thewchan

--- a/tests/test_v1_yaml/version_pyobjc_correct.yaml
+++ b/tests/test_v1_yaml/version_pyobjc_correct.yaml
@@ -1,0 +1,70 @@
+schema_version: 1
+
+context:
+  name: pyobjc-framework-Quartz
+  version: "12.2.1"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/source/${{ name[0] }}/${{ name }}/pyobjc_framework_quartz-${{ version }}.tar.gz
+  sha256: b3b8b6f71e66147f8ff9e6213864cc8527e3a0b1ee90835b93ce221f4802d9b0
+
+build:
+  number: 0
+  script:
+    # force pyobjc to use conda-forge's chosen SDK
+    - export CFLAGS="${CFLAGS} -isysroot ${SDKROOT:-$CONDA_BUILD_SYSROOT}"
+    # force ignoring invalid compiler flag (-Wl,-export-dynamic)
+    - export CFLAGS="${CFLAGS} -Wno-unused-command-line-argument"
+    - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: (not osx) or match(python, ">=2,<3") or python_impl == 'pypy' or (arm64 and match(python, "<3.9"))
+
+requirements:
+  build:
+    - ${{ compiler("c") }}
+    - ${{ stdlib("c") }}
+    - if: build_platform != target_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+  host:
+    - pip
+    - python
+    - setuptools
+    - wheel
+  run:
+    - python
+    - pyobjc-core >=${{ version }}
+    - pyobjc-framework-cocoa >=${{ version }}
+
+tests:
+  - python:
+      pip_check: true
+      imports:
+        - Quartz
+        - Quartz.CoreGraphics
+        - Quartz.CoreVideo
+        - Quartz.ImageIO
+        - Quartz.ImageKit
+        - Quartz.PDFKit
+        - Quartz.QuartzComposer
+        - Quartz.QuartzCore
+        - Quartz.QuartzFilters
+        - Quartz.QuickLookUI
+
+about:
+  license: MIT
+  license_file: LICENSE.txt
+  summary: Wrappers for the Quartz frameworks on Mac OS X
+  homepage: https://github.com/ronaldoussoren/pyobjc
+  repository: https://github.com/ronaldoussoren/pyobjc/tree/master/pyobjc-framework-Quartz
+  documentation: https://pyobjc.readthedocs.io/en/latest/
+
+extra:
+  recipe-maintainers:
+    - jschueller
+    - hhslepicka
+    - thewchan

--- a/tests/test_version_migrator.py
+++ b/tests/test_version_migrator.py
@@ -136,6 +136,13 @@ def test_version_up(case, new_ver, tmp_path, caplog):
         ),
         ("polars", "1.20.0"),
         ("svcore", "0.2025.40"),
+        pytest.param(
+            "pyobjc",
+            "12.2.1",
+            marks=pytest.mark.xfail(
+                reason="https://github.com/conda-forge/conda-forge-bot/issues/6272"
+            ),
+        ),
     ],
 )
 def test_version_up_v1(case, new_ver, tmp_path, caplog):


### PR DESCRIPTION
<!--
Thanks for contributing to conda-forge-bot!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

Add a `pyobjc-framework-quartz` per the failures in https://github.com/conda-forge/conda-forge-bot/issues/6272.  It is failing due to the render happening with `linux-64`.  The test also fails due to the `match(python, ...)` skip but that might be just a harness problem.

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

#6272