### PR TITLE
Do not reintroduce `linux_aarch64` cross via minimigrator

### DIFF
--- a/conda_forge_tick/migrators/cross_compile.py
+++ b/conda_forge_tick/migrators/cross_compile.py
@@ -554,7 +554,7 @@ class CrossCompilationForARMAndPower(MiniMigrator):
 
             build_platform = config.get("build_platform", {})
             if build_platform:
-                for arch in ["linux_aarch64", "linux_ppc64le"]:
+                for arch in ["linux_ppc64le"]:
                     if arch in build_platform:
                         continue
                     if config.get("provider", {}).get(arch) == "default":

--- a/tests/test_cross_compile.py
+++ b/tests/test_cross_compile.py
@@ -423,7 +423,6 @@ fi
         == """\
 build_platform:
   linux_64: linux_64
-  linux_aarch64: linux_64
   linux_ppc64le: linux_64
 provider:
   linux_aarch64: default


### PR DESCRIPTION
#### Description:

Remove `linux_aarch64` platform from the targets for the `CrossCompilationForARMAndPower` minimigrator, in order to stop it from undesirably reintroducing cross-compilation for packages that are building for `linux_aarch64` natively.

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

Fixes #6281