### PR TITLE
Add LinuxRISCV64 migrator for linux-riscv64 cross-compile support

### DIFF
--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -74,7 +74,7 @@ from conda_forge_tick.migrators import (
     YAMLRoundTrip,
     make_from_lazy_json_data,
 )
-from conda_forge_tick.migrators.arch import OSXArm, WinArm64
+from conda_forge_tick.migrators.arch import LinuxRISCV64, OSXArm, WinArm64
 from conda_forge_tick.migrators.migration_yaml import MigrationYamlCreator
 from conda_forge_tick.migrators_types import BuildRunExportsDict, PackageName
 from conda_forge_tick.os_utils import pushd
@@ -282,6 +282,25 @@ def add_arch_migrate(migrators: MutableSequence[Migrator], gx: nx.DiGraph) -> No
                     UpdateCMakeArgsWinMigrator(),
                     GuardTestingWinMigrator(),
                     CrossRBaseWinMigrator(),
+                    CrossPythonMigrator(),
+                    NoCondaInspectMigrator(),
+                    MPIPinRunAsBuildCleanup(),
+                    CombineV1ConditionsMigrator(),
+                ],
+            ),
+        )
+
+    with fold_log_lines("making linux-riscv64 migrator"):
+        migrators.append(
+            LinuxRISCV64(
+                total_graph=gx,
+                pr_limit=PR_LIMIT,
+                piggy_back_migrations=[
+                    UpdateConfigSubGuessMigrator(),
+                    CondaForgeYAMLCleanup(),
+                    UpdateCMakeArgsMigrator(),
+                    GuardTestingMigrator(),
+                    CrossRBaseMigrator(),
                     CrossPythonMigrator(),
                     NoCondaInspectMigrator(),
                     MPIPinRunAsBuildCleanup(),

--- a/conda_forge_tick/migrators/__init__.py
+++ b/conda_forge_tick/migrators/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-from .arch import ArchRebuild, OSXArm, WinArm64
+from .arch import ArchRebuild, LinuxRISCV64, OSXArm, WinArm64
 from .broken_rebuild import RebuildBroken
 from .conda_forge_yaml_cleanup import CondaForgeYAMLCleanup
 from .core import (

--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -470,3 +470,44 @@ class WinArm64(_CrossCompileRebuild):
 
     def remote_branch(self, feedstock_ctx: FeedstockContext) -> str:
         return super().remote_branch(feedstock_ctx) + "_arm64_win"
+
+
+class LinuxRISCV64(_CrossCompileRebuild):
+    """A Migrator that adds linux-riscv64 builds to feedstocks."""
+
+    allowed_schema_versions = {0, 1}
+    migrator_version = 1
+    build_platform = {"linux_riscv64": "linux_64"}
+    pkg_list_filename = "linux_riscv64.txt"
+    arches = {"linux_riscv64": "linux_64"}
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("name", "support linux riscv64 platform")
+        super().__init__(*args, **kwargs)
+
+    def pr_title(self, feedstock_ctx: FeedstockContext) -> str:
+        title = "Support linux-riscv64 platform"
+        branch = feedstock_ctx.attrs.get("branch", "main")
+        if branch not in ["main", "master"]:
+            return f"[{branch}] " + title
+        else:
+            return title
+
+    def pr_body(
+        self, feedstock_ctx: ClonedFeedstockContext, add_label_text: bool = True
+    ) -> str:
+        body = super().pr_body(feedstock_ctx)
+        body = body.format(
+            dedent(
+                """\
+        This feedstock is being rebuilt as part of the linux riscv64 migration.
+
+        **Feel free to merge the PR if CI is all green, but please don't close it
+        without reaching out the the linux-riscv64 team first at <code>@</code>conda-forge/help-linux-riscv64.**
+        """,
+            ),
+        )
+        return body
+
+    def remote_branch(self, feedstock_ctx: FeedstockContext) -> str:
+        return super().remote_branch(feedstock_ctx) + "_riscv64"

--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -500,11 +500,11 @@ class LinuxRISCV64(_CrossCompileRebuild):
         body = body.format(
             dedent(
                 """\
-        This feedstock is being rebuilt as part of the linux riscv64 migration.
+                This feedstock is being rebuilt as part of the linux riscv64 migration.
 
-        **Feel free to merge the PR if CI is all green, but please don't close it
-        without reaching out the the linux-riscv64 team first at <code>@</code>conda-forge/help-riscv64.**
-        """,
+                **Feel free to merge the PR if CI is all green, but please don't close it
+                without reaching out the the linux-riscv64 team first at <code>@</code>conda-forge/help-riscv64.**
+                """,
             ),
         )
         return body

--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -503,7 +503,7 @@ class LinuxRISCV64(_CrossCompileRebuild):
         This feedstock is being rebuilt as part of the linux riscv64 migration.
 
         **Feel free to merge the PR if CI is all green, but please don't close it
-        without reaching out the the linux-riscv64 team first at <code>@</code>conda-forge/help-linux-riscv64.**
+        without reaching out the the linux-riscv64 team first at <code>@</code>conda-forge/help-riscv64.**
         """,
             ),
         )

--- a/conda_forge_tick/models/pr_info.py
+++ b/conda_forge_tick/models/pr_info.py
@@ -51,6 +51,7 @@ class MigratorName(StrEnum):
     ARCH_REBUILD = "ArchRebuild"
     OSX_ARM = "OSXArm"
     WIN_ARM64 = "WinArm64"
+    LINUX_RISCV64 = "LinuxRISCV64"
     MIGRATION_YAML = "MigrationYaml"
     REBUILD = "Rebuild"
     BLAS_REBUILD = "BlasRebuild"

--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -23,6 +23,7 @@ from conda_forge_tick.make_migrators import load_migrators
 from conda_forge_tick.migrators import (
     ArchRebuild,
     GraphMigrator,
+    LinuxRISCV64,
     MatplotlibBase,
     MigrationYamlCreator,
     Migrator,
@@ -516,6 +517,7 @@ def main(migrator_filter: str | list[str] | None = None) -> None:
                     or isinstance(migrator, ArchRebuild)
                     or isinstance(migrator, OSXArm)
                     or isinstance(migrator, WinArm64)
+                    or isinstance(migrator, LinuxRISCV64)
                 ):
                     longterm_status[migrator_name] = f"{migrator.name} Migration Status"
                 else:

--- a/tests/test_migrator_to_json.py
+++ b/tests/test_migrator_to_json.py
@@ -303,6 +303,33 @@ def test_migrator_to_json_win_arm64():
     assert dumps(migrator2.to_lazy_json_data()) == lzj_data
 
 
+def test_migrator_to_json_riscv64():
+    gx = nx.DiGraph()
+    gx.add_node("conda", reqs=["python"], payload={}, blah="foo")
+    gx.graph["outputs_lut"] = {}
+
+    migrator = conda_forge_tick.migrators.LinuxRISCV64(
+        target_packages=["python"],
+        total_graph=gx,
+        pr_limit=5,
+    )
+
+    data = migrator.to_lazy_json_data()
+    pprint.pprint(data)
+    lzj_data = dumps(data)
+    print("lazy json data:\n", lzj_data)
+    assert data["__migrator__"] is True
+    assert data["class"] == "LinuxRISCV64"
+    assert data["name"] == "supportlinuxriscv64platform"
+
+    migrator2 = make_from_lazy_json_data(loads(lzj_data))
+    assert [pgm.__class__.__name__ for pgm in migrator2.piggy_back_migrations] == [
+        pgm.__class__.__name__ for pgm in migrator.piggy_back_migrations
+    ]
+    assert isinstance(migrator2, conda_forge_tick.migrators.LinuxRISCV64)
+    assert dumps(migrator2.to_lazy_json_data()) == lzj_data
+
+
 @pytest.mark.parametrize(
     "klass",
     [

--- a/tests/test_migrator_to_json.py
+++ b/tests/test_migrator_to_json.py
@@ -345,8 +345,7 @@ def test_migrator_to_json_riscv64():
         },
     )
     assert (
-        migrator.pr_title(other_branch_ctx)
-        == "[1.20.x] Support linux-riscv64 platform"
+        migrator.pr_title(other_branch_ctx) == "[1.20.x] Support linux-riscv64 platform"
     )
 
     cloned_ctx = ClonedFeedstockContext(

--- a/tests/test_migrator_to_json.py
+++ b/tests/test_migrator_to_json.py
@@ -7,6 +7,7 @@ import networkx as nx
 import pytest
 
 import conda_forge_tick.migrators
+from conda_forge_tick.contexts import ClonedFeedstockContext, FeedstockContext
 from conda_forge_tick.lazy_json_backends import dumps, loads
 from conda_forge_tick.migrators import core, make_from_lazy_json_data
 
@@ -328,6 +329,34 @@ def test_migrator_to_json_riscv64():
     ]
     assert isinstance(migrator2, conda_forge_tick.migrators.LinuxRISCV64)
     assert dumps(migrator2.to_lazy_json_data()) == lzj_data
+
+    main_ctx = FeedstockContext(
+        feedstock_name="python",
+        attrs={"conda-forge.yml": {"provider": {"default_branch": "main"}}},
+    )
+    assert migrator.pr_title(main_ctx) == "Support linux-riscv64 platform"
+    assert migrator.remote_branch(main_ctx) == "bot-pr_riscv64"
+
+    other_branch_ctx = FeedstockContext(
+        feedstock_name="python",
+        attrs={
+            "conda-forge.yml": {"provider": {"default_branch": "main"}},
+            "branch": "1.20.x",
+        },
+    )
+    assert (
+        migrator.pr_title(other_branch_ctx)
+        == "[1.20.x] Support linux-riscv64 platform"
+    )
+
+    cloned_ctx = ClonedFeedstockContext(
+        feedstock_name="python",
+        attrs={"conda-forge.yml": {"provider": {"default_branch": "main"}}},
+        local_clone_dir=Path("/dev/null"),
+    )
+    body = migrator.pr_body(cloned_ctx)
+    assert "linux riscv64 migration" in body
+    assert "conda-forge/help-riscv64" in body
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Mirrors OSXArm/WinArm64: adds build_platform: {linux_riscv64: linux_64}
and test: native_and_emulated to feedstocks' conda-forge.yml.

<!--
Thanks for contributing to conda-forge-bot!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

https://github.com/conda-forge/conda-forge.github.io/issues/1744
